### PR TITLE
Picture Slides Lab should stay inside screen at low resolution #1017

### DIFF
--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/View/PictureSlidesLabWindow.xaml
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/View/PictureSlidesLabWindow.xaml
@@ -300,42 +300,36 @@
                 </Grid>
             </Grid>
             <Grid Name="ImageSelectionGrid" Margin="5,0,0,0" Grid.Column="2">
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="995*"/>
-                    <ColumnDefinition Width="48*"/>
-                    <ColumnDefinition Width="139*"/>
-                </Grid.ColumnDefinitions>
                 <Grid.RowDefinitions>
                     <RowDefinition Height="5" />
                     <RowDefinition Height="35" />
                     <RowDefinition Height="*" />
                 </Grid.RowDefinitions>
-                <Grid Grid.Row="1" Margin="0,0,0,5" Grid.ColumnSpan="3">
+                <Grid Grid.Row="1" Margin="0,0,0,5">
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="auto" />
                         <ColumnDefinition Width="95" />
                         <ColumnDefinition Width="auto" />
                         <ColumnDefinition Width="40" />
-                        <ColumnDefinition Width="5*"></ColumnDefinition>
-                        <ColumnDefinition Width="38*"/>
+                        <ColumnDefinition Width="*"></ColumnDefinition>
                         <ColumnDefinition Width="125" />
                         <ColumnDefinition Width="40" />
                     </Grid.ColumnDefinitions>
-                    <Button IsEnabled="false" Name="GotoSlideButton" ToolTip="Go to a slide to edit its style." Width="85" Click="GotoSlideButton_OnClick" Margin="2,0,7,0" Grid.Column="1">Go to slide</Button>
+                    <Button IsEnabled="false" Name="GotoSlideButton" ToolTip="Go to a slide to edit its style." Width="85" Click="GotoSlideButton_OnClick" Margin="0,0,5,0" Grid.Column="1">Go to slide</Button>
                     <Button IsEnabled="false" Name="LoadStylesButton" ToolTip="Load the style or picture from a slide to customize." Width="60" Click="LoadButton_OnClick" Margin="0,0,5,0" Grid.Column="2">Load...</Button>
-                    <controls:ProgressRing Name="ImageDownloadProgressRing" Width="10" Height="10" Grid.Column="3" IsActive="{Binding Path=IsActiveDownloadProgressRing.Flag, Mode=TwoWay}" Margin="10,5" />
-                    <Button Name="AddCitationSlideButton" Click="AddCitationSlideButton_OnClick" ToolTip="Add a picture sources slide." Margin="0,0,5,0" Grid.Column="6">Add sources slide</Button>
-                    <Button BorderThickness="0" Background="Transparent" Name="OpenSettingsButton" Click="OpenSettingsButton_OnClick" ToolTip="Open settings flyout." Margin="0,0,5,0" Grid.Column="7">
+                    <controls:ProgressRing Name="ImageDownloadProgressRing" Width="10" Height="10" Grid.Column="3" IsActive="{Binding Path=IsActiveDownloadProgressRing.Flag, Mode=TwoWay}" />
+                    <Button Name="AddCitationSlideButton" Click="AddCitationSlideButton_OnClick" ToolTip="Add a picture sources slide." Margin="0,0,5,0" Grid.Column="5">Add sources slide</Button>
+                    <Button BorderThickness="0" Background="Transparent" Name="OpenSettingsButton" Click="OpenSettingsButton_OnClick" ToolTip="Open settings flyout." Margin="0,0,5,0" Grid.Column="6">
                         <Image Name="SettingsButtonIcon"></Image>
                     </Button>
                 </Grid>
-                <TextBlock Visibility="Hidden" Margin="238,231,51,230" Name="ImageSelectionInstructions" MaxWidth="730" TextWrapping="Wrap" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="#AAAAAA" FontSize="18" Grid.Row="2">
+                <TextBlock Visibility="Hidden" Margin="10,0,10,0" Name="ImageSelectionInstructions" MaxWidth="730" TextWrapping="Wrap" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="#AAAAAA" FontSize="18" Grid.Row="2">
                     To add pictures<LineBreak/>
                     1. Click ‘+’ and choose more pictures from your computer hard disk,<LineBreak/>
                     2. Or use a Browser to search in Google Image Search, and drag-and-drop the search result thumbnails (one at a time) onto this window or the quick drop icon.<LineBreak/>
                     3. Or use a Browser to navigate to a Web page containing the picture you want to use, and drag-and-drop (or copy-paste) the picture onto this window or the quick drop icon</TextBlock>
