### PR TITLE
Fixes for Highlight Text feature

### DIFF
--- a/PowerPointLabs/PowerPointLabs/HighlightBulletsBackground.cs
+++ b/PowerPointLabs/PowerPointLabs/HighlightBulletsBackground.cs
@@ -1,9 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Drawing;
-using System.Runtime.InteropServices;
 using PowerPointLabs.Models;
 using Office = Microsoft.Office.Core;
 using PowerPoint = Microsoft.Office.Interop.PowerPoint;
@@ -89,7 +86,7 @@ namespace PowerPointLabs
                         highlightShape.Fill.ForeColor.RGB = Utils.Graphics.ConvertColorToRgb(backgroundColor);
                         highlightShape.Fill.Transparency = 0.50f;
                         highlightShape.Line.Visible = Office.MsoTriState.msoFalse;
-                        highlightShape.ZOrder(Office.MsoZOrderCmd.msoSendToBack);
+                        Utils.Graphics.MoveZToJustBehind(highlightShape, sh);
                         highlightShape.Name = "PPTLabsHighlightBackgroundShape" + DateTime.Now.ToString("yyyyMMddHHmmssffff");
                         highlightShape.Tags.Add("HighlightBackground", sh.Name);
                         highlightShape.Select(Office.MsoTriState.msoFalse);

--- a/PowerPointLabs/PowerPointLabs/HighlightBulletsBackground.cs
+++ b/PowerPointLabs/PowerPointLabs/HighlightBulletsBackground.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Drawing;
+using System.Linq;
 using PowerPointLabs.Models;
 using Office = Microsoft.Office.Core;
 using PowerPoint = Microsoft.Office.Interop.PowerPoint;
@@ -23,32 +24,35 @@ namespace PowerPointLabs
                 Office.TextRange2 selectedText = null;
 
                 //Get shapes to consider for animation
+                List<PowerPoint.Shape> shapesToUse = null;
                 switch (userSelection)
                 {
                     case HighlightBackgroundSelection.kShapeSelected:
                         selectedShapes = Globals.ThisAddIn.Application.ActiveWindow.Selection.ShapeRange;
+                        shapesToUse = GetShapesToUse(currentSlide, selectedShapes);
                         break;
                     case HighlightBackgroundSelection.kTextSelected:
                         selectedShapes = Globals.ThisAddIn.Application.ActiveWindow.Selection.ShapeRange;
                         selectedText = Globals.ThisAddIn.Application.ActiveWindow.Selection.TextRange2.TrimText();
+                        shapesToUse = GetShapesToUse(currentSlide, selectedShapes);
                         break;
                     case HighlightBackgroundSelection.kNoneSelected:
                         currentSlide.DeleteShapesWithPrefix("PPIndicator");
                         currentSlide.DeleteShapesWithPrefix("PPTLabsHighlightBackgroundShape");
-                        selectedShapes = currentSlide.Shapes.Range();
+                        shapesToUse = GetAllUsableShapesInSlide(currentSlide);
                         break;
                     default:
                         break;
                 }
 
-                List<PowerPoint.Shape> shapesToUse = GetShapesToUse(currentSlide, selectedShapes);
-                
-                bool newShapesAdded = false;
                 Globals.ThisAddIn.Application.ActiveWindow.Selection.Unselect();
                 Globals.ThisAddIn.Application.ActiveWindow.View.GotoSlide(currentSlide.Index);
 
+                if (shapesToUse == null || shapesToUse.Count == 0)
+                    return;
+
                 SelectOldShapesToAnimate(currentSlide, shapesToUse);
