### PR TITLE
let Crop to Shape throw unknown exception stacktrace #782

### DIFF
--- a/PowerPointLabs/PowerPointLabs/CropToShape.cs
+++ b/PowerPointLabs/PowerPointLabs/CropToShape.cs
@@ -37,8 +37,6 @@ namespace PowerPointLabs
             try
             {
                 VerifyIsSelectionValid(selection);
-                //FOR DEBUG. TO BE DELETED.
-                ThrowErrorCode(250);
             }
             catch (Exception e)
             {

--- a/PowerPointLabs/PowerPointLabs/CropToShape.cs
+++ b/PowerPointLabs/PowerPointLabs/CropToShape.cs
@@ -37,12 +37,14 @@ namespace PowerPointLabs
             try
             {
                 VerifyIsSelectionValid(selection);
+                //FOR DEBUG. TO BE DELETED.
+                ThrowErrorCode(250);
             }
             catch (Exception e)
             {
                 if (handleError)
                 {
-                    MessageBox.Show(GetErrorMessageForErrorCode(e.Message), MessageBoxTitle);
+                    ProcessErrorMessage(e);
                     return null;
                 }
 
@@ -53,7 +55,7 @@ namespace PowerPointLabs
         }
 
         public static PowerPoint.Shape Crop(PowerPoint.ShapeRange shapeRange, double magnifyRatio = 1.0,
-                                            bool handleError = true)
+            bool handleError = true)
         {
             try
             {
@@ -69,13 +71,14 @@ namespace PowerPointLabs
             {
                 if (handleError)
                 {
-                    MessageBox.Show(GetErrorMessageForErrorCode(e.Message), MessageBoxTitle);
+                    ProcessErrorMessage(e);
                     return null;
                 }
 
                 throw;
             }
         }
+
 
         private static bool VerifyIsShapeRangeValid(PowerPoint.ShapeRange shapeRange, bool handleError)
         {
@@ -97,7 +100,7 @@ namespace PowerPointLabs
             {
                 if (handleError)
                 {
-                    MessageBox.Show(GetErrorMessageForErrorCode(e.Message), MessageBoxTitle);
+                    ProcessErrorMessage(e);
                     return false;
                 }
 
@@ -374,6 +377,22 @@ namespace PowerPointLabs
                     return ErrorMessageForRotationNonZero;
                 default:
                     return ErrorMessageForUndefined;
+            }
+        }
+
+        private static void ProcessErrorMessage(Exception e)
+        {
+            //This method prompts the error message to user. If it has an unrecognised error code,
+            //an alternative message window with erro trace stack pops up and prompts the user to
+            //send the trace stack to the developer team.
+            var errMessage = GetErrorMessageForErrorCode(e.Message);
+            if (!string.Equals(errMessage, ErrorMessageForUndefined, StringComparison.Ordinal))
+            {
+                MessageBox.Show(errMessage, MessageBoxTitle);
+            }
+            else
+            {
+                Views.ErrorDialogWrapper.ShowDialog(MessageBoxTitle, e.Message, e);
             }
         }
 


### PR DESCRIPTION
CropToShape.cs now pops up error message window with trace stack, if the error code is not recognized.

0. Previously, GetErrorMessageForErrorCode() was used directly to show a error message box without any trace stack.
1. A new method ProcessErrorMessage() is created. This is the method, within CropToShape.cs, is now used in 3 places where GetErrorMessageForErrorCode() was used directly.
2. There are two more references to GetErrorMessageForErrorCode() outside CropToShape.cs. These are left untouched for now, since I do not yet have a complete understanding of what those references do.