### PR TITLE
Fix zoom to area on image shapes.

### DIFF
--- a/PowerPointLabs/PowerPointLabs/Models/PowerPointDeMagnifyingSlide.cs
+++ b/PowerPointLabs/PowerPointLabs/Models/PowerPointDeMagnifyingSlide.cs
@@ -127,6 +127,7 @@ namespace PowerPointLabs.Models
 
             Globals.ThisAddIn.Application.ActiveWindow.View.GotoSlide(_slide.SlideIndex);
             zoomSlideCroppedShapes.Select();
+            zoomShapeCopy.Visible = Office.MsoTriState.msoTrue;
             zoomShapeCopy.Select(Office.MsoTriState.msoFalse);
             PowerPoint.ShapeRange selection = Globals.ThisAddIn.Application.ActiveWindow.Selection.ShapeRange;
             PowerPoint.Shape groupShape = selection.Group();

--- a/PowerPointLabs/PowerPointLabs/Models/PowerPointZoomToAreaSingleSlide.cs
+++ b/PowerPointLabs/PowerPointLabs/Models/PowerPointZoomToAreaSingleSlide.cs
@@ -320,6 +320,7 @@ namespace PowerPointLabs.Models
 
             Globals.ThisAddIn.Application.ActiveWindow.View.GotoSlide(_slide.SlideIndex);
             shapeToZoom.Select();
+            zoomShapeCopy.Visible = Office.MsoTriState.msoTrue;
             zoomShapeCopy.Select(Office.MsoTriState.msoFalse);
             PowerPoint.ShapeRange selection = Globals.ThisAddIn.Application.ActiveWindow.Selection.ShapeRange;
             PowerPoint.Shape groupShape = selection.Group();

--- a/PowerPointLabs/PowerPointLabs/ZoomToArea.cs
+++ b/PowerPointLabs/PowerPointLabs/ZoomToArea.cs
@@ -1,8 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
-using System.Text;
-using System.Runtime.InteropServices;
 using PowerPointLabs.Models;
 using Office = Microsoft.Office.Core;
 using PowerPoint = Microsoft.Office.Interop.PowerPoint;
