### PR TITLE
fixes #403

### DIFF
--- a/PowerPointLabs/PowerPointLabs/ThisAddIn.cs
+++ b/PowerPointLabs/PowerPointLabs/ThisAddIn.cs
@@ -667,6 +667,8 @@ namespace PowerPointLabs
 
                         copiedSlides.Add(slide);
                     }
+
+                    copiedSlides.Sort((x, y) => (x.SlideIndex - y.SlideIndex));
                 }
                 else if (selection.Type == PowerPoint.PpSelectionType.ppSelectionShapes)
                 {
@@ -678,10 +680,7 @@ namespace PowerPointLabs
                         var shape = sh as PowerPoint.Shape;
                         copiedShapes.Add(shape);
                     }
-                    copiedShapes.Sort((PowerPoint.Shape x, PowerPoint.Shape y) =>
-                    {
-                        return x.Id - y.Id;
-                    });
+                    copiedShapes.Sort((PowerPoint.Shape x, PowerPoint.Shape y) => (x.Id - y.Id));
                 }
             }
             catch


### PR DESCRIPTION
fixes #403 
selecting by ctrl and shift are both handled by sorting slides under copy according to slide index.
