### PR TITLE
FT_PositionsLabDuplicateAndRotate typo #1147

### DIFF
--- a/PowerPointLabs/Test/FunctionalTest/PositionsLabDuplicateAndRotateTest.cs
+++ b/PowerPointLabs/Test/FunctionalTest/PositionsLabDuplicateAndRotateTest.cs
@@ -45,7 +45,7 @@ namespace Test.FunctionalTest
 
             TestOneShapeFixed(positionsLab);
             TestOneShapeDynamic(positionsLab);
-            TestMultipleShapesDynamic(positionsLab);
+            TestMultipleShapesFixed(positionsLab);
             TestMultipleShapesDynamic(positionsLab);
         }
 


### PR DESCRIPTION
I made a typo, causing the wrong test method to be called.
That typo is fixed in this PR