### PR TITLE
Fix #56 'Hide' option in context menu

### DIFF
--- a/PowerPointLabs/PowerPointLabs/Ribbon1.cs
+++ b/PowerPointLabs/PowerPointLabs/Ribbon1.cs
@@ -628,6 +628,10 @@ namespace PowerPointLabs
         {
             return TextCollection.AddCustomShapeShapeLabel;
         }
+        public string GetHideSelectedShapeLabel(Office.IRibbonControl control)
+        {
+            return TextCollection.HideSelectedShapeLabel;
+        }
         public string GetCutOutShapeShapeLabel(Office.IRibbonControl control)
         {
             return TextCollection.CutOutShapeShapeLabel;
@@ -2370,5 +2374,12 @@ namespace PowerPointLabs
             }
             return null;
         }
+
+        public void HideShapeButtonClick(Office.IRibbonControl control)
+        {
+            var selectedShapes = Globals.ThisAddIn.Application.ActiveWindow.Selection.ShapeRange;
+            selectedShapes.Visible = Office.MsoTriState.msoFalse;
+        }
+
     }
 }

--- a/PowerPointLabs/PowerPointLabs/Ribbon1.xml
+++ b/PowerPointLabs/PowerPointLabs/Ribbon1.xml
@@ -427,6 +427,10 @@
                 getLabel="GetFitToHeightShapeLabel"
                 getImage="GetFitToHeightImage"
                 onAction="FitToHeightClick"/>
+      <button id="hideShapeFreeform"
+              getLabel ="GetHideSelectedShapeLabel"
+              getImage="GetAddToCustomShapeContextImage"
+              onAction="HideShapeButtonClick"/>
       </menu>
     </contextMenu>
     <contextMenu idMso="ContextMenuPicture">

--- a/PowerPointLabs/PowerPointLabs/Ribbon1.xml
+++ b/PowerPointLabs/PowerPointLabs/Ribbon1.xml
@@ -390,6 +390,10 @@
                 getLabel="GetFitToHeightShapeLabel"
                 getImage="GetFitToHeightImage"
                 onAction="FitToHeightClick"/>
+        <button id="hideShapeShape"
+              getLabel ="GetHideSelectedShapeLabel"
+              getImage="GetAddToCustomShapeContextImage"
+              onAction="HideShapeButtonClick"/>
       </menu>
     </contextMenu>
     <contextMenu idMso="ContextMenuShapeFreeform">
@@ -454,6 +458,10 @@
                 getLabel ="GetAddCustomShapeShapeLabel"
                 getImage="GetAddToCustomShapeContextImage"
                 onAction="AddShapeButtonClick"/>
+        <button id="hideShape"
+               getLabel ="GetHideSelectedShapeLabel"
+               getImage="GetAddToCustomShapeContextImage"
+               onAction="HideShapeButtonClick"/>
       </menu>
     </contextMenu>
     <contextMenu idMso="ContextMenuChartArea">
@@ -547,6 +555,10 @@
                 getLabel="GetCutOutShapeShapeLabel"
                 getImage="GetCutOutShapeMenuImage"
                 onAction="CropShapeButtonClick"/>
+        <button id="hideShapeGroup"
+              getLabel ="GetHideSelectedShapeLabel"
+              getImage="GetAddToCustomShapeContextImage"
+              onAction="HideShapeButtonClick"/>
       </menu>
     </contextMenu>
     <contextMenu idMso="ContextMenuInk">

--- a/PowerPointLabs/PowerPointLabs/TextCollection.cs
+++ b/PowerPointLabs/PowerPointLabs/TextCollection.cs
@@ -231,6 +231,7 @@
         public const string HighlightBulletsBackgroundShapeLabel = "Highlight Background";
         public const string ConvertToPictureShapeLabel = "Convert to Picture";
         public const string AddCustomShapeShapeLabel = "Add to Shapes Lab";
+        public const string HideSelectedShapeLabel = "Hide the Shape";
         public const string CutOutShapeShapeLabel = "Crop To Shape";
         public const string FitToWidthShapeLabel = "Fit To Width";
         public const string FitToHeightShapeLabel = "Fit To Height";


### PR DESCRIPTION
Fix the issue by adding the hide button in the context menu, single selection and multiple selections are considered, as well as different selection type (text box or picture or shape). so far the text shown is "Hide the Shape", and icon not decided.