-                newShapesAdded = AddNewShapesToAnimate(currentSlide, shapesToUse, selectedText);
+                bool newShapesAdded = AddNewShapesToAnimate(currentSlide, shapesToUse, selectedText);
 
                 if (newShapesAdded)
                 {
@@ -191,18 +195,66 @@ namespace PowerPointLabs
         /// </summary>
         private static List<PowerPoint.Shape> GetShapesToUse(PowerPointSlide currentSlide, PowerPoint.ShapeRange shapes)
         {
-            List<PowerPoint.Shape> shapesToUse = new List<PowerPoint.Shape>();
-            foreach (PowerPoint.Shape sh in shapes)
-            {
-                if (sh.Name.Contains("PPTLabsHighlightBackgroundShape"))
-                    continue;
-                if (sh.HasTextFrame == Office.MsoTriState.msoTrue && sh.TextFrame2.HasText == Office.MsoTriState.msoTrue)
-                {
-                    currentSlide.DeleteShapeAnimations(sh);
-                    shapesToUse.Add(sh);
-                }
-            }
+            var shapesToUse = shapes.Cast<PowerPoint.Shape>()
+                                    .Where(sh => !sh.Name.Contains("PPTLabsHighlightBackgroundShape")
+                                                    && HasText(sh))
+                                    .ToList();
+            shapesToUse.ForEach(currentSlide.DeleteShapeAnimations);
             return shapesToUse;
+        }
+
+        /// <summary>
+        /// Get all shapes in slide to use for animation.
+        /// If there are text boxes with bullet points, returns only the text boxes with bullet points.
+        /// If there are no text boxes with bullet points, returns everything.
+        /// </summary>
+        private static List<PowerPoint.Shape> GetAllUsableShapesInSlide(PowerPointSlide currentSlide)
+        {
+            var selectedShapes = currentSlide.Shapes.Range().Cast<PowerPoint.Shape>().ToArray();
+
+            var usableShapesWithBullets = selectedShapes
+                                            .Where(sh => !sh.Name.Contains("PPTLabsHighlightBackgroundShape")
+                                                        && HasText(sh)
+                                                        && HasBullets(sh))
+                                            .ToList();
+
+            var allUsableShapes = selectedShapes
+                                    .Where(sh => !sh.Name.Contains("PPTLabsHighlightBackgroundShape")
+                                                    && HasText(sh))
+                                    .ToList();
+
+            if (usableShapesWithBullets.Count == 0)
+            {
+                allUsableShapes.ForEach(currentSlide.DeleteShapeAnimations);
+                return allUsableShapes;
+            }
+            else
+            {
+                usableShapesWithBullets.ForEach(currentSlide.DeleteShapeAnimations);
+                return usableShapesWithBullets;
+            }
+        }
+
+        /// <summary>
+        /// Returns true iff shape (assuming has text) has bullet points.
+        /// Duplicate method in HighlightBulletsText.cs
+        /// </summary>
+        private static bool HasBullets(PowerPoint.Shape shape)
+        {
+            return shape.TextFrame2.TextRange.ParagraphFormat.Bullet.Visible == Office.MsoTriState.msoTrue &&
+                   shape.TextFrame2.TextRange.ParagraphFormat.Bullet.Type != Office.MsoBulletType.msoBulletNone;
+
+        }
+
+        /// <summary>
+        /// Returns true iff shape has a text frame.
+        /// Duplicate method in HighlightBulletsText.cs
+        /// </summary>
+        private static bool HasText(PowerPoint.Shape shape)
+        {
+            return shape.HasTextFrame == Office.MsoTriState.msoTrue &&
+                   shape.TextFrame2.HasText == Office.MsoTriState.msoTrue;
+
         }
     }
 }

--- a/PowerPointLabs/PowerPointLabs/HighlightBulletsBackground.cs
+++ b/PowerPointLabs/PowerPointLabs/HighlightBulletsBackground.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Drawing;
 using PowerPointLabs.Models;
 using Office = Microsoft.Office.Core;

--- a/PowerPointLabs/PowerPointLabs/HighlightBulletsBackground.cs
+++ b/PowerPointLabs/PowerPointLabs/HighlightBulletsBackground.cs
@@ -24,7 +24,7 @@ namespace PowerPointLabs
                 Office.TextRange2 selectedText = null;
 
                 //Get shapes to consider for animation
-                switch (userSelection) // TODO: Make it work for selected shapes.
+                switch (userSelection)
                 {
                     case HighlightBackgroundSelection.kShapeSelected:
                         selectedShapes = Globals.ThisAddIn.Application.ActiveWindow.Selection.ShapeRange;
@@ -184,11 +184,12 @@ namespace PowerPointLabs
                     sh.Delete();
         }
 
