### PR TITLE
Issue 636

### DIFF
--- a/PowerPointLabs/PowerPointLabs/DefaultMotionAnimation.cs
+++ b/PowerPointLabs/PowerPointLabs/DefaultMotionAnimation.cs
@@ -1,8 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Runtime.InteropServices;
 using PowerPointLabs.Models;
 using Office = Microsoft.Office.Core;
 using PowerPoint = Microsoft.Office.Interop.PowerPoint;
@@ -11,8 +7,9 @@ namespace PowerPointLabs
 {
     class DefaultMotionAnimation
     {
+        private static PowerPoint.Effect effect;
         //Use initial shape and final shape to calculate intial and final positions
-        //Add motion, resize and rotation animations to initialShape
+        //Add motion, resize and rotation animations to shape
         public static void AddDefaultMotionAnimation(
             PowerPointSlide animationSlide, 
             PowerPoint.Shape initialShape, 
@@ -91,7 +88,99 @@ namespace PowerPointLabs
             AddResizeAnimation(animationSlide, shapeToZoom, initialWidth, initialHeight, finalWidth, finalHeight, duration, ref trigger);
         }
 
-        private static void AddMotionAnimation(PowerPointSlide animationSlide, PowerPoint.Shape animationShape, float initialX, float initialY, float finalX, float finalY, float duration, ref PowerPoint.MsoAnimTriggerType trigger)
+        /// <summary>
+        /// Pans initialShape to the location and size of finalShape
+        /// </summary>
+        public static void AddZoomToAreaPanAnimation(PowerPointSlide animationSlide, PowerPoint.Shape initialShape, PowerPoint.Shape finalShape, PowerPoint.MsoAnimTriggerType trigger)
+        {
+            float initialX = (initialShape.Left + (initialShape.Width) / 2);
+            float initialY = (initialShape.Top + (initialShape.Height) / 2);
+            float initialWidth = initialShape.Width;
+            float initialHeight = initialShape.Height;
+
+            float finalX = (finalShape.Left + (finalShape.Width) / 2);
+            float finalY = (finalShape.Top + (finalShape.Height) / 2);
+            float finalWidth = finalShape.Width;
+            float finalHeight = finalShape.Height;
+
+            float duration = 0.4f;
+
+            AddMotionAnimation(animationSlide, initialShape, initialX, initialY, finalX, finalY, duration, ref trigger);
+            AddResizeAnimation(animationSlide, initialShape, initialWidth, initialHeight, finalWidth, finalHeight, duration, ref trigger);
+        }
+
+        /// <summary>
+        /// Zoom out from initial shape to the full slide.
+        /// Returns the final disappear effect for initialShape.
+        /// </summary>
+        public static PowerPoint.Effect AddZoomOutMotionAnimation(PowerPointSlide animationSlide, PowerPoint.Shape initialShape, PowerPoint.MsoAnimTriggerType trigger)
+        {
+            float initialX = (initialShape.Left + (initialShape.Width) / 2);
+            float initialY = (initialShape.Top + (initialShape.Height) / 2);
+            float initialWidth = initialShape.Width;
+            float initialHeight = initialShape.Height;
+
+            float finalX = PowerPointPresentation.Current.SlideWidth / 2;
+            float finalY = PowerPointPresentation.Current.SlideHeight / 2;
+            float finalWidth = PowerPointPresentation.Current.SlideWidth;
+            float finalHeight = PowerPointPresentation.Current.SlideHeight;
+
+            float duration = 0.4f;
+
+            AddMotionAnimation(animationSlide, initialShape, initialX, initialY, finalX, finalY, duration, ref trigger);
+            AddResizeAnimation(animationSlide, initialShape, initialWidth, initialHeight, finalWidth, finalHeight, duration, ref trigger);
+
+            var sequence = animationSlide.TimeLine.MainSequence;
+            var effectDisappear = sequence.AddEffect(initialShape, PowerPoint.MsoAnimEffect.msoAnimEffectFade,
+                PowerPoint.MsoAnimateByLevel.msoAnimateLevelNone,
+                PowerPoint.MsoAnimTriggerType.msoAnimTriggerWithPrevious);
+            effectDisappear.Exit = Office.MsoTriState.msoTrue;
+            effectDisappear.Timing.Duration = 0.01f;
+            return effectDisappear;
+        }
+
+        /// <summary>
+        /// Preloads a shape within the slide to reduce lag. Call after the animations for the shape have been created.
+        /// </summary>
+        public static void PreloadShape(PowerPointSlide animationSlide, PowerPoint.Shape shape)
+        {
+            // The cover image is used to cover the screen while the preloading happens behind the cover image.
+            PowerPoint.Shape coverImage = shape.Duplicate()[1];
+            coverImage.Left = shape.Left;
+            coverImage.Top = shape.Top;
+            animationSlide.RemoveAnimationsForShape(coverImage);
+
+            float originalWidth = shape.Width;
+            float originalHeight = shape.Height;
+            float originalLeft = shape.Left;
+            float originalTop = shape.Top;
+
+            // fit the shape exactly in the screen for preloading.
+            float scaleRatio = Math.Min(PowerPointPresentation.Current.SlideWidth / shape.Width,
+                PowerPointPresentation.Current.SlideHeight / shape.Height);
+            animationSlide.RelocateShapeWithoutPath(shape, 0, 0, shape.Width * scaleRatio, shape.Height * scaleRatio);
+
+            var trigger = PowerPoint.MsoAnimTriggerType.msoAnimTriggerWithPrevious;
+            var effectMotion = AddMotionAnimation(animationSlide, shape, shape.Left, shape.Top, originalLeft + (originalWidth - shape.Width) / 2, originalTop + (originalHeight - shape.Height) / 2, 0, ref trigger);
+            var effectResize = AddResizeAnimation(animationSlide, shape, shape.Width, shape.Height, originalWidth, originalHeight, 0, ref trigger);
+
+            // Make "cover" image disappear after preload.
+            var sequence = animationSlide.TimeLine.MainSequence;
+            var effectDisappear = sequence.AddEffect(coverImage, PowerPoint.MsoAnimEffect.msoAnimEffectFade,
+                PowerPoint.MsoAnimateByLevel.msoAnimateLevelNone,
+                PowerPoint.MsoAnimTriggerType.msoAnimTriggerWithPrevious);
+            effectDisappear.Exit = Office.MsoTriState.msoTrue;
+            effectDisappear.Timing.Duration = 0.01f;
+
+
+            int firstEffectIndex = animationSlide.IndexOfFirstEffect(shape);
+            // Move the animations to just before the index of the first effect.
+            if (effectDisappear != null) effectDisappear.MoveTo(firstEffectIndex);
+            if (effectResize != null) effectResize.MoveTo(firstEffectIndex);
+            if (effectMotion != null) effectMotion.MoveTo(firstEffectIndex);
+        }
+
+        private static PowerPoint.Effect AddMotionAnimation(PowerPointSlide animationSlide, PowerPoint.Shape animationShape, float initialX, float initialY, float finalX, float finalY, float duration, ref PowerPoint.MsoAnimTriggerType trigger)
         {
             if ((finalX != initialX) || (finalY != initialY))
             {
@@ -109,10 +198,12 @@ namespace PowerPointLabs
                 motion.MotionEffect.Path = "M 0 0 C " + point1X + " " + point1Y + " " + point1X + " " + point1Y + " " + point2X + " " + point2Y + " E";
                 effectMotion.Timing.SmoothStart = Office.MsoTriState.msoFalse;
                 effectMotion.Timing.SmoothEnd = Office.MsoTriState.msoFalse;
+                return effectMotion;
             }
+            return null;
         }
 
-        private static void AddRotationAnimation(PowerPointSlide animationSlide, PowerPoint.Shape animationShape, float initialRotation, float finalRotation, float duration, ref PowerPoint.MsoAnimTriggerType trigger)
+        private static PowerPoint.Effect AddRotationAnimation(PowerPointSlide animationSlide, PowerPoint.Shape animationShape, float initialRotation, float finalRotation, float duration, ref PowerPoint.MsoAnimTriggerType trigger)
         {
             if (finalRotation != initialRotation)
             {
@@ -121,23 +212,28 @@ namespace PowerPointLabs
                 effectRotate.Timing.Duration = duration;
                 effectRotate.EffectParameters.Amount = PowerPointLabsGlobals.GetMinimumRotation(initialRotation, finalRotation);
                 trigger = PowerPoint.MsoAnimTriggerType.msoAnimTriggerWithPrevious;
+                return effectRotate;
             }
+            return null;
         }
 
-        private static void AddResizeAnimation(PowerPointSlide animationSlide, PowerPoint.Shape animationShape, float initialWidth, float initialHeight, float finalWidth, float finalHeight, float duration, ref PowerPoint.MsoAnimTriggerType trigger)
+        private static PowerPoint.Effect AddResizeAnimation(PowerPointSlide animationSlide, PowerPoint.Shape animationShape, float initialWidth, float initialHeight, float finalWidth, float finalHeight, float duration, ref PowerPoint.MsoAnimTriggerType trigger)
         {
             if ((finalWidth != initialWidth) || (finalHeight != initialHeight))
             {
                 animationShape.LockAspectRatio = Office.MsoTriState.msoFalse;
                 PowerPoint.Effect effectResize = animationSlide.TimeLine.MainSequence.AddEffect(animationShape, PowerPoint.MsoAnimEffect.msoAnimEffectGrowShrink, PowerPoint.MsoAnimateByLevel.msoAnimateLevelNone, trigger);
                 PowerPoint.AnimationBehavior resize = effectResize.Behaviors[1];
+
                 effectResize.Timing.Duration = duration;
 
                 resize.ScaleEffect.ByX = (finalWidth / initialWidth) * 100;
                 resize.ScaleEffect.ByY = (finalHeight / initialHeight) * 100;
 
                 trigger = PowerPoint.MsoAnimTriggerType.msoAnimTriggerWithPrevious;
+                return effectResize;
             }
+            return null;
         }
     }
 }

