### PR TITLE
Double clicking 'Create Spotlight' causing crash #1151

### DIFF
--- a/PowerPointLabs/PowerPointLabs/Ribbon1.cs
+++ b/PowerPointLabs/PowerPointLabs/Ribbon1.cs
@@ -278,6 +278,11 @@ namespace PowerPointLabs
         {
             try
             {
+                if (Globals.ThisAddIn.Application.ActiveWindow.Selection.Type != PowerPoint.PpSelectionType.ppSelectionShapes)
+                {
+                    return;
+                }
+
                 Globals.ThisAddIn.Application.StartNewUndoEntry();
 
                 Spotlight.AddSpotlightEffect();


### PR DESCRIPTION
Fixes #1151.

The error occurs because the shape is deselected by the first click, then when the second click runs with no selected shapes, it throws an error.

We can fix this by adding a check.