-        /*Get shapes to use for animation.
-         * If user does not select anything: Select shapes which have bullet points
-         * If user selects some shapes: Keep shapes from user selection which have bullet points
-         * If user selects some text: Keep shapes used to store text
-         */
+        /// <summary>
+        /// Get shapes to use for animation.
+        /// If user does not select anything: Select shapes which have bullet points
+        /// If user selects some shapes: Keep shapes from user selection which have bullet points
+        /// If user selects some text: Keep shapes used to store text
+        /// </summary>
         private static List<PowerPoint.Shape> GetShapesToUse(PowerPointSlide currentSlide, PowerPoint.ShapeRange shapes)
         {
             List<PowerPoint.Shape> shapesToUse = new List<PowerPoint.Shape>();
@@ -196,21 +197,10 @@ namespace PowerPointLabs
             {
                 if (sh.Name.Contains("PPTLabsHighlightBackgroundShape"))
                     continue;
-                if (userSelection == HighlightBackgroundSelection.kTextSelected)
+                if (sh.HasTextFrame == Office.MsoTriState.msoTrue && sh.TextFrame2.HasText == Office.MsoTriState.msoTrue)
                 {
-                    if (sh.HasTextFrame == Office.MsoTriState.msoTrue && sh.TextFrame2.HasText == Office.MsoTriState.msoTrue)
-                    {
-                        currentSlide.DeleteShapeAnimations(sh);
-                        shapesToUse.Add(sh);
-                    }
-                }
-                else
-                {
-                    if (sh.HasTextFrame == Office.MsoTriState.msoTrue && sh.TextFrame2.HasText == Office.MsoTriState.msoTrue)
-                    {
-                        currentSlide.DeleteShapeAnimations(sh);
-                        shapesToUse.Add(sh);
-                    }
+                    currentSlide.DeleteShapeAnimations(sh);
+                    shapesToUse.Add(sh);
                 }
             }
             return shapesToUse;

--- a/PowerPointLabs/PowerPointLabs/HighlightBulletsText.cs
+++ b/PowerPointLabs/PowerPointLabs/HighlightBulletsText.cs
@@ -1,9 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Drawing;
-using System.Runtime.InteropServices;
 using PowerPointLabs.Models;
 using Office = Microsoft.Office.Core;
 using PowerPoint = Microsoft.Office.Interop.PowerPoint;
@@ -54,7 +52,6 @@ namespace PowerPointLabs
                 currentSlide.Name = "PPTLabsHighlightBulletsSlide" + DateTime.Now.ToString("yyyyMMddHHmmssffff");
 
                 PowerPoint.Sequence sequence = currentSlide.TimeLine.MainSequence;
-                int initialEffectCount = sequence.Count;
                 bool isFirstShape = IsFirstShape(currentSlide);
 
                 foreach (PowerPoint.Shape sh in shapesToUse)
@@ -63,24 +60,41 @@ namespace PowerPointLabs
                         sh.Name = "HighlightTextShape" + DateTime.Now.ToString("yyyyMMddHHmmssffff");
 
                     //Add Font Appear effect for all paragraphs within shape
+                    int currentIndex = sequence.Count;
                     sequence.AddEffect(sh, PowerPoint.MsoAnimEffect.msoAnimEffectChangeFontColor, PowerPoint.MsoAnimateByLevel.msoAnimateTextByFifthLevel, PowerPoint.MsoAnimTriggerType.msoAnimTriggerOnPageClick);
-                    int addedEffectCount = sequence.Count - initialEffectCount;
+                    var appearEffects = AsList(sequence, currentIndex + 1, sequence.Count + 1);
 
                     //Add Font Disappear effect for all paragraphs within shape
+                    currentIndex = sequence.Count;
                     sequence.AddEffect(sh, PowerPoint.MsoAnimEffect.msoAnimEffectChangeFontColor, PowerPoint.MsoAnimateByLevel.msoAnimateTextByFifthLevel, PowerPoint.MsoAnimTriggerType.msoAnimTriggerWithPrevious);
-                    int addedEffectsStart = initialEffectCount + 1;
-                    
-                    //Remove effects for paragraphs without bullet points
-                    RemoveEffectsForTextWithoutBullets(currentSlide, sh, addedEffectsStart, addedEffectCount, selectedText);
-                    int finalEffectCount = sequence.Count - initialEffectCount;
+                    var disappearEffects = AsList(sequence, currentIndex + 1, sequence.Count + 1);
 
-                    if (finalEffectCount > 0)
+                    //Remove effects for paragraphs without bullet points 
+                    var markedForRemoval = GetParagraphsToRemove(sh, selectedText);
+                    // assert appearEffects.Count == disappearEffects.Count;
+                    // assert markedForRemoval.Count <= appearEffects.Count;
+                    for (int i = markedForRemoval.Count - 1; i >= 0; --i)
                     {
-                        FormatAddedEffects(currentSlide, addedEffectsStart, finalEffectCount, isFirstShape);                        
-                        initialEffectCount += finalEffectCount;
-                        isFirstShape = false;
+                        // delete from back.
+                        int index = markedForRemoval[i];
+                        appearEffects[index].Delete();
+                        appearEffects.RemoveAt(index);
+                        disappearEffects[index].Delete();
+                        disappearEffects.RemoveAt(index);
                     }
+
+                    if (appearEffects.Count == 0)
+                    {
+                        continue;
+                    }
+
+                    RearrangeEffects(appearEffects, disappearEffects);
+                    FormatAppearEffects(appearEffects, isFirstShape);
+                    FormatDisappearEffects(disappearEffects);
+                    isFirstShape = false;
                 }
