### PR TITLE
Effects Lab: Blur/recolor all except selected changes original slide #1108

### DIFF
--- a/PowerPointLabs/PowerPointLabs/Ribbon1.cs
+++ b/PowerPointLabs/PowerPointLabs/Ribbon1.cs
@@ -2198,7 +2198,15 @@ namespace PowerPointLabs
 
                 if (dupSlide != null)
                 {
-                    dupSlide.Delete();
+                    if (generateOnRemainder)
+                    {
+                        dupSlide.Delete();
+                    }
+                    else
+                    {
+                        dupSlide.MoveTo(curSlide.Index);
+                        curSlide.Delete();
+                    }
                 }
                 
                 PowerPointPresentation.Current.AddAckSlide();

--- a/PowerPointLabs/Test/FunctionalTest/EffectsLabTest.cs
+++ b/PowerPointLabs/Test/FunctionalTest/EffectsLabTest.cs
@@ -17,6 +17,8 @@ namespace Test.FunctionalTest
         public void FT_EffectsLabTest()
         {
             PplFeatures.BlurrinessOverlay("EffectsLabBlurBackground", true);
+            TestRemainderEffect(46, PplFeatures.SepiaBackgroundEffect);
+            TestRemainderEffect(43, PplFeatures.BlurBackgroundEffect);
             TestRemainderEffect(40, PplFeatures.BlurBackgroundEffect);
             PplFeatures.BlurrinessOverlay("EffectsLabBlurRemainder", true);
             TestRemainderEffect(37, PplFeatures.BlurRemainderEffect);


### PR DESCRIPTION
Fixes #1108 

When effects is to be applied on the background, replaced the original slide with a duplicated one. Tested on 2013.