### PR TITLE
More fixes for ZoomToArea

### DIFF
--- a/PowerPointLabs/PowerPointLabs/Models/PowerPointMagnifyingSlide.cs
+++ b/PowerPointLabs/PowerPointLabs/Models/PowerPointMagnifyingSlide.cs
@@ -15,6 +15,7 @@ namespace PowerPointLabs.Models
         private PowerPointMagnifyingSlide(PowerPoint.Slide slide) : base(slide)
         {
             _slide.Name = "PPTLabsMagnifyingSlide" + DateTime.Now.ToString("yyyyMMddHHmmssffff");
+            DeleteHiddenShapes();
         }
 
         new public static PowerPointSlide FromSlideFactory(PowerPoint.Slide slide)

--- a/PowerPointLabs/PowerPointLabs/Models/PowerPointSlide.cs
+++ b/PowerPointLabs/PowerPointLabs/Models/PowerPointSlide.cs
@@ -249,6 +249,15 @@ namespace PowerPointLabs.Models
             }
         }
 
+        public void DeleteHiddenShapes()
+        {
+            _slide.Shapes
+                .Cast<Shape>()
+                .Where(sh => sh.Visible == MsoTriState.msoFalse)
+                .ToList()
+                .ForEach(sh => sh.Delete());
+        }
+
         public void DeleteAllShapes()
         {
             List<Shape> shapes = _slide.Shapes.Cast<Shape>().ToList();

--- a/PowerPointLabs/PowerPointLabs/ZoomToArea.cs
+++ b/PowerPointLabs/PowerPointLabs/ZoomToArea.cs
@@ -34,6 +34,10 @@ namespace PowerPointLabs
 
                 Globals.ThisAddIn.Application.ActiveWindow.View.GotoSlide(currentSlide.Index);
                 PowerPointPresentation.Current.AddAckSlide();
+
+                // Always call ReleaseComObject and GC.Collect after shape deletion to prevent shape corruption after undo.
+                System.Runtime.InteropServices.Marshal.ReleaseComObject(selectedShapes);
+                GC.Collect();
             }
             catch (Exception e)
             {

--- a/PowerPointLabs/PowerPointLabs/ZoomToArea.cs
+++ b/PowerPointLabs/PowerPointLabs/ZoomToArea.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using PowerPointLabs.Models;
 using Office = Microsoft.Office.Core;


### PR DESCRIPTION
There appears to be a bug in powerpoint where if you delete a shape programmatically then undo the change, the shape enters a weird state where if you try to access any of its properties programmatically again, a COMException occurs. I think this is mentioned in "common traps" by @kai33.
[Steps to replicate: 1) Use ZoomToArea on a rectangle. 2) Undo. 3) Use Drill Down on the same rectangle]

Apparently this issue comes about due to powerpoint not properly releasing memory after the shape is deleted
The only fix I found for this that works reliably so far is to run some mixture of ReleaseComObject and GC.Collect after the shape is deleted programmatically.