+
+                Globals.ThisAddIn.Application.CommandBars.ExecuteMso("AnimationPreview");
                 PowerPointPresentation.Current.AddAckSlide();
             }
             catch (Exception e)
@@ -90,35 +104,17 @@ namespace PowerPointLabs
             }
         }
 
-        //Reorder and customize the font appear and font disappear animations added earlier
-        private static void FormatAddedEffects(PowerPointSlide currentSlide, int addedEffectsStart, int finalEffectCount, bool isFirstShape)
+        /// <summary>
+        /// Takes the effects in the sequence in the range [startIndex,endIndex) and puts them into a list in the same order.
+        /// </summary>
+        private static List<PowerPoint.Effect> AsList(PowerPoint.Sequence sequence, int startIndex, int endIndex)
         {
-            PowerPoint.Sequence sequence = currentSlide.TimeLine.MainSequence;
-
-            //Highlight Color appear
-            PowerPoint.Effect firstHighlightAppear = sequence[addedEffectsStart];
-            firstHighlightAppear.EffectParameters.Color2.RGB = Utils.Graphics.ConvertColorToRgb(highlightColor);
-            firstHighlightAppear.Timing.Duration = 0.01f;
-            firstHighlightAppear.Timing.TriggerType = isFirstShape ? PowerPoint.MsoAnimTriggerType.msoAnimTriggerOnPageClick : PowerPoint.MsoAnimTriggerType.msoAnimTriggerAfterPrevious;
-
-            int countCopy = finalEffectCount / 2;
-            for (int i = 2, j = 1; i < finalEffectCount; i += 2, j++)
+            var list = new List<PowerPoint.Effect>();
+            for (int i = startIndex; i < endIndex; ++i)
             {
-                PowerPoint.Effect nextHighlightAppear = sequence[addedEffectsStart - 1 + i];
-                nextHighlightAppear.EffectParameters.Color2.RGB = Utils.Graphics.ConvertColorToRgb(highlightColor);
-                nextHighlightAppear.Timing.Duration = 0.01f;
-
-                PowerPoint.Effect firstHighlightDisappear = sequence[addedEffectsStart - 1 + countCopy + j];
-                firstHighlightDisappear.EffectParameters.Color2.RGB = Utils.Graphics.ConvertColorToRgb(defaultColor);
-                firstHighlightDisappear.Timing.Duration = 0.01f;
-                firstHighlightDisappear.MoveTo(addedEffectsStart + i);
-                firstHighlightDisappear.Timing.TriggerType = PowerPoint.MsoAnimTriggerType.msoAnimTriggerWithPrevious;
+                list.Add(sequence[i]);
             }
-
-            PowerPoint.Effect lastHighlightDisappear = sequence[sequence.Count];
-            lastHighlightDisappear.EffectParameters.Color2.RGB = Utils.Graphics.ConvertColorToRgb(defaultColor);
-            lastHighlightDisappear.Timing.Duration = 0.01f;
-            lastHighlightDisappear.Timing.TriggerType = PowerPoint.MsoAnimTriggerType.msoAnimTriggerOnPageClick;
+            return list;
         }
 
         //Delete existing animations
