### PR TITLE
Some tests fail when run after FT_TextFragmentsTest #1116

### DIFF
--- a/PowerPointLabs/PowerPointLabs/HighlightBulletsBackground.cs
+++ b/PowerPointLabs/PowerPointLabs/HighlightBulletsBackground.cs
@@ -61,7 +61,9 @@ namespace PowerPointLabs
                     bool oldValue = AnimateInSlide.frameAnimationChecked;
                     AnimateInSlide.frameAnimationChecked = false;
                     AnimateInSlide.isHighlightBullets = true;
+                    AnimateInSlide.isHighlightTextFragments = false;
                     AnimateInSlide.AddAnimationInSlide();
+                    AnimateInSlide.isHighlightBullets = false;
                     AnimateInSlide.frameAnimationChecked = oldValue;
                     PowerPointPresentation.Current.AddAckSlide();
                 }

--- a/PowerPointLabs/PowerPointLabs/HighlightTextFragments.cs
+++ b/PowerPointLabs/PowerPointLabs/HighlightTextFragments.cs
@@ -98,6 +98,7 @@ namespace PowerPointLabs
             AnimateInSlide.isHighlightBullets = false;
             AnimateInSlide.isHighlightTextFragments = true;
             AnimateInSlide.AddAnimationInSlide();
+            AnimateInSlide.isHighlightTextFragments = false;
             AnimateInSlide.frameAnimationChecked = oldFrameAnimationChecked;
         }
 


### PR DESCRIPTION
Fixes #1116 

After using highlight bullet background or text fragment, some variables from AnimateInSlide get changed. What I did was to ensure that the variables that were changed are set back to the original after the operation.

Tested on ppt 2013.