### PR TITLE
Fix exception when removing audio #701

### DIFF
--- a/PowerPointLabs/PowerPointLabs/Ribbon1.cs
+++ b/PowerPointLabs/PowerPointLabs/Ribbon1.cs
@@ -1831,10 +1831,10 @@ namespace PowerPointLabs
             }
 
             var recorderPane = Globals.ThisAddIn.GetActivePane(typeof(RecorderTaskPane));
+
+            if (recorderPane == null) return;
+
             var recorder = recorderPane.Control as RecorderTaskPane;
-
-            if (recorder == null) return;
-
             recorder.ClearRecordDataListForSelectedSlides();
 
             // if current list is visible, update the pane immediately


### PR DESCRIPTION
How to trigger the bug:

1. Run PPL from VS in debug mode
2. Create an audio.
3. Remove the audio by clicking the Remove Audio button on the ribbon

I am unable to reproduce the issue where the Add Audio button does not work. So I am not sure if this PR should close #701 