### PR TITLE
Shapes Lab: Dialog boxes are not properly sized #1094 

### DIFF
--- a/PowerPointLabs/PowerPointLabs/Views/ShapesLabCategoryInfoForm.Designer.cs
+++ b/PowerPointLabs/PowerPointLabs/Views/ShapesLabCategoryInfoForm.Designer.cs
@@ -36,29 +36,29 @@
             // 
             // categoryNameBox
             // 
-            this.categoryNameBox.Location = new System.Drawing.Point(230, 50);
-            this.categoryNameBox.Margin = new System.Windows.Forms.Padding(6, 6, 6, 6);
+            this.categoryNameBox.Location = new System.Drawing.Point(364, 74);
+            this.categoryNameBox.Margin = new System.Windows.Forms.Padding(10, 9, 10, 9);
             this.categoryNameBox.Name = "categoryNameBox";
-            this.categoryNameBox.Size = new System.Drawing.Size(358, 31);
+            this.categoryNameBox.Size = new System.Drawing.Size(565, 44);
             this.categoryNameBox.TabIndex = 0;
             this.categoryNameBox.KeyDown += new System.Windows.Forms.KeyEventHandler(this.CategoryNameBoxKeyDown);
             // 
             // label1
             // 
             this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(28, 56);
-            this.label1.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
+            this.label1.Location = new System.Drawing.Point(44, 83);
+            this.label1.Margin = new System.Windows.Forms.Padding(10, 0, 10, 0);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(161, 25);
+            this.label1.Size = new System.Drawing.Size(241, 37);
             this.label1.TabIndex = 1;
             this.label1.Text = "Category Name";
             // 
             // okButton
             // 
-            this.okButton.Location = new System.Drawing.Point(278, 129);
-            this.okButton.Margin = new System.Windows.Forms.Padding(6, 6, 6, 6);
+            this.okButton.Location = new System.Drawing.Point(440, 191);
+            this.okButton.Margin = new System.Windows.Forms.Padding(10, 9, 10, 9);
             this.okButton.Name = "okButton";
-            this.okButton.Size = new System.Drawing.Size(150, 48);
+            this.okButton.Size = new System.Drawing.Size(238, 71);
             this.okButton.TabIndex = 2;
             this.okButton.Text = "Ok";
             this.okButton.UseVisualStyleBackColor = true;
@@ -66,10 +66,10 @@
             // 
             // cancelButton
             // 
-            this.cancelButton.Location = new System.Drawing.Point(442, 129);
-            this.cancelButton.Margin = new System.Windows.Forms.Padding(6, 6, 6, 6);
+            this.cancelButton.Location = new System.Drawing.Point(700, 191);
+            this.cancelButton.Margin = new System.Windows.Forms.Padding(10, 9, 10, 9);
             this.cancelButton.Name = "cancelButton";
-            this.cancelButton.Size = new System.Drawing.Size(150, 48);
+            this.cancelButton.Size = new System.Drawing.Size(238, 71);
             this.cancelButton.TabIndex = 3;
             this.cancelButton.Text = "Cancel";
             this.cancelButton.UseVisualStyleBackColor = true;
