### PR TITLE
Fixes highlight points

### DIFF
--- a/PowerPointLabs/PowerPointLabs/HighlightBulletsBackground.cs
+++ b/PowerPointLabs/PowerPointLabs/HighlightBulletsBackground.cs
@@ -152,9 +152,9 @@ namespace PowerPointLabs
             List<PowerPoint.Shape> shapesToDelete = new List<PowerPoint.Shape>();
             bool shouldSelect;
 
-            for (int i = currentSlide.Shapes.Count; i >= 1; i--)
+            var shapes = currentSlide.GetShapesOrderedByTimeline();
+            foreach (var sh in shapes)
             {
-                PowerPoint.Shape sh = currentSlide.Shapes[i];
                 shouldSelect = true; //We should not select existing highlight shapes. Instead they should be deleted
                 if (sh.Name.Contains("PPTLabsHighlightBackgroundShape"))
                 {

--- a/PowerPointLabs/PowerPointLabs/HighlightTextFragments.cs
+++ b/PowerPointLabs/PowerPointLabs/HighlightTextFragments.cs
@@ -102,8 +102,6 @@ namespace PowerPointLabs
             List<PowerPoint.Shape> previousFragments = currentSlide.GetTextFragments();
             currentSlide.RemoveAnimationsForShapes(previousFragments);
 
-            previousFragments.Reverse();
-
             return previousFragments;
         }
 

--- a/PowerPointLabs/PowerPointLabs/HighlightTextFragments.cs
+++ b/PowerPointLabs/PowerPointLabs/HighlightTextFragments.cs
@@ -36,10 +36,12 @@ namespace PowerPointLabs
                     case HighlightTextSelection.kNoneSelected:
                         return;
                     default:
-                        break;
+                        return;
                 }
+                if (selectedText.Length <= 0) return;
+                if (selectedShapes.Count != 1) return;
 
-                List<PowerPoint.Shape> selectionToAnimate = GetShapesFromLinesInText(currentSlide, selectedText);
+                List<PowerPoint.Shape> selectionToAnimate = GetShapesFromLinesInText(currentSlide, selectedText, selectedShapes[1]);
                 GroupShapesForAnimation(selectionToAnimate);
 
                 List<PowerPoint.Shape> shapesToAnimate = GetShapesToAnimate(currentSlide);
@@ -105,7 +107,7 @@ namespace PowerPointLabs
             return previousFragments;
         }
 
-        private static List<PowerPoint.Shape> GetShapesFromLinesInText(PowerPointSlide currentSlide, Office.TextRange2 text)
+        private static List<PowerPoint.Shape> GetShapesFromLinesInText(PowerPointSlide currentSlide, Office.TextRange2 text, PowerPoint.Shape shape)
         {
             List<PowerPoint.Shape> shapesToAnimate = new List<PowerPoint.Shape>();
 
@@ -122,7 +124,7 @@ namespace PowerPointLabs
                 highlightShape.Fill.ForeColor.RGB = Utils.Graphics.ConvertColorToRgb(backgroundColor);
                 highlightShape.Fill.Transparency = 0.50f;
                 highlightShape.Line.Visible = Office.MsoTriState.msoFalse;
-                highlightShape.ZOrder(Office.MsoZOrderCmd.msoSendToBack);
+                Utils.Graphics.MoveZToJustBehind(highlightShape, shape);
                 highlightShape.Name = "PPTLabsHighlightTextFragmentsShape" + Guid.NewGuid().ToString();
                 highlightShape.Tags.Add("HighlightTextFragment", highlightShape.Name);
                 highlightShape.Select(Office.MsoTriState.msoFalse);


### PR DESCRIPTION
Fix highlighted text fragments appearing behind all shapes.
Fix highlight background appearing in wrong order when you apply it multiple times in same slide. (because previously the animation order was decided by Z-Order, which is potentially buggy)