-                <TextBlock Visibility="Hidden" Margin="252,290,64,290" Name="ImageSelectionInstructionsForFirstTime" MaxWidth="730" TextWrapping="Wrap" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="#AAAAAA" FontSize="18" Grid.Row="2">Select a picture to preview styles, then select a style and click `Apply` button to apply it to the slide.</TextBlock>
-                <ListBox TabIndex="1" PreviewMouseDown="ImageSelectionListBox_OnPreviewMouseDown" Name="ImageSelectionListBox" KeyDown="ImageSelectionListBox_OnKeyDown" SelectionChanged="ImageSelectionListBox_OnSelectionChanged" SelectedItem="{Binding Path=ImageSelectionListSelectedItem.ImageItem, Mode=TwoWay}" SelectedIndex="{Binding Path=ImageSelectionListSelectedId.Number, Mode=TwoWay}" ItemsSource="{Binding Path=ImageSelectionList, Mode=TwoWay}" Grid.Row="2" Grid.ColumnSpan="3">
+                <TextBlock Visibility="Hidden" Margin="10,0,10,0" Name="ImageSelectionInstructionsForFirstTime" MaxWidth="730" TextWrapping="Wrap" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="#AAAAAA" FontSize="18" Grid.Row="2">Select a picture to preview styles, then select a style and click `Apply` button to apply it to the slide.</TextBlock>
+                <ListBox TabIndex="1" PreviewMouseDown="ImageSelectionListBox_OnPreviewMouseDown" Name="ImageSelectionListBox" KeyDown="ImageSelectionListBox_OnKeyDown" SelectionChanged="ImageSelectionListBox_OnSelectionChanged" SelectedItem="{Binding Path=ImageSelectionListSelectedItem.ImageItem, Mode=TwoWay}" SelectedIndex="{Binding Path=ImageSelectionListSelectedId.Number, Mode=TwoWay}" ItemsSource="{Binding Path=ImageSelectionList, Mode=TwoWay}" Grid.Row="2">
                     <ListBox.ContextMenu>
                         <ContextMenu Name="ImageSelectionListBoxContextMenu">
                             <MenuItem Header="Adjust picture dimensions" Click="MenuItemAdjustImage_OnClick"></MenuItem>

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/View/PictureSlidesLabWindow.xaml
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/View/PictureSlidesLabWindow.xaml
@@ -10,8 +10,8 @@
              WindowStartupLocation="CenterScreen"
              Name="Window"
              Title="Picture Slides Lab"
-             Width="1200"
-             Height="700"
+             
+                           
              WindowTitleBrush="#0070C0"
              BorderThickness="1"
              BorderBrush="#0070C0"
@@ -300,36 +300,42 @@
                 </Grid>
             </Grid>
             <Grid Name="ImageSelectionGrid" Margin="5,0,0,0" Grid.Column="2">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="995*"/>
+                    <ColumnDefinition Width="48*"/>
+                    <ColumnDefinition Width="139*"/>
+                </Grid.ColumnDefinitions>
                 <Grid.RowDefinitions>
                     <RowDefinition Height="5" />
                     <RowDefinition Height="35" />
                     <RowDefinition Height="*" />
                 </Grid.RowDefinitions>
-                <Grid Grid.Row="1" Margin="0,0,0,5">
+                <Grid Grid.Row="1" Margin="0,0,0,5" Grid.ColumnSpan="3">
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="auto" />
                         <ColumnDefinition Width="95" />
                         <ColumnDefinition Width="auto" />
                         <ColumnDefinition Width="40" />
-                        <ColumnDefinition Width="*"></ColumnDefinition>
+                        <ColumnDefinition Width="5*"></ColumnDefinition>
+                        <ColumnDefinition Width="38*"/>
                         <ColumnDefinition Width="125" />
                         <ColumnDefinition Width="40" />
                     </Grid.ColumnDefinitions>
-                    <Button IsEnabled="false" Name="GotoSlideButton" ToolTip="Go to a slide to edit its style." Width="85" Click="GotoSlideButton_OnClick" Margin="0,0,5,0" Grid.Column="1">Go to slide</Button>
+                    <Button IsEnabled="false" Name="GotoSlideButton" ToolTip="Go to a slide to edit its style." Width="85" Click="GotoSlideButton_OnClick" Margin="2,0,7,0" Grid.Column="1">Go to slide</Button>
                     <Button IsEnabled="false" Name="LoadStylesButton" ToolTip="Load the style or picture from a slide to customize." Width="60" Click="LoadButton_OnClick" Margin="0,0,5,0" Grid.Column="2">Load...</Button>
