### PR TITLE
Sync background producing many extra undo entries #754

### DIFF
--- a/PowerPointLabs/PowerPointLabs/AgendaLab/AgendaLabMain.cs
+++ b/PowerPointLabs/PowerPointLabs/AgendaLab/AgendaLabMain.cs
@@ -214,6 +214,8 @@ namespace PowerPointLabs.AgendaLab
                 currentWindow.ViewType = PpViewType.ppViewNormal;
 
                 BringToFront(refSlide);
+                
+                Graphics.CopyToDesign("Agenda Template", refSlide);
 
                 switch (type)
                 {
@@ -317,6 +319,8 @@ namespace PowerPointLabs.AgendaLab
             AgendaSlide.SetAsReferenceSlideName(refSlide, Type.Beam);
             refSlide.AddTemplateSlideMarker();
             refSlide.Hidden = true;
+
+            Graphics.CopyToDesign("Agenda Template", refSlide);
 
             return refSlide;
         }
@@ -460,6 +464,8 @@ namespace PowerPointLabs.AgendaLab
             refSlide.AddTemplateSlideMarker();
             refSlide.Hidden = true;
 
+            Graphics.CopyToDesign("Agenda Template", refSlide);
+
             return refSlide;
         }
 
@@ -483,6 +489,8 @@ namespace PowerPointLabs.AgendaLab
             AgendaSlide.SetAsReferenceSlideName(refSlide, Type.Visual);
             refSlide.AddTemplateSlideMarker();
             refSlide.Hidden = true;
+
+            Graphics.CopyToDesign("Agenda Template", refSlide);
 
             return refSlide;
         }

--- a/PowerPointLabs/PowerPointLabs/AgendaLab/AgendaLabSyncFunctions.cs
+++ b/PowerPointLabs/PowerPointLabs/AgendaLab/AgendaLabSyncFunctions.cs
@@ -246,9 +246,10 @@ namespace PowerPointLabs.AgendaLab
 
             DeleteShapesMarkedForDeletion(candidate, markedForDeletion);
 
-            candidate.CopyBackgroundColourFrom(refSlide);
             candidate.Layout = refSlide.Layout;
-            candidate.Design = refSlide.Design;
+            
+            candidate.Design = Graphics.GetDesign("Agenda Template");
+            candidate.GetNativeSlide().FollowMasterBackground = MsoTriState.msoTrue;
 
             // synchronize extra shapes other than visual items in reference slide
             var candidateSlideShapes = candidate.GetNameToShapeDictionary();

--- a/PowerPointLabs/PowerPointLabs/Utils/Graphics.cs
+++ b/PowerPointLabs/PowerPointLabs/Utils/Graphics.cs
@@ -788,9 +788,41 @@ namespace PowerPointLabs.Utils
             Native.SendMessage(control.Handle, (uint) Native.Message.WM_SETREDRAW, new IntPtr(1), IntPtr.Zero);
             control.Refresh();
         }
-        # endregion
+        #endregion
 
-        # region Color
+        #region Design
+
+        public static Design CreateDesign(string designName)
+        {
+            return Globals.ThisAddIn.Application.ActivePresentation.Designs.Add(designName);
+        }
+
+        public static Design GetDesign(string designName)
+        {
+            foreach (Design design in Globals.ThisAddIn.Application.ActivePresentation.Designs)
+            {
+                if (design.Name.Equals(designName))
+                {
+                    return design;
+                }
+            }
+            return null;
+        }
+
+        public static void CopyToDesign(string designName, PowerPointSlide refSlide)
+        {
+            var design = GetDesign(designName);
+            if (design == null)
+            {
+                design = CreateDesign(designName);
+            }
+            design.SlideMaster.Background.Fill.ForeColor = refSlide.GetNativeSlide().Background.Fill.ForeColor;
+            design.SlideMaster.Background.Fill.BackColor = refSlide.GetNativeSlide().Background.Fill.BackColor;
+        }
+
+        #endregion
+
+        #region Color
         public static int ConvertColorToRgb(Drawing.Color argb)
         {
             return (argb.B << 16) | (argb.G << 8) | argb.R;

--- a/PowerPointLabs/PowerPointLabs/Utils/Graphics.cs
+++ b/PowerPointLabs/PowerPointLabs/Utils/Graphics.cs
@@ -788,7 +788,7 @@ namespace PowerPointLabs.Utils
             Native.SendMessage(control.Handle, (uint) Native.Message.WM_SETREDRAW, new IntPtr(1), IntPtr.Zero);
             control.Refresh();
         }
-        #endregion
+        # endregion
 
         # region Design
 

--- a/PowerPointLabs/PowerPointLabs/Utils/Graphics.cs
+++ b/PowerPointLabs/PowerPointLabs/Utils/Graphics.cs
@@ -790,7 +790,7 @@ namespace PowerPointLabs.Utils
         }
         #endregion
 
-        #region Design
+        # region Design
 
         public static Design CreateDesign(string designName)
         {
@@ -820,9 +820,9 @@ namespace PowerPointLabs.Utils
             design.SlideMaster.Background.Fill.BackColor = refSlide.GetNativeSlide().Background.Fill.BackColor;
         }
 
-        #endregion
+        # endregion
 
-        #region Color
+        # region Color
         public static int ConvertColorToRgb(Drawing.Color argb)
         {
             return (argb.B << 16) | (argb.G << 8) | argb.R;

--- a/PowerPointLabs/PowerPointLabs/Utils/Graphics.cs
+++ b/PowerPointLabs/PowerPointLabs/Utils/Graphics.cs
@@ -794,12 +794,12 @@ namespace PowerPointLabs.Utils
 
         public static Design CreateDesign(string designName)
         {
-            return Globals.ThisAddIn.Application.ActivePresentation.Designs.Add(designName);
+            return PowerPointPresentation.Current.Presentation.Designs.Add(designName);
         }
 
         public static Design GetDesign(string designName)
         {
-            foreach (Design design in Globals.ThisAddIn.Application.ActivePresentation.Designs)
+            foreach (Design design in PowerPointPresentation.Current.Presentation.Designs)
             {
                 if (design.Name.Equals(designName))
                 {


### PR DESCRIPTION
Fixes #754.

We can get around setting the background fill by saving the template slide's background to a design, then setting all agenda slides to follow the design. This doesn't trigger any extra undo entries.