--- a/PowerPointLabs/PowerPointLabs/Models/PowerPointDeMagnifyingSlide.cs
+++ b/PowerPointLabs/PowerPointLabs/Models/PowerPointDeMagnifyingSlide.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using Office = Microsoft.Office.Core;
 using PowerPoint = Microsoft.Office.Interop.PowerPoint;
 
@@ -68,10 +66,10 @@ namespace PowerPointLabs.Models
             else
             {
                 GetShapeToZoomWithBackground(zoomShape);
-                FrameMotionAnimation.animationType = FrameMotionAnimation.FrameMotionAnimationType.kZoomToAreaDeMagnify;
-                FrameMotionAnimation.AddStepBackFrameMotionAnimation(this, zoomSlideCroppedShapes);
-                lastEffect = _slide.TimeLine.MainSequence[_slide.TimeLine.MainSequence.Count];
-
+                var lastDisappearEffect = DefaultMotionAnimation.AddZoomOutMotionAnimation(this,
+                    zoomSlideCroppedShapes, PowerPoint.MsoAnimTriggerType.msoAnimTriggerWithPrevious);
+                DefaultMotionAnimation.PreloadShape(this, zoomSlideCroppedShapes);
+                
                 //Add appear animations to existing shapes
                 bool isFirst = true;
                 PowerPoint.Effect effectFade = null;
@@ -89,12 +87,11 @@ namespace PowerPointLabs.Models
                         isFirst = false;
                     }
                 }
