### PR TITLE
Fix #592 Text highlight is behind the text

### DIFF
--- a/PowerPointLabs/PowerPointLabs/HighlightTextFragments.cs
+++ b/PowerPointLabs/PowerPointLabs/HighlightTextFragments.cs
@@ -108,7 +108,7 @@ namespace PowerPointLabs
         private static List<PowerPoint.Shape> GetShapesFromLinesInText(PowerPointSlide currentSlide, Office.TextRange2 text, PowerPoint.Shape shape)
         {
             List<PowerPoint.Shape> shapesToAnimate = new List<PowerPoint.Shape>();
-            Boolean isHasBackground = (shape.Fill.Transparency).CompareTo(1.0f) == 0;
+            Boolean isTextBoxTransparent = (shape.Fill.Transparency).CompareTo(1.0f) == 0;
 
             foreach (Office.TextRange2 line in text.Lines)
             {
@@ -123,7 +123,7 @@ namespace PowerPointLabs
                 highlightShape.Fill.ForeColor.RGB = Utils.Graphics.ConvertColorToRgb(backgroundColor);
                 highlightShape.Fill.Transparency = 0.50f;
                 highlightShape.Line.Visible = Office.MsoTriState.msoFalse;
-                if (isHasBackground)
+                if (isTextBoxTransparent)
                 {
                     Utils.Graphics.MoveZToJustBehind(highlightShape, shape);
                 }

--- a/PowerPointLabs/PowerPointLabs/HighlightTextFragments.cs
+++ b/PowerPointLabs/PowerPointLabs/HighlightTextFragments.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Drawing;
 using System.Runtime.InteropServices;
+using DocumentFormat.OpenXml.Presentation;
 using PowerPointLabs.Models;
 using Office = Microsoft.Office.Core;
 using PowerPoint = Microsoft.Office.Interop.PowerPoint;
@@ -108,6 +109,7 @@ namespace PowerPointLabs
         private static List<PowerPoint.Shape> GetShapesFromLinesInText(PowerPointSlide currentSlide, Office.TextRange2 text, PowerPoint.Shape shape)
         {
             List<PowerPoint.Shape> shapesToAnimate = new List<PowerPoint.Shape>();
+            Boolean isHasBackground = (shape.Fill.Transparency).CompareTo(1.0f) == 0;
 
             foreach (Office.TextRange2 line in text.Lines)
             {
@@ -122,7 +124,10 @@ namespace PowerPointLabs
                 highlightShape.Fill.ForeColor.RGB = Utils.Graphics.ConvertColorToRgb(backgroundColor);
                 highlightShape.Fill.Transparency = 0.50f;
                 highlightShape.Line.Visible = Office.MsoTriState.msoFalse;
-                Utils.Graphics.MoveZToJustBehind(highlightShape, shape);
+                if (isHasBackground)
+                {
+                    Utils.Graphics.MoveZToJustBehind(highlightShape, shape);
+                }
                 highlightShape.Name = "PPTLabsHighlightTextFragmentsShape" + Guid.NewGuid().ToString();
                 highlightShape.Tags.Add("HighlightTextFragment", highlightShape.Name);
                 highlightShape.Select(Office.MsoTriState.msoFalse);

--- a/PowerPointLabs/PowerPointLabs/HighlightTextFragments.cs
+++ b/PowerPointLabs/PowerPointLabs/HighlightTextFragments.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Text;
 using System.Drawing;
 using System.Runtime.InteropServices;
-using DocumentFormat.OpenXml.Presentation;
 using PowerPointLabs.Models;
 using Office = Microsoft.Office.Core;
 using PowerPoint = Microsoft.Office.Interop.PowerPoint;


### PR DESCRIPTION
Use Transparency instead of comparing forecolor