@@ -133,41 +129,143 @@ namespace PowerPointLabs
                         currentSlide.DeleteShapeAnimations(tmp);
         }
 
-        private static void RemoveEffectsForTextWithoutBullets(PowerPointSlide currentSlide, PowerPoint.Shape sh, int addedEffectsStart, int addedEffectCount, Office.TextRange2 selectedText)
+        /// <summary>
+        /// The add animations creates a text animation for every paragraph in the text box.
+        /// But we may not always want all the paragraphs to have animations.
+        /// This method marks paragraphs to remove text animations from and returns a list of the indexes of the marked paragraphs.
+        /// Indexes returned is in increasing order.
+        /// </summary>
+        private static List<int> GetParagraphsToRemove(PowerPoint.Shape sh, Office.TextRange2 selectedText)
         {
-            PowerPoint.Sequence sequence = currentSlide.TimeLine.MainSequence;
-            //Remove effects for text without bullets
-            for (int i = 1, j = 1; i <= sh.TextFrame2.TextRange.Paragraphs.Count; i++, j++)
+            var textRange = sh.TextFrame2.TextRange;
+            if (userSelection == HighlightTextSelection.kTextSelected)
             {
-                Office.TextRange2 paragraph = sh.TextFrame2.TextRange.Paragraphs[i];
-                if (userSelection == HighlightTextSelection.kTextSelected)
+                return GetUnselectedParagraphs(textRange, selectedText);
+            }
+            else
+            {
+                return GetParagraphsWithoutBullets(textRange);
+            }
+        }
+
+        /// <summary>
+        /// If there are bullet points, returns a list of paragraphs without bullet points (marked for removal)
+        /// If there are no paragraphs with bullet points at all, then return empty list (mark nothing for removal)
+        /// </summary>
+        private static List<int> GetParagraphsWithoutBullets(Office.TextRange2 textRange)
+        {
+            var indexList = new List<int>();
+            int index = 0;
+            bool hasBulletPoint = false;
+            for (int i = 1; i <= textRange.Paragraphs.Count; ++i)
+            {
+                var paragraph = textRange.Paragraphs[i];
+                if (paragraph.Text.Trim().Length == 0)
                 {
-                    if (paragraph.Text.Trim().Length == 0)
-                    {
-                        addedEffectCount--;
-                        j--;
-                        continue;
-                    }
-                    if ((selectedText.Start + selectedText.Length < paragraph.Start) || (selectedText.Start > paragraph.Start + paragraph.Length - 1))
-                    {
-                        sequence[addedEffectsStart - 1 + i + addedEffectCount].Delete();
-                        sequence[addedEffectsStart - 1 + j].Delete();
-                        j--;
-                        addedEffectCount -= 2;
-                    }
+                    continue;
+                }
+                if (paragraph.ParagraphFormat.Bullet.Visible == Office.MsoTriState.msoFalse)
+                {
+                    indexList.Add(index);
                 }
                 else
                 {
-                    if (paragraph.ParagraphFormat.Bullet.Visible == Office.MsoTriState.msoFalse)
-                    {
-                        sequence[addedEffectsStart - 1 + i + addedEffectCount].Delete(); //Delete disappear effect
-                        sequence[addedEffectsStart - 1 + j].Delete(); //Delete appear effect
-                        j--;
-                        addedEffectCount -= 2;
-                    }
+                    hasBulletPoint = true;
                 }
+                index++;
+            }
+
+            // Return nothing if there is no bullet point at all.
+            if (!hasBulletPoint)
+            {
+                indexList.Clear();
+            }
+            return indexList;
+        }
+
+        /// <summary>
+        /// Get a list of unselected paragraphs to mark for removal.
+        /// </summary>
+        private static List<int> GetUnselectedParagraphs(Office.TextRange2 textRange, Office.TextRange2 selectedText)
+        {
+            var indexList = new List<int>();
+            int index = 0;
+            for (int i = 1; i <= textRange.Paragraphs.Count; ++i)
+            {
+                var paragraph = textRange.Paragraphs[i];
+                if (paragraph.Text.Trim().Length == 0)
+                {
+                    continue;
+                }
+                if (selectedText.Start + selectedText.Length < paragraph.Start ||
+                    selectedText.Start > paragraph.Start + paragraph.Length - 1)
+                {
+                    indexList.Add(index);
+                }
+                index++;
+            }
+            return indexList;
+        }
+
+
+        /// <summary>
+        /// Rearranges the appear and disappear effects to be in the correct order for highlight bullets.
+        /// Order: [0a] [1a 0d] [2a 1d] [3a 2d] [4a 3d] [4d]
+        /// </summary>
+        private static void RearrangeEffects(List<PowerPoint.Effect> appearEffects, List<PowerPoint.Effect> disappearEffects)
+        {
+            // First
+            if (appearEffects.Count >= 2)
+            {
+                appearEffects[1].MoveAfter(appearEffects[0]);
+            }
+
+            // Middle
+            for (int i = 1; i < appearEffects.Count - 1; ++i)
+            {
+                disappearEffects[i - 1].MoveAfter(appearEffects[i]);
+                appearEffects[i + 1].MoveAfter(disappearEffects[i - 1]);
+            }
+
+            // Last
+            disappearEffects[appearEffects.Count - 1].MoveAfter(disappearEffects[appearEffects.Count - 1]);
+        }
+
+        /// <summary>
+        /// Apply formatting and timing to the "appear" effects. (i.e. highlight bullet)
+        /// </summary>
+        private static void FormatAppearEffects(List<PowerPoint.Effect> appearEffects, bool isFirstShape)
+        {
+            foreach (var effect in appearEffects)
+            {
+                effect.Timing.TriggerType = PowerPoint.MsoAnimTriggerType.msoAnimTriggerOnPageClick;
+                // TODO: Orange text bug occurs on this line. effect.EffectParameters.Color2.RGB is not changed for some reason.
+                effect.EffectParameters.Color2.RGB = Utils.Graphics.ConvertColorToRgb(highlightColor);
+                effect.Timing.Duration = 0.1f;
+                effect.Timing.TriggerDelayTime = 0.1f;
+            }
+            if (!isFirstShape)
+            {
+                appearEffects.First().Timing.TriggerType = PowerPoint.MsoAnimTriggerType.msoAnimTriggerAfterPrevious;
             }
         }
