### PR TITLE
Highlight Lab: Spotlight does not fill up whole screen in PowerPoint 2016 #1071

### DIFF
--- a/PowerPointLabs/PowerPointLabs/Models/PowerPointSpotlightSlide.cs
+++ b/PowerPointLabs/PowerPointLabs/Models/PowerPointSpotlightSlide.cs
@@ -182,9 +182,16 @@ namespace PowerPointLabs.Models
             newRange.Select();
 
             PowerPoint.Selection currentSelection = Globals.ThisAddIn.Application.ActiveWindow.Selection;
+
+            // Save the original dimensions because ppPastePNG resizes it in Version 2016
+            float originalWidth = currentSelection.ShapeRange[1].Width;
+            float originalHeight = currentSelection.ShapeRange[1].Height;
             currentSelection.Cut();
 
             PowerPoint.Shape spotlightPicture = this.Shapes.PasteSpecial(PowerPoint.PpPasteDataType.ppPastePNG)[1];
+            spotlightPicture.Width = originalWidth;
+            spotlightPicture.Height = originalHeight;
+
             return spotlightPicture;
         }
 

--- a/PowerPointLabs/PowerPointLabs/Models/PowerPointSpotlightSlide.cs
+++ b/PowerPointLabs/PowerPointLabs/Models/PowerPointSpotlightSlide.cs
@@ -183,7 +183,7 @@ namespace PowerPointLabs.Models
 
             PowerPoint.Selection currentSelection = Globals.ThisAddIn.Application.ActiveWindow.Selection;
 
-            // Save the original dimensions because ppPastePNG resizes it in Version 2016
+            // Save the original dimensions because ppPastePNG is resized in PowerPoint 2016
             float originalWidth = currentSelection.ShapeRange[1].Width;
             float originalHeight = currentSelection.ShapeRange[1].Height;
             currentSelection.Cut();


### PR DESCRIPTION
Fixes #1071 

When using Create Spotlight on the (blue) shape in PowerPoint 2016:
<img src="https://cloud.githubusercontent.com/assets/19281538/22175133/008f54ec-e02a-11e6-88a2-07ffbe3936b4.png" width="400">

Before fix | After fix
--- | ---
![image](https://cloud.githubusercontent.com/assets/19281538/22175143/39fc5f40-e02a-11e6-9d97-f5e9d4947778.png) | ![image](https://cloud.githubusercontent.com/assets/19281538/22175134/08d7dd86-e02a-11e6-842a-475b7df4ed4e.png)