@@ -18,21 +17,23 @@ namespace PowerPointLabs
         {
             try
             {
-                var currentSlide = PowerPointCurrentPresentationInfo.CurrentSlide as PowerPointSlide;
+                var currentSlide = PowerPointCurrentPresentationInfo.CurrentSlide;
                 DeleteExistingZoomToAreaSlides(currentSlide);
                 currentSlide.Name = "PPTLabsZoomToAreaSlide" + DateTime.Now.ToString("yyyyMMddHHmmssffff");
 
-                PowerPoint.ShapeRange selectedShapes = Globals.ThisAddIn.Application.ActiveWindow.Selection.ShapeRange;
-                List<PowerPoint.Shape> editedSelectedShapes = GetEditedShapesForZoomToArea(currentSlide, selectedShapes);
+                var selectedShapes = Globals.ThisAddIn.Application.ActiveWindow.Selection.ShapeRange;
+                var zoomRectangles = ReplaceWithZoomRectangleImages(currentSlide, selectedShapes);
 
-                if (!multiSlideZoomChecked)
-                    AddSingleSlideZoomToArea(currentSlide, editedSelectedShapes);
-                else
+                MakeInvisible(zoomRectangles);
+                List<PowerPoint.Shape> editedSelectedShapes = GetEditedShapesForZoomToArea(currentSlide, zoomRectangles);
+                if (multiSlideZoomChecked)
                     AddMultiSlideZoomToArea(currentSlide, editedSelectedShapes);
+                else
+                    AddSingleSlideZoomToArea(currentSlide, editedSelectedShapes);
+                MakeVisible(zoomRectangles);
 
                 Globals.ThisAddIn.Application.ActiveWindow.View.GotoSlide(currentSlide.Index);
-                PostFormatSelectedShapes(ref selectedShapes);
-                PowerPointPresentation.Current.AddAckSlide();   
+                PowerPointPresentation.Current.AddAckSlide();
             }
             catch (Exception e)
             {
@@ -97,30 +98,43 @@ namespace PowerPointLabs
             zoomSlide.AddZoomToAreaAnimation(currentSlide, shapesToZoom);
         }
 
-        private static List<PowerPoint.Shape> GetEditedShapesForZoomToArea(PowerPointSlide currentSlide, PowerPoint.ShapeRange selectedShapes)
+        private static List<PowerPoint.Shape> ReplaceWithZoomRectangleImages(PowerPointSlide currentSlide, PowerPoint.ShapeRange shapeRange)
         {
-            List<PowerPoint.Shape> editedSelectedShapes = new List<PowerPoint.Shape>();
+            var zoomRectangles = new List<PowerPoint.Shape>();
             int shapeCount = 1;
-            foreach (PowerPoint.Shape zoomShape in selectedShapes)
+            foreach (PowerPoint.Shape zoomShape in shapeRange)
             {
-                currentSlide.DeleteShapeAnimations(zoomShape);
-                currentSlide.AddAppearDisappearAnimation(zoomShape);
-                zoomShape.Name = "PPTLabsMagnifyShape" + DateTime.Now.ToString("yyyyMMddHHmmssffff");
-                editedSelectedShapes.Add(GetBestFitShape(currentSlide, zoomShape));
+                var zoomRectangle = currentSlide.Shapes.AddShape(Office.MsoAutoShapeType.msoShapeRectangle,
+                                                                zoomShape.Left,
+                                                                zoomShape.Top,
+                                                                zoomShape.Width,
+                                                                zoomShape.Height);
+                currentSlide.AddAppearDisappearAnimation(zoomRectangle);
 
-                if (zoomShape.HasTextFrame == Office.MsoTriState.msoTrue)
-                {
-                    zoomShape.TextFrame2.DeleteText();
-                    zoomShape.TextFrame2.TextRange.Text = "Zoom Shape " + shapeCount;
-                    zoomShape.TextFrame2.AutoSize = Office.MsoAutoSize.msoAutoSizeTextToFitShape;
-                    zoomShape.TextFrame2.TextRange.Font.Fill.ForeColor.RGB = 0xffffff;
-                    zoomShape.TextFrame2.TextRange.Font.Bold = Office.MsoTriState.msoTrue;
-                }
+                // Set Name
+                zoomRectangle.Name = "PPTLabsMagnifyShape" + DateTime.Now.ToString("yyyyMMddHHmmssffff");
 
-                zoomShape.Visible = Office.MsoTriState.msoFalse;
+                // Set Text
+                zoomRectangle.TextFrame2.TextRange.Text = "Zoom Shape " + shapeCount;
+                zoomRectangle.TextFrame2.AutoSize = Office.MsoAutoSize.msoAutoSizeTextToFitShape;
+                zoomRectangle.TextFrame2.TextRange.Font.Fill.ForeColor.RGB = 0xffffff;
+                zoomRectangle.TextFrame2.TextRange.Font.Bold = Office.MsoTriState.msoTrue;
+
+                // Set Colour
+                zoomRectangle.Fill.ForeColor.RGB = 0xaaaaaa;
+                zoomRectangle.Fill.Transparency = 0.7f;
+                zoomRectangle.Line.ForeColor.RGB = 0x000000;
+
+                zoomRectangles.Add(zoomRectangle);
+                zoomShape.Delete();
                 shapeCount++;
             }
-            return editedSelectedShapes;
+            return zoomRectangles;
+        }
+
+        private static List<PowerPoint.Shape> GetEditedShapesForZoomToArea(PowerPointSlide currentSlide, List<PowerPoint.Shape> zoomRectangles)
+        {
+            return zoomRectangles.Select(zoomShape => GetBestFitShape(currentSlide, zoomShape)).ToList();
         }
 
         //Shape dimensions should match the slide dimensions and the shape should be within the slide
@@ -128,7 +142,7 @@ namespace PowerPointLabs
         {
             zoomShape.Copy();
             PowerPoint.Shape zoomShapeCopy = currentSlide.Shapes.Paste()[1];
-
+            
             zoomShapeCopy.LockAspectRatio = Office.MsoTriState.msoFalse;
 
             if (zoomShape.Width > zoomShape.Height)
@@ -160,14 +174,19 @@ namespace PowerPointLabs
             return zoomShapeCopy;
         }
 
-        private static void PostFormatSelectedShapes(ref PowerPoint.ShapeRange selectedShapes)
+        private static void MakeInvisible(IEnumerable<PowerPoint.Shape> zoomRectangles)
         {
-            foreach (PowerPoint.Shape sh in selectedShapes)
+            foreach (var sh in zoomRectangles)
+            {
+                sh.Visible = Office.MsoTriState.msoFalse;
+            }
+        }
+
+        private static void MakeVisible(IEnumerable<PowerPoint.Shape> zoomRectangles)
+        {
+            foreach (var sh in zoomRectangles)
             {
                 sh.Visible = Office.MsoTriState.msoTrue;
-                sh.Fill.ForeColor.RGB = 0xaaaaaa;
-                sh.Fill.Transparency = 0.7f;
-                sh.Line.ForeColor.RGB = 0x000000;
             }
         }
 


### PR DESCRIPTION
Fix bug where only shapes, not images are replaced by transparent rectangles in zoom to area.

Previously, if you applied autozoom (zoom to area) after selecting images, the graphic of the images will not be changed into the autozoom transparent rectangle, which can be confusing to users (lack of feedback). Users may also wonder why their image is not visible in the presentation after they accidentally apply autozoom on the image and delete the autozoom slides.