-                    <controls:ProgressRing Name="ImageDownloadProgressRing" Width="10" Height="10" Grid.Column="3" IsActive="{Binding Path=IsActiveDownloadProgressRing.Flag, Mode=TwoWay}" />
-                    <Button Name="AddCitationSlideButton" Click="AddCitationSlideButton_OnClick" ToolTip="Add a picture sources slide." Margin="0,0,5,0" Grid.Column="5">Add sources slide</Button>
-                    <Button BorderThickness="0" Background="Transparent" Name="OpenSettingsButton" Click="OpenSettingsButton_OnClick" ToolTip="Open settings flyout." Margin="0,0,5,0" Grid.Column="6">
+                    <controls:ProgressRing Name="ImageDownloadProgressRing" Width="10" Height="10" Grid.Column="3" IsActive="{Binding Path=IsActiveDownloadProgressRing.Flag, Mode=TwoWay}" Margin="10,5" />
+                    <Button Name="AddCitationSlideButton" Click="AddCitationSlideButton_OnClick" ToolTip="Add a picture sources slide." Margin="0,0,5,0" Grid.Column="6">Add sources slide</Button>
+                    <Button BorderThickness="0" Background="Transparent" Name="OpenSettingsButton" Click="OpenSettingsButton_OnClick" ToolTip="Open settings flyout." Margin="0,0,5,0" Grid.Column="7">
                         <Image Name="SettingsButtonIcon"></Image>
                     </Button>
                 </Grid>
-                <TextBlock Visibility="Hidden" Margin="10,0,10,0" Name="ImageSelectionInstructions" MaxWidth="730" TextWrapping="Wrap" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="#AAAAAA" FontSize="18" Grid.Row="2">
+                <TextBlock Visibility="Hidden" Margin="238,231,51,230" Name="ImageSelectionInstructions" MaxWidth="730" TextWrapping="Wrap" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="#AAAAAA" FontSize="18" Grid.Row="2">
                     To add pictures<LineBreak/>
                     1. Click ‘+’ and choose more pictures from your computer hard disk,<LineBreak/>
                     2. Or use a Browser to search in Google Image Search, and drag-and-drop the search result thumbnails (one at a time) onto this window or the quick drop icon.<LineBreak/>
                     3. Or use a Browser to navigate to a Web page containing the picture you want to use, and drag-and-drop (or copy-paste) the picture onto this window or the quick drop icon</TextBlock>
-                <TextBlock Visibility="Hidden" Margin="10,0,10,0" Name="ImageSelectionInstructionsForFirstTime" MaxWidth="730" TextWrapping="Wrap" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="#AAAAAA" FontSize="18" Grid.Row="2">Select a picture to preview styles, then select a style and click `Apply` button to apply it to the slide.</TextBlock>
-                <ListBox TabIndex="1" PreviewMouseDown="ImageSelectionListBox_OnPreviewMouseDown" Name="ImageSelectionListBox" KeyDown="ImageSelectionListBox_OnKeyDown" SelectionChanged="ImageSelectionListBox_OnSelectionChanged" SelectedItem="{Binding Path=ImageSelectionListSelectedItem.ImageItem, Mode=TwoWay}" SelectedIndex="{Binding Path=ImageSelectionListSelectedId.Number, Mode=TwoWay}" ItemsSource="{Binding Path=ImageSelectionList, Mode=TwoWay}" Grid.Row="2">
+                <TextBlock Visibility="Hidden" Margin="252,290,64,290" Name="ImageSelectionInstructionsForFirstTime" MaxWidth="730" TextWrapping="Wrap" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="#AAAAAA" FontSize="18" Grid.Row="2">Select a picture to preview styles, then select a style and click `Apply` button to apply it to the slide.</TextBlock>
+                <ListBox TabIndex="1" PreviewMouseDown="ImageSelectionListBox_OnPreviewMouseDown" Name="ImageSelectionListBox" KeyDown="ImageSelectionListBox_OnKeyDown" SelectionChanged="ImageSelectionListBox_OnSelectionChanged" SelectedItem="{Binding Path=ImageSelectionListSelectedItem.ImageItem, Mode=TwoWay}" SelectedIndex="{Binding Path=ImageSelectionListSelectedId.Number, Mode=TwoWay}" ItemsSource="{Binding Path=ImageSelectionList, Mode=TwoWay}" Grid.Row="2" Grid.ColumnSpan="3">
                     <ListBox.ContextMenu>
                         <ContextMenu Name="ImageSelectionListBoxContextMenu">
                             <MenuItem Header="Adjust picture dimensions" Click="MenuItemAdjustImage_OnClick"></MenuItem>

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/View/PictureSlidesLabWindow.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/View/PictureSlidesLabWindow.xaml.cs
@@ -145,6 +145,9 @@ namespace PowerPointLabs.PictureSlidesLab.View
         private void InitViewModel()
         {
             ViewModel = new PictureSlidesLabWindowViewModel(this);
+            this.Window.Width = 1200;
+            this.Window.Height = 700;
+            this.Window.WindowStartupLocation(CenterScreen);
             ViewModel.StylesVariationList.CollectionChanged += StylesVariationList_OnCollectionChanged;
             ViewModel.StylesPreviewList.CollectionChanged += StylesPreviewList_OnCollectionChanged;
             ViewModel.ImageSelectionList.CollectionChanged += ImageSelectionList_OnCollectionChanged;
@@ -1240,7 +1243,6 @@ namespace PowerPointLabs.PictureSlidesLab.View
                 return (bool) propertyInfo.GetValue(this, null);
             }
         }