+
+        /// <summary>
+        /// Apply formatting and timing to the "disappear" effects. (i.e. unhighlight bullet)
+        /// </summary>
+        private static void FormatDisappearEffects(List<PowerPoint.Effect> disappearEffects)
+        {
+            foreach (var effect in disappearEffects)
+            {
+                effect.Timing.TriggerType = PowerPoint.MsoAnimTriggerType.msoAnimTriggerWithPrevious;
+                effect.EffectParameters.Color2.RGB = Utils.Graphics.ConvertColorToRgb(defaultColor);
+                effect.Timing.Duration = 0.1f;
+                effect.Timing.TriggerDelayTime = 0.1f;
+            }
+            disappearEffects.Last().Timing.TriggerType = PowerPoint.MsoAnimTriggerType.msoAnimTriggerOnPageClick;
+        }
+
+
         private static bool IsFirstShape(PowerPointSlide currentSlide)
         {
             PowerPoint.Sequence sequence = currentSlide.TimeLine.MainSequence;
@@ -181,31 +279,21 @@ namespace PowerPointLabs
             return isFirstShape;
         }
 
-        /*Get shapes to use for animation.
-         * If user does not select anything: Select shapes which have bullet points
-         * If user selects some shapes: Keep shapes from user selection which have bullet points
-         * If user selects some text: Keep shapes used to store text
-         */
+
+        /// <summary>
+        /// Get shapes to use for animation.
+        /// If user does not select anything: Select shapes which have bullet points
+        /// If user selects some shapes: Keep shapes from user selection which have bullet points
+        /// If user selects some text: Keep shapes used to store text
+        /// </summary>
         private static List<PowerPoint.Shape> GetShapesToUse(PowerPointSlide currentSlide, PowerPoint.ShapeRange selectedShapes)
         {
             List<PowerPoint.Shape> shapesToUse = new List<PowerPoint.Shape>();
             foreach (PowerPoint.Shape sh in selectedShapes)
             {
-                if (userSelection != HighlightTextSelection.kTextSelected)
+                if (sh.HasTextFrame == Office.MsoTriState.msoTrue && sh.TextFrame2.HasText == Office.MsoTriState.msoTrue)
                 {
-                    if (sh.HasTextFrame == Office.MsoTriState.msoTrue && sh.TextFrame2.HasText == Office.MsoTriState.msoTrue
-                    && sh.TextFrame2.TextRange.ParagraphFormat.Bullet.Visible == Office.MsoTriState.msoTrue
-                    && sh.TextFrame2.TextRange.ParagraphFormat.Bullet.Type != Office.MsoBulletType.msoBulletNone)
-                    {
-                        shapesToUse.Add(sh);
-                    }
-                }
-                else
-                {
-                    if (sh.HasTextFrame == Office.MsoTriState.msoTrue && sh.TextFrame2.HasText == Office.MsoTriState.msoTrue)
-                    {
-                        shapesToUse.Add(sh);
-                    }
+                    shapesToUse.Add(sh);
                 }
             }
             return shapesToUse;

--- a/PowerPointLabs/PowerPointLabs/Utils/Graphics.cs
+++ b/PowerPointLabs/PowerPointLabs/Utils/Graphics.cs
@@ -217,6 +217,67 @@ namespace PowerPointLabs.Utils
                 newCandidateRange.Text = candidateText;
             }
         }
