### PR TITLE
Spotlight smaller than slide #968 

### DIFF
--- a/PowerPointLabs/PowerPointLabs/Models/PowerPointSpotlightSlide.cs
+++ b/PowerPointLabs/PowerPointLabs/Models/PowerPointSpotlightSlide.cs
@@ -128,21 +128,24 @@ namespace PowerPointLabs.Models
 
         private void CropSpotlightPictureToSlide(ref PowerPoint.Shape shapeToCrop)
         {
+            float scaleFactorWidth = PowerPointLabs.Utils.Graphics.GetScaleWidth(shapeToCrop);
+            float scaleFactorHeight = PowerPointLabs.Utils.Graphics.GetScaleHeight(shapeToCrop);
+
             if (shapeToCrop.Left < 0)
             {
-                shapeToCrop.PictureFormat.CropLeft += (0.0f - shapeToCrop.Left);
+                shapeToCrop.PictureFormat.CropLeft += ((0.0f - shapeToCrop.Left) / scaleFactorWidth);
             }
             if (shapeToCrop.Left + shapeToCrop.Width > PowerPointPresentation.Current.SlideWidth)
             {
-                shapeToCrop.PictureFormat.CropRight += (shapeToCrop.Left + shapeToCrop.Width - PowerPointPresentation.Current.SlideWidth);
+                shapeToCrop.PictureFormat.CropRight += ((shapeToCrop.Left + shapeToCrop.Width - PowerPointPresentation.Current.SlideWidth) / scaleFactorWidth);
             }
             if (shapeToCrop.Top < 0)
             {
-                shapeToCrop.PictureFormat.CropTop += (0.0f - shapeToCrop.Top);
+                shapeToCrop.PictureFormat.CropTop += ((0.0f - shapeToCrop.Top) / scaleFactorHeight);
             }
             if (shapeToCrop.Top + shapeToCrop.Height > PowerPointPresentation.Current.SlideHeight)
             {
-                shapeToCrop.PictureFormat.CropBottom += (shapeToCrop.Top + shapeToCrop.Height - PowerPointPresentation.Current.SlideHeight);
+                shapeToCrop.PictureFormat.CropBottom += ((shapeToCrop.Top + shapeToCrop.Height - PowerPointPresentation.Current.SlideHeight) / scaleFactorHeight);
             }
         }
 
@@ -196,6 +199,7 @@ namespace PowerPointLabs.Models
             float incrementHeight = (SoftEdgePadding * Spotlight.defaultSoftEdges) / spotlightPicture.Height;
 
             spotlightPicture.SoftEdge.Radius = Spotlight.defaultSoftEdges;
+            spotlightPicture.Shadow.Size = 0;
 
             spotlightPicture.Name = "SpotlightShape1";
         }

--- a/PowerPointLabs/PowerPointLabs/Utils/Graphics.cs
+++ b/PowerPointLabs/PowerPointLabs/Utils/Graphics.cs
@@ -403,6 +403,28 @@ namespace PowerPointLabs.Utils
             shape.Top = value - shape.Height;
         }
 
+        public static float GetScaleWidth(Shape shape)
+        {
+            float oldWidth = shape.Width;
+            shape.ScaleWidth(1, MsoTriState.msoCTrue);
+            float scaleFactorWidth = oldWidth / shape.Width;
+
+            shape.ScaleWidth(scaleFactorWidth, MsoTriState.msoCTrue);
+
+            return scaleFactorWidth;
+        }
+
+        public static float GetScaleHeight(Shape shape)
+        {
+            float oldHeight = shape.Height;
+            shape.ScaleHeight(1, MsoTriState.msoCTrue);
+            float scaleFactorHeight = oldHeight / shape.Height;
+
+            shape.ScaleHeight(scaleFactorHeight, MsoTriState.msoCTrue);
+
+            return scaleFactorHeight;
+        }
+
         // TODO: This could be an extension method of shape.
         /// <summary>
         /// anchorFraction = 0 means left side, anchorFraction = 1 means right side.


### PR DESCRIPTION
Refer to PowerPointLabs/PowerPointLabs#968

![image](https://cloud.githubusercontent.com/assets/8565916/13548090/a431f36c-e322-11e5-95e4-48fc6d8c323f.png)

Bug was due to `renderedPicture` in `RenderSpotlightPicture(PowerPoint.Shape spotlightPicture)` in 2010 having scale width and height of 1.3. Using crop on `renderedPicture` resulted in more cropping (1.3 times) than expected.

Another bug was that `this.Shapes.PasteSpecial(...)` in 2010 gave a shape that has shadow of msoShadow14 (in 2016 there is no shadow). Using `spotlightPicture.Export(...)` gave a image that had a white border at right and bottom edges (due to shadow).