-
         #endregion
     }
 }

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/View/PictureSlidesLabWindow.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/View/PictureSlidesLabWindow.xaml.cs
@@ -68,6 +68,8 @@ namespace PowerPointLabs.PictureSlidesLab.View
 
         private int sysHeight;
         private int sysWidth;
+        private double sizeH;
+        private double sizeW;
 
         # endregion
 
@@ -116,12 +118,15 @@ namespace PowerPointLabs.PictureSlidesLab.View
             System.Drawing.Size mSize = SystemInformation.WorkingArea.Size;
             sysHeight = mSize.Height;
             sysWidth = mSize.Width;
+            sizeW = sysWidth * 1.0 / 1280;
+            sizeH = sysHeight * 1.0 / 800;
         }
 
         private void InitSize()
         {
-            this.Window.Width = 1200 * (sysWidth * 1.0 / 1280);
-            this.Window.Height = 700 * (sysHeight * 1.0 / 800);
+            this.Window.Width = 1200 * sizeW;
+            this.Window.Height = 700 * sizeH;
+            this.Window.StylesPreviewGrid.Width = 560 * sizeW;
         }
 
         private void InitPosition()

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/View/PictureSlidesLabWindow.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/View/PictureSlidesLabWindow.xaml.cs
@@ -66,10 +66,12 @@ namespace PowerPointLabs.PictureSlidesLab.View
         private bool _isDisplayDefaultPicture;
         private bool _isEnableUpdatePreview = true;
 
-        private int sysHeight;
-        private int sysWidth;
-        private double sizeH;
-        private double sizeW;
+        //Window size control constant
+        private const double StandardSystemWidth = 1280.0;
+        private const double StandardSystemHeight = 800.0;
+        private const double StandardWindowWidth = 1200.0;
+        private const double StandardWindowHeight = 700.0;
+        private const double StandardPrewienGridWidth = 560.0;
 
         # endregion
 
@@ -93,9 +95,7 @@ namespace PowerPointLabs.PictureSlidesLab.View
         {
             try
             {
-                GetScreenSize();
-                InitSize();
-                InitPosition();
+                InitSizePosition();
                 InitUiExceptionHandling();
                 InitViewModel();
                 InitGotoSlideDialog();
@@ -113,26 +113,19 @@ namespace PowerPointLabs.PictureSlidesLab.View
             }
         }
 
-        private void GetScreenSize()
+        private void InitSizePosition()
         {
             System.Drawing.Size mSize = SystemInformation.WorkingArea.Size;
-            sysHeight = mSize.Height;
-            sysWidth = mSize.Width;
-            sizeW = sysWidth * 1.0 / 1280;
-            sizeH = sysHeight * 1.0 / 800;
-        }
+            double systemHeight = mSize.Height * 1.0;
+            double systemWidth = mSize.Width * 1.0;
+            double windowWidth = systemWidth / StandardSystemWidth;
+            double windowHeight = systemHeight / StandardSystemHeight;
 