+
+        /// <summary>
+        /// Moves shiftShape forward/backward until it is just behind destinationShape
+        /// </summary>
+        public static void MoveZToJustBehind(Shape shiftShape, Shape destinationShape)
+        {
+            // Step 1: Shift forward until it overshoots destination.
+            while (shiftShape.ZOrderPosition < destinationShape.ZOrderPosition)
+            {
+                int currentValue = shiftShape.ZOrderPosition;
+                shiftShape.ZOrder(MsoZOrderCmd.msoBringForward);
+                if (shiftShape.ZOrderPosition == currentValue)
+                {
+                    // Break if no change. Guards against infinite loops.
+                    break;
+                }
+            }
+
+            // Step 2: Shift backward until it overshoots destination.
+            while (shiftShape.ZOrderPosition > destinationShape.ZOrderPosition)
+            {
+                int currentValue = shiftShape.ZOrderPosition;
+                shiftShape.ZOrder(MsoZOrderCmd.msoSendBackward);
+                if (shiftShape.ZOrderPosition == currentValue)
+                {
+                    // Break if no change. Guards against infinite loops.
+                    break;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Moves shiftShape forward/backward until it is just in front of destinationShape
+        /// </summary>
+        public static void MoveZToJustInFront(Shape shiftShape, Shape destinationShape)
+        {
+            // Step 1: Shift backward until it overshoots destination.
+            while (shiftShape.ZOrderPosition > destinationShape.ZOrderPosition)
+            {
+                int currentValue = shiftShape.ZOrderPosition;
+                shiftShape.ZOrder(MsoZOrderCmd.msoSendBackward);
+                if (shiftShape.ZOrderPosition == currentValue)
+                {
+                    // Break if no change. Guards against infinite loops.
+                    break;
+                }
+            }
+
+            // Step 2: Shift forward until it overshoots destination.
+            while (shiftShape.ZOrderPosition < destinationShape.ZOrderPosition)
+            {
+                int currentValue = shiftShape.ZOrderPosition;
+                shiftShape.ZOrder(MsoZOrderCmd.msoBringForward);
+                if (shiftShape.ZOrderPosition == currentValue)
+                {
+                    // Break if no change. Guards against infinite loops.
+                    break;
+                }
+            }
+        }
+
         # endregion
 
         # region Text


### PR DESCRIPTION
1) Fix bug where newly-spawned highlight shapes in Highlight Text Background is sent to back, behind all other shapes. Now it is sent to just behind the text box.

2) If there are no bullet points in the text box, All the text in the text box is highlighted. (for both highlight points and highlight points background)

3) Fix bug 2 in issue #709.

4) Add feedback when highlight points is used (for issue #688)