@@ -77,16 +77,17 @@
             // 
             // ShapesLabCategoryInfoForm
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(12F, 25F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(19F, 37F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(650, 235);
+            this.AutoSize = true;
+            this.ClientSize = new System.Drawing.Size(1029, 348);
             this.ControlBox = false;
             this.Controls.Add(this.cancelButton);
             this.Controls.Add(this.okButton);
             this.Controls.Add(this.label1);
             this.Controls.Add(this.categoryNameBox);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
-            this.Margin = new System.Windows.Forms.Padding(6, 6, 6, 6);
+            this.Margin = new System.Windows.Forms.Padding(10, 9, 10, 9);
             this.Name = "ShapesLabCategoryInfoForm";
             this.SizeGripStyle = System.Windows.Forms.SizeGripStyle.Hide;
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;

--- a/PowerPointLabs/PowerPointLabs/Views/ShapesLabCategoryInfoForm.Designer.cs
+++ b/PowerPointLabs/PowerPointLabs/Views/ShapesLabCategoryInfoForm.Designer.cs
@@ -36,26 +36,29 @@
             // 
             // categoryNameBox
             // 
-            this.categoryNameBox.Location = new System.Drawing.Point(115, 24);
+            this.categoryNameBox.Location = new System.Drawing.Point(230, 50);
+            this.categoryNameBox.Margin = new System.Windows.Forms.Padding(6, 6, 6, 6);
             this.categoryNameBox.Name = "categoryNameBox";
-            this.categoryNameBox.Size = new System.Drawing.Size(181, 21);
+            this.categoryNameBox.Size = new System.Drawing.Size(358, 31);
             this.categoryNameBox.TabIndex = 0;
             this.categoryNameBox.KeyDown += new System.Windows.Forms.KeyEventHandler(this.CategoryNameBoxKeyDown);
             // 
             // label1
             // 
             this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(14, 27);
+            this.label1.Location = new System.Drawing.Point(28, 56);
+            this.label1.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(83, 12);
+            this.label1.Size = new System.Drawing.Size(161, 25);
             this.label1.TabIndex = 1;
             this.label1.Text = "Category Name";
             // 
             // okButton
             // 
-            this.okButton.Location = new System.Drawing.Point(139, 62);
+            this.okButton.Location = new System.Drawing.Point(278, 129);
+            this.okButton.Margin = new System.Windows.Forms.Padding(6, 6, 6, 6);
             this.okButton.Name = "okButton";
-            this.okButton.Size = new System.Drawing.Size(75, 23);
+            this.okButton.Size = new System.Drawing.Size(150, 48);
             this.okButton.TabIndex = 2;
             this.okButton.Text = "Ok";
             this.okButton.UseVisualStyleBackColor = true;
@@ -63,9 +66,10 @@
             // 
             // cancelButton
             // 
-            this.cancelButton.Location = new System.Drawing.Point(221, 62);
+            this.cancelButton.Location = new System.Drawing.Point(442, 129);
+            this.cancelButton.Margin = new System.Windows.Forms.Padding(6, 6, 6, 6);
             this.cancelButton.Name = "cancelButton";
-            this.cancelButton.Size = new System.Drawing.Size(75, 23);
+            this.cancelButton.Size = new System.Drawing.Size(150, 48);
             this.cancelButton.TabIndex = 3;
             this.cancelButton.Text = "Cancel";
             this.cancelButton.UseVisualStyleBackColor = true;
@@ -73,16 +77,18 @@
             // 
             // ShapesLabCategoryInfoForm
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 12F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(12F, 25F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(325, 113);
+            this.ClientSize = new System.Drawing.Size(650, 235);
             this.ControlBox = false;
             this.Controls.Add(this.cancelButton);
             this.Controls.Add(this.okButton);
             this.Controls.Add(this.label1);
             this.Controls.Add(this.categoryNameBox);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
+            this.Margin = new System.Windows.Forms.Padding(6, 6, 6, 6);
             this.Name = "ShapesLabCategoryInfoForm";
+            this.SizeGripStyle = System.Windows.Forms.SizeGripStyle.Hide;
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
             this.Text = "Category Information";
             this.ResumeLayout(false);

--- a/PowerPointLabs/PowerPointLabs/Views/ShapesLabSetting.Designer.cs
+++ b/PowerPointLabs/PowerPointLabs/Views/ShapesLabSetting.Designer.cs
@@ -37,10 +37,10 @@
             // 
             // okButton
             // 
-            this.okButton.Location = new System.Drawing.Point(334, 154);
-            this.okButton.Margin = new System.Windows.Forms.Padding(6, 6, 6, 6);
+            this.okButton.Location = new System.Drawing.Point(529, 228);
+            this.okButton.Margin = new System.Windows.Forms.Padding(10, 9, 10, 9);
             this.okButton.Name = "okButton";
-            this.okButton.Size = new System.Drawing.Size(150, 48);
+            this.okButton.Size = new System.Drawing.Size(238, 71);
             this.okButton.TabIndex = 0;
             this.okButton.Text = "Ok";
             this.okButton.UseVisualStyleBackColor = true;
@@ -48,10 +48,10 @@
             // 
             // cancelButton
             // 
-            this.cancelButton.Location = new System.Drawing.Point(496, 154);
-            this.cancelButton.Margin = new System.Windows.Forms.Padding(6, 6, 6, 6);
+            this.cancelButton.Location = new System.Drawing.Point(785, 228);
+            this.cancelButton.Margin = new System.Windows.Forms.Padding(10, 9, 10, 9);
             this.cancelButton.Name = "cancelButton";
-            this.cancelButton.Size = new System.Drawing.Size(150, 48);
+            this.cancelButton.Size = new System.Drawing.Size(238, 71);
             this.cancelButton.TabIndex = 1;
             this.cancelButton.Text = "Cancel";
             this.cancelButton.UseVisualStyleBackColor = true;
@@ -60,19 +60,19 @@
             // label1
             // 
             this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(24, 37);
-            this.label1.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
+            this.label1.Location = new System.Drawing.Point(38, 55);
+            this.label1.Margin = new System.Windows.Forms.Padding(10, 0, 10, 0);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(276, 25);
+            this.label1.Size = new System.Drawing.Size(409, 37);
             this.label1.TabIndex = 2;
             this.label1.Text = "Default Shape Saving Path:";
             // 
             // pathBox
             // 
-            this.pathBox.Location = new System.Drawing.Point(26, 79);
-            this.pathBox.Margin = new System.Windows.Forms.Padding(6, 6, 6, 6);
+            this.pathBox.Location = new System.Drawing.Point(41, 117);
+            this.pathBox.Margin = new System.Windows.Forms.Padding(10, 9, 10, 9);
             this.pathBox.Name = "pathBox";
-            this.pathBox.Size = new System.Drawing.Size(548, 31);
+            this.pathBox.Size = new System.Drawing.Size(865, 44);
             this.pathBox.TabIndex = 3;
             // 
             // browseButton
@@ -80,19 +80,20 @@
             this.browseButton.BackgroundImage = global::PowerPointLabs.Properties.Resources.Load_icon;
             this.browseButton.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
             this.browseButton.Cursor = System.Windows.Forms.Cursors.Hand;
-            this.browseButton.Location = new System.Drawing.Point(590, 73);
-            this.browseButton.Margin = new System.Windows.Forms.Padding(6, 6, 6, 6);
+            this.browseButton.Location = new System.Drawing.Point(934, 108);
+            this.browseButton.Margin = new System.Windows.Forms.Padding(10, 9, 10, 9);
             this.browseButton.Name = "browseButton";
-            this.browseButton.Size = new System.Drawing.Size(56, 56);
+            this.browseButton.Size = new System.Drawing.Size(89, 83);
             this.browseButton.TabIndex = 4;
             this.browseButton.UseVisualStyleBackColor = true;
             this.browseButton.Click += new System.EventHandler(this.BrowseButtonClick);
             // 
             // ShapesLabSetting
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(12F, 25F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(19F, 37F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(682, 285);
+            this.AutoSize = true;
+            this.ClientSize = new System.Drawing.Size(1080, 422);
             this.ControlBox = false;
             this.Controls.Add(this.browseButton);
             this.Controls.Add(this.pathBox);
@@ -100,7 +101,7 @@
             this.Controls.Add(this.cancelButton);
             this.Controls.Add(this.okButton);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
-            this.Margin = new System.Windows.Forms.Padding(6, 6, 6, 6);
+            this.Margin = new System.Windows.Forms.Padding(10, 9, 10, 9);
             this.Name = "ShapesLabSetting";
             this.SizeGripStyle = System.Windows.Forms.SizeGripStyle.Hide;
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;

--- a/PowerPointLabs/PowerPointLabs/Views/ShapesLabSetting.Designer.cs
+++ b/PowerPointLabs/PowerPointLabs/Views/ShapesLabSetting.Designer.cs
@@ -37,9 +37,10 @@
             // 
             // okButton
             // 
-            this.okButton.Location = new System.Drawing.Point(167, 74);
+            this.okButton.Location = new System.Drawing.Point(334, 154);
+            this.okButton.Margin = new System.Windows.Forms.Padding(6, 6, 6, 6);
             this.okButton.Name = "okButton";
-            this.okButton.Size = new System.Drawing.Size(75, 23);
+            this.okButton.Size = new System.Drawing.Size(150, 48);
             this.okButton.TabIndex = 0;
             this.okButton.Text = "Ok";
             this.okButton.UseVisualStyleBackColor = true;
@@ -47,9 +48,10 @@
             // 
             // cancelButton
             // 
-            this.cancelButton.Location = new System.Drawing.Point(248, 74);
+            this.cancelButton.Location = new System.Drawing.Point(496, 154);
+            this.cancelButton.Margin = new System.Windows.Forms.Padding(6, 6, 6, 6);
             this.cancelButton.Name = "cancelButton";
-            this.cancelButton.Size = new System.Drawing.Size(75, 23);
+            this.cancelButton.Size = new System.Drawing.Size(150, 48);
             this.cancelButton.TabIndex = 1;
             this.cancelButton.Text = "Cancel";
             this.cancelButton.UseVisualStyleBackColor = true;
@@ -58,17 +60,19 @@
             // label1
             // 
             this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(12, 18);
+            this.label1.Location = new System.Drawing.Point(24, 37);
+            this.label1.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(161, 12);
+            this.label1.Size = new System.Drawing.Size(276, 25);
             this.label1.TabIndex = 2;
             this.label1.Text = "Default Shape Saving Path:";
             // 
             // pathBox
             // 
-            this.pathBox.Location = new System.Drawing.Point(13, 38);
+            this.pathBox.Location = new System.Drawing.Point(26, 79);
+            this.pathBox.Margin = new System.Windows.Forms.Padding(6, 6, 6, 6);
             this.pathBox.Name = "pathBox";
-            this.pathBox.Size = new System.Drawing.Size(276, 21);
+            this.pathBox.Size = new System.Drawing.Size(548, 31);
             this.pathBox.TabIndex = 3;
             // 
             // browseButton
@@ -76,18 +80,19 @@
             this.browseButton.BackgroundImage = global::PowerPointLabs.Properties.Resources.Load_icon;
             this.browseButton.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
             this.browseButton.Cursor = System.Windows.Forms.Cursors.Hand;
-            this.browseButton.Location = new System.Drawing.Point(295, 35);
+            this.browseButton.Location = new System.Drawing.Point(590, 73);
+            this.browseButton.Margin = new System.Windows.Forms.Padding(6, 6, 6, 6);
             this.browseButton.Name = "browseButton";
-            this.browseButton.Size = new System.Drawing.Size(28, 27);
+            this.browseButton.Size = new System.Drawing.Size(56, 56);
             this.browseButton.TabIndex = 4;
             this.browseButton.UseVisualStyleBackColor = true;
             this.browseButton.Click += new System.EventHandler(this.BrowseButtonClick);
             // 
             // ShapesLabSetting
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 12F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(12F, 25F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(341, 137);
+            this.ClientSize = new System.Drawing.Size(682, 285);
             this.ControlBox = false;
             this.Controls.Add(this.browseButton);
             this.Controls.Add(this.pathBox);
@@ -95,7 +100,9 @@
             this.Controls.Add(this.cancelButton);
             this.Controls.Add(this.okButton);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
+            this.Margin = new System.Windows.Forms.Padding(6, 6, 6, 6);
             this.Name = "ShapesLabSetting";
+            this.SizeGripStyle = System.Windows.Forms.SizeGripStyle.Hide;
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
             this.Text = "Setting";
             this.ResumeLayout(false);


### PR DESCRIPTION
Fixes #1094 

FT_ShapesLabTest passed.
Tested on Windows 10, PowerPoint 2016, screen resolution 3200x1800.

On 192-DPI:
![192dpi](https://cloud.githubusercontent.com/assets/19281538/22427274/7cfecf20-e73d-11e6-9988-fb4259d850cd.PNG)

On 96-DPI:
![96dpi](https://cloud.githubusercontent.com/assets/19281538/22427278/7eb12b24-e73d-11e6-83ea-e71a188c12d7.PNG)