-
+                
                 //Move last frame disappear animation to end 
-                lastEffect.MoveTo(_slide.TimeLine.MainSequence.Count);
-                lastEffect.Timing.TriggerType = PowerPoint.MsoAnimTriggerType.msoAnimTriggerWithPrevious;
-                lastEffect.Timing.TriggerDelayTime = 0.0f;
-                lastEffect.Timing.Duration = 0.01f;
+                lastDisappearEffect.MoveTo(_slide.TimeLine.MainSequence.Count);
+                lastDisappearEffect.Timing.TriggerType = PowerPoint.MsoAnimTriggerType.msoAnimTriggerWithPrevious;
+                lastDisappearEffect.Timing.TriggerDelayTime = 0.01f;
             }
 
             indicatorShape.ZOrder(Office.MsoZOrderCmd.msoBringToFront);

--- a/PowerPointLabs/PowerPointLabs/Models/PowerPointMagnifiedPanSlide.cs
+++ b/PowerPointLabs/PowerPointLabs/Models/PowerPointMagnifiedPanSlide.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using Office = Microsoft.Office.Core;
 using PowerPoint = Microsoft.Office.Interop.PowerPoint;
 
@@ -29,8 +28,9 @@ namespace PowerPointLabs.Models
         public void AddZoomToAreaAnimation(PowerPointSlide slideToPanFrom, PowerPointSlide slideToPanTo)
         {
             PrepareForZoomToArea(slideToPanFrom, slideToPanTo);
-            FrameMotionAnimation.animationType = FrameMotionAnimation.FrameMotionAnimationType.kAutoAnimate;
-            FrameMotionAnimation.AddZoomToAreaPanFrameMotionAnimation(this, panShapeFrom, panShapeTo);
+            DefaultMotionAnimation.AddZoomToAreaPanAnimation(this, panShapeFrom, panShapeTo, PowerPoint.MsoAnimTriggerType.msoAnimTriggerAfterPrevious);
+            DefaultMotionAnimation.PreloadShape(this, panShapeFrom);
+            
             indicatorShape.ZOrder(Office.MsoZOrderCmd.msoBringToFront);
         }
 

--- a/PowerPointLabs/PowerPointLabs/PowerPointLabs.csproj
+++ b/PowerPointLabs/PowerPointLabs/PowerPointLabs.csproj
@@ -285,7 +285,6 @@
     <Compile Include="TextCollection.cs" />
     <Compile Include="Utils\Common.cs" />
     <Compile Include="Utils\Comparers.cs" />
-    <Compile Include="Utils\Extensions.cs" />
     <Compile Include="Utils\FileDir.cs" />
     <Compile Include="Utils\Graphics.cs" />
     <Compile Include="Views\CustomPaintTextBox.cs" />


### PR DESCRIPTION
Fixes the lag issue in Zoom to Area (pan + zoomout) by replacing frame motion animation by a default motion animation with preloading of images.
Does not change the multi-slide animation.