-        private void InitSize()
-        {
-            this.Window.Width = 1200 * sizeW;
-            this.Window.Height = 700 * sizeH;
-            this.Window.StylesPreviewGrid.Width = 560 * sizeW;
-        }
-
-        private void InitPosition()
-        {
-            this.Window.Left = (sysWidth * 1.0 - this.Window.Width) / 2;
-            this.Window.Top = (sysHeight * 1.0 - this.Window.Height) / 2;
+            this.Window.Width = StandardWindowWidth * windowWidth;
+            this.Window.Height = StandardWindowHeight * windowHeight;
+            this.Window.StylesPreviewGrid.Width = StandardPrewienGridWidth * windowWidth;
+            this.Window.Left = (systemWidth - this.Window.Width) / 2;
+            this.Window.Top = (systemHeight - this.Window.Height) / 2;
             this.Window.WindowStartupLocation = WindowStartupLocation.Manual;
         }
 

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/View/PictureSlidesLabWindow.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/View/PictureSlidesLabWindow.xaml.cs
@@ -66,6 +66,9 @@ namespace PowerPointLabs.PictureSlidesLab.View
         private bool _isDisplayDefaultPicture;
         private bool _isEnableUpdatePreview = true;
 
+        private int sysHeight;
+        private int sysWidth;
+
         # endregion
 
         #region Lifecycle
@@ -88,6 +91,9 @@ namespace PowerPointLabs.PictureSlidesLab.View
         {
             try
             {
+                GetScreenSize();
+                InitSize();
+                InitPosition();
                 InitUiExceptionHandling();
                 InitViewModel();
                 InitGotoSlideDialog();
@@ -103,6 +109,26 @@ namespace PowerPointLabs.PictureSlidesLab.View
                 ShowErrorMessageBox(TextCollection.PictureSlidesLabText.ErrorWhenInitialize, e);
                 Logger.LogException(e, "Init");
             }
+        }
+
+        private void GetScreenSize()
+        {
+            System.Drawing.Size mSize = SystemInformation.WorkingArea.Size;
+            sysHeight = mSize.Height;
+            sysWidth = mSize.Width;
+        }
+
+        private void InitSize()
+        {
+            this.Window.Width = 1200 * (sysWidth * 1.0 / 1280);
+            this.Window.Height = 700 * (sysHeight * 1.0 / 800);
+        }
+
+        private void InitPosition()
+        {
+            this.Window.Left = (sysWidth * 1.0 - this.Window.Width) / 2;
+            this.Window.Top = (sysHeight * 1.0 - this.Window.Height) / 2;
+            this.Window.WindowStartupLocation = WindowStartupLocation.Manual;
         }
 
         private void InitUiExceptionHandling()
@@ -145,9 +171,6 @@ namespace PowerPointLabs.PictureSlidesLab.View
         private void InitViewModel()
         {
             ViewModel = new PictureSlidesLabWindowViewModel(this);
-            this.Window.Width = 1200;
-            this.Window.Height = 700;
-            this.Window.WindowStartupLocation(CenterScreen);
             ViewModel.StylesVariationList.CollectionChanged += StylesVariationList_OnCollectionChanged;
             ViewModel.StylesPreviewList.CollectionChanged += StylesPreviewList_OnCollectionChanged;
             ViewModel.ImageSelectionList.CollectionChanged += ImageSelectionList_OnCollectionChanged;

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/View/PictureSlidesLabWindow.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/View/PictureSlidesLabWindow.xaml.cs
@@ -86,6 +86,7 @@ namespace PowerPointLabs.PictureSlidesLab.View
             IsOpen = true;
             SettingsButtonIcon.Source = ImageUtil.BitmapToImageSource(Properties.Resources.PslSettings);
             PictureAspectRefreshButtonIcon.Source = ImageUtil.BitmapToImageSource(Properties.Resources.PslRefresh);
+            InitSizePosition();
             Logger.Log("PSL begins");
 
             SetTimeout(Init, 800);
@@ -95,7 +96,6 @@ namespace PowerPointLabs.PictureSlidesLab.View
         {
             try
             {
-                InitSizePosition();
                 InitUiExceptionHandling();
                 InitViewModel();
                 InitGotoSlideDialog();


### PR DESCRIPTION
Fixes #1017 
 It can fit the screen even 800 * 600.

![2016513-175858](https://cloud.githubusercontent.com/assets/10655859/15244722/226722aa-1935-11e6-8a8e-7dd1ad1a7939.jpg)

It is a picture of the screen resolution of 800*600.

(BTW sorry the wrong word in the commit)