### PR TITLE
Message in the sidebar of Shapes Lab is out of alignment #912 

### DIFF
--- a/PowerPointLabs/PowerPointLabs/CustomShapePane.Designer.cs
+++ b/PowerPointLabs/PowerPointLabs/CustomShapePane.Designer.cs
@@ -1,5 +1,6 @@
 ﻿using System.Drawing;
 using System.Windows.Forms;
+using PowerPointLabs.Utils;
 
 namespace PowerPointLabs
 {
@@ -237,7 +238,8 @@ namespace PowerPointLabs
                 new Font("Arial", 15.75F, FontStyle.Bold, GraphicsUnit.Point,
                          0),
             ForeColor = SystemColors.ButtonShadow,
-            Location = new Point(81, 11),
+            Location = new Point((int)(81 * Utils.Graphics.GetDpiScale()), 
+                                 (int)(11 * Utils.Graphics.GetDpiScale())),
             Name = "noShapeLabel",
             Size = new Size(212, 24),
             Text = TextCollection.CustomShapeNoShapeTextFirstLine
@@ -250,7 +252,8 @@ namespace PowerPointLabs
                 new Font("Arial", 10F, FontStyle.Bold, GraphicsUnit.Point,
                          0),
             ForeColor = SystemColors.ButtonShadow,
-            Location = new Point(11, 41),
+            Location = new Point((int)(11 * Utils.Graphics.GetDpiScale()),
+                                 (int)(41 * Utils.Graphics.GetDpiScale())),
             Name = "noShapeLabel",
             Size = new Size(242, 24),
             Text = TextCollection.CustomShapeNoShapeTextSecondLine
@@ -258,6 +261,7 @@ namespace PowerPointLabs
 
         private readonly Panel _noShapePanel = new Panel
         {
+            AutoSize = true,
             Name = "noShapePanel",
             Size = new Size(392, 100),
             Margin = new Padding(0, 0, 0, 0)

--- a/PowerPointLabs/PowerPointLabs/Utils/Graphics.cs
+++ b/PowerPointLabs/PowerPointLabs/Utils/Graphics.cs
@@ -24,6 +24,17 @@ namespace PowerPointLabs.Utils
 #pragma warning disable 0618
         #region Const
         public const float PictureExportingRatio = 96.0f / 72.0f;
+        private const float TargetDpi = 96.0f;
+        private static float dpiScale = 1.0f;
+
+        // Static initializer to retrieve dpi scale once
+        static Graphics()
+        {
+            using (System.Drawing.Graphics g = System.Drawing.Graphics.FromHwnd(IntPtr.Zero))
+            {
+                dpiScale = g.DpiX / TargetDpi;
+            }
+        }
         # endregion
 
         # region API
@@ -882,6 +893,11 @@ namespace PowerPointLabs.Utils
             {
                 bitmap.UnlockBits(bitmapData);
             }
+        }
+
+        public static float GetDpiScale()
+        {
+            return dpiScale;
         }
         # endregion
     }


### PR DESCRIPTION
Fixes #912 

**My claims on the problem and solution (correct me if I am wrong):**
This problem occurs on machines with DPI settings that is not 96 DPI. 
Due to the Labels being added in programmatically, the Location attributes are not scaled to DPI and not anchored properly. 
The parent Panel is also missing the AutoSize=true property, causing the Labels to be clipped.

This is tested on Windows 10, PowerPoint 2016, 192 DPI, Resolution 3200 x 1800.

**Before fix:**
* on 96 DPI
![100_beforefix](https://cloud.githubusercontent.com/assets/19281538/22182606/46a4a6d4-e0e4-11e6-8375-3e23652a6cee.PNG)

* on 192 DPI
![200_beforefix](https://cloud.githubusercontent.com/assets/19281538/22182552/eab650c6-e0e2-11e6-84ef-4151f4afe2a5.PNG)

**After fix:**
* on 96 DPI *(no change)*
![100_afterfix](https://cloud.githubusercontent.com/assets/19281538/22182570/54cf3c3e-e0e3-11e6-9437-abc98ae50f67.PNG)

* on 192 DPI *(message shows properly)*
![200_afterfix](https://cloud.githubusercontent.com/assets/19281538/22182555/fccd29c4-e0e2-11e6-94ab-4f27d36dd534.PNG)
