### PR TITLE
remove customized close window

### DIFF
--- a/PowerPointLabs/PowerPointLabs/NotesToAudio.cs
+++ b/PowerPointLabs/PowerPointLabs/NotesToAudio.cs
@@ -122,7 +122,14 @@ namespace PowerPointLabs
             {
                 if (audio.Contains(fileNameSearchPattern))
                 {
-                    File.Delete(audio);
+                    try
+                    {
+                        File.Delete(audio);
+                    }
+                    catch (Exception e)
+                    {
+                        PowerPointLabsGlobals.Log("Error", "Failed to delete audio, it may be still playing. " + e.Message);
+                    }
                 }
             }
 

--- a/PowerPointLabs/PowerPointLabs/Ribbon1.cs
+++ b/PowerPointLabs/PowerPointLabs/Ribbon1.cs
@@ -1564,12 +1564,6 @@ namespace PowerPointLabs
                 return false;
             }
 
-            if (!Globals.ThisAddIn.VerifyOnLocal(pres))
-            {
-                MessageBox.Show(TextCollection.OnlinePresentationNotCompatibleErrorMsg);
-                return false;
-            }
-
             return true;
         }
 

--- a/PowerPointLabs/PowerPointLabs/ThisAddIn.cs
+++ b/PowerPointLabs/PowerPointLabs/ThisAddIn.cs
@@ -39,10 +39,6 @@ namespace PowerPointLabs
                                     string> _documentHashcodeMapper = new Dictionary<PowerPoint.DocumentWindow,
                                                                                      string>();
 
-        private readonly Dictionary<PowerPoint.DocumentWindow,
-            bool> _documentPathAssociateMapper = new Dictionary<PowerPoint.DocumentWindow,
-                bool>();
-
         internal ShapesLabConfig ShapesLabConfigs;
 
         internal PowerPointShapeGalleryPresentation ShapePresentation;
@@ -250,8 +246,6 @@ namespace PowerPointLabs
             var activeWindow = pres.Application.ActiveWindow;
             var tempName = pres.Name.GetHashCode().ToString(CultureInfo.InvariantCulture);
 
-            // new unsaved document window does not have path associated
-            _documentPathAssociateMapper[activeWindow] = true;
             _documentHashcodeMapper[activeWindow] = tempName;
         }
 
@@ -267,11 +261,6 @@ namespace PowerPointLabs
         {
             var activeWindow = pres.Application.ActiveWindow;
             var tempName = pres.Name.GetHashCode().ToString(CultureInfo.InvariantCulture);
-
-            if (!_documentPathAssociateMapper.ContainsKey(activeWindow))
-            {
-                _documentPathAssociateMapper[activeWindow] = pres.Path == string.Empty;
-            }
 
             // if we opened a new window, register the window with its name
             if (!_documentHashcodeMapper.ContainsKey(activeWindow))
@@ -325,47 +314,7 @@ namespace PowerPointLabs
             }
 
             Trace.TraceInformation("Closing associated window...");
-
-            if (_documentPathAssociateMapper.ContainsKey(associatedWindow) &&
-                _documentPathAssociateMapper[associatedWindow])
-            {
-                CleanUp(associatedWindow);
-
-                return;
-            }
-
-            if (pres.Saved == Office.MsoTriState.msoTrue)
-            {
-                Trace.TraceInformation("Presentation saved.");
-
-                CleanUp(associatedWindow);
-            }
-            else
-            {
-                var handle = Native.FindWindow("PPTFrameClass", pres.Name + " - Microsoft PowerPoint");
-                var prompt =
-                    MessageBox.Show(string.Format("Do you want to save {0}", associatedWindow.Caption),
-                                    Application.Name,
-                                    MessageBoxButtons.YesNoCancel, MessageBoxIcon.Warning,
-                                    MessageBoxDefaultButton.Button1);
-
-                Native.SetForegroundWindow(handle);
-
-                switch (prompt)
-                {
-                    case DialogResult.Yes:
-                        CleanUp(associatedWindow);
-                        SendKeys.Send("{ENTER}");
-                        break;
-                    case DialogResult.No:
-                        CleanUp(associatedWindow);
-                        SendKeys.Send("N");
-                        break;
-                    default:
-                        SendKeys.Send("{ESC}");
-                        break;
-                }
-            }
+            CleanUp(associatedWindow);
         }
 
         private void ShutDownImageSearchPane()
@@ -747,6 +696,23 @@ namespace PowerPointLabs
             _documentPaneMapper.Remove(activeWindow);
         }
 
+        private void RemoveTaskPane(PowerPoint.DocumentWindow window, Type paneType)
+        {
+            if (!_documentPaneMapper.ContainsKey(window))
+            {
+                return;
+            }
+
+            var activePanes = _documentPaneMapper[window];
+            for (var i = activePanes.Count - 1; i >= 0; i--)
+            {
+                var pane = activePanes[i];
+                if (pane.Control.GetType() != paneType) continue;
+                CustomTaskPanes.Remove(pane);
+                activePanes.RemoveAt(i);
+            }
+        }
+
         private void RegulatePresentationName(PowerPoint.Presentation pres, string tempPath, ref string presName,
                                               ref string presFullName)
         {
@@ -760,21 +726,7 @@ namespace PowerPointLabs
                 presName += ".pptx";
             }
 
-            PowerPoint.DocumentWindow associatedWindow;
-
-            try
-            {
-                associatedWindow = pres.Windows[1];
-            }
-            catch (Exception)
-            {
-                associatedWindow = null;
-            }
-
-            if (associatedWindow != null &&
-                _documentPathAssociateMapper.ContainsKey(associatedWindow) &&
-                _documentPathAssociateMapper[associatedWindow] &&
-                !string.IsNullOrEmpty(tempPath))
+            if (tempPath != null)
             {
                 pres.SaveCopyAs(tempPath + presName);
                 presFullName = tempPath + presName;
@@ -796,6 +748,8 @@ namespace PowerPointLabs
             if (recorder != null && !recorderPane.Visible)
             {
                 recorder.RecorderPaneClosing();
+                // remove recorder pane and force it to reload when next time open
+                RemoveTaskPane(Application.ActiveWindow, typeof(RecorderTaskPane));
             }
         }
 
@@ -946,8 +900,6 @@ namespace PowerPointLabs
         private void CleanUp(PowerPoint.DocumentWindow associatedWindow)
         {
             _isClosing = true;
-
-            _documentPathAssociateMapper.Remove(associatedWindow);
 
             if (_documentHashcodeMapper.ContainsKey(associatedWindow))
             {

--- a/PowerPointLabs/PowerPointLabs/ThisAddIn.cs
+++ b/PowerPointLabs/PowerPointLabs/ThisAddIn.cs
@@ -728,6 +728,9 @@ namespace PowerPointLabs
 
             if (tempPath != null)
             {
+                // every time when recorder pane is open,
+                // save this presentation's copy, which will be used
+                // to load audio files later
                 pres.SaveCopyAs(tempPath + presName);
                 presFullName = tempPath + presName;
             }


### PR DESCRIPTION
Fixes #750 

@nevet kindly have a look when u'r free

This pr also fixes the following problems in the Recorder pane:
1. record, close recorder pane, open the pane again.. cannot play
2. open new blank ppt, open recorder pane, open another ppt (same window), no audio in the list.
3. open new blank ppt, open another ppt, open recorder pane to record something, click close button of ppt window, click Cancel of the window, open recorder pane again, find that the audio just recorded is not the recorded one.
4. cannot open recorder pane in the online tutorial (now works fine with online tutorial).