### PR TITLE
Optimize Magnify feature for picture #631

### DIFF
--- a/PowerPointLabs/PowerPointLabs/Models/PowerPointMagnifyingSlide.cs
+++ b/PowerPointLabs/PowerPointLabs/Models/PowerPointMagnifyingSlide.cs
@@ -63,7 +63,8 @@ namespace PowerPointLabs.Models
             foreach (PowerPoint.Shape s in matchingShapes)
                 s.Delete();
 
-            AddZoomSlideCroppedPicture();
+            float magnifyRatio = PowerPointPresentation.Current.SlideWidth / zoomShape.Width;
+            AddZoomSlideCroppedPicture(magnifyRatio);
 
             DeleteSlideNotes();
             DeleteSlideMedia();
@@ -122,7 +123,7 @@ namespace PowerPointLabs.Models
         }
 
         //Stores slide-size crop of the current slide as a global variable
-        private void AddZoomSlideCroppedPicture()
+        private void AddZoomSlideCroppedPicture(float magnifyRatio = 1.0f)
         {
             PowerPointSlide zoomSlideCopy = this.Duplicate();
             Globals.ThisAddIn.Application.ActiveWindow.View.GotoSlide(zoomSlideCopy.Index);
@@ -130,7 +131,7 @@ namespace PowerPointLabs.Models
             PowerPoint.Shape cropShape = zoomSlideCopy.Shapes.AddShape(Office.MsoAutoShapeType.msoShapeRectangle, 0, 0, PowerPointPresentation.Current.SlideWidth - 0.01f, PowerPointPresentation.Current.SlideHeight - 0.01f);
             cropShape.Select();
             PowerPoint.Selection sel = Globals.ThisAddIn.Application.ActiveWindow.Selection;
-            PowerPoint.Shape croppedShape = CropToShape.Crop(sel);
+            PowerPoint.Shape croppedShape = CropToShape.Crop(sel, magnifyRatio: magnifyRatio);
             croppedShape.Cut();
 
             zoomSlideCroppedShapes = _slide.Shapes.PasteSpecial(PowerPoint.PpPasteDataType.ppPastePNG)[1];

--- a/PowerPointLabs/PowerPointLabs/Ribbon1.cs
+++ b/PowerPointLabs/PowerPointLabs/Ribbon1.cs
@@ -1912,9 +1912,10 @@ namespace PowerPointLabs
 
             try
             {
-                var croppedShape = CropToShape.Crop(selection, magnifyRatio: 1.4f, isInPlace: true, handleError: false);
+                var magnifyRatio = 1.4f;
 
-                MagnifyGlassEffect(croppedShape, 1.4f);
+                var croppedShape = CropToShape.Crop(selection, magnifyRatio, isInPlace: true, handleError: false);
+                MagnifyGlassEffect(croppedShape, magnifyRatio);
             }
             catch (Exception e)
             {

--- a/PowerPointLabs/PowerPointLabs/Ribbon1.cs
+++ b/PowerPointLabs/PowerPointLabs/Ribbon1.cs
@@ -1912,7 +1912,7 @@ namespace PowerPointLabs
 
             try
             {
-                var croppedShape = CropToShape.Crop(selection, isInPlace: true, handleError: false);
+                var croppedShape = CropToShape.Crop(selection, magnifyRatio: 1.4f, isInPlace: true, handleError: false);
 
                 MagnifyGlassEffect(croppedShape, 1.4f);
             }

--- a/PowerPointLabs/PowerPointLabs/Utils/Graphics.cs
+++ b/PowerPointLabs/PowerPointLabs/Utils/Graphics.cs
@@ -630,17 +630,17 @@ namespace PowerPointLabs.Utils
         # endregion
 
         # region Slide
-        public static void ExportSlide(Slide slide, string exportPath)
+        public static void ExportSlide(Slide slide, string exportPath, float magnifyRatio = 1.0f)
         {
             slide.Export(exportPath,
                          "PNG",
-                         (int) GetDesiredExportWidth(),
-                         (int) GetDesiredExportHeight());
+                         (int)(GetDesiredExportWidth() * magnifyRatio),
+                         (int)(GetDesiredExportHeight() * magnifyRatio));
         }
 
-        public static void ExportSlide(PowerPointSlide slide, string exportPath)
+        public static void ExportSlide(PowerPointSlide slide, string exportPath, float magnifyRatio = 1.0f)
         {
-            ExportSlide(slide.GetNativeSlide(), exportPath);
+            ExportSlide(slide.GetNativeSlide(), exportPath, magnifyRatio);
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #631 and #607 

### Zoom To Area:
<img src="https://cloud.githubusercontent.com/assets/19281538/23210289/def3759e-f937-11e6-8f9b-a29f1acca824.png" width="550">

Zoom To Area (before fix):
<img src="https://cloud.githubusercontent.com/assets/19281538/23210322/070f26ae-f938-11e6-95ce-cfc416186c82.PNG" width="550">

Zoom To Area (after fix):
<img src="https://cloud.githubusercontent.com/assets/19281538/23210326/0874f97e-f938-11e6-8f0f-4be8a24af2fe.PNG" width="550">

### Magnify Effect:
<img src="https://cloud.githubusercontent.com/assets/19281538/23210377/3f75afb8-f938-11e6-99e9-c223de8e89a7.PNG" width="400">

Magnify Effect (before fix):
<img src="https://cloud.githubusercontent.com/assets/19281538/23210394/51c02798-f938-11e6-8799-3585c75ba4f1.PNG" width="400">

Magnify Effect (after fix):
<img src="https://cloud.githubusercontent.com/assets/19281538/23210395/52d2e116-f938-11e6-950a-3257f3005bfa.PNG" width="400">

Limitations faced:
* Exporting pictures to original dimensions: 
    * Imported pictures are downscaled if larger than slide dimensions
    * No API to get original picture dimensions (used in "Save as picture..." context menu)
* Scaling every objects in PPT to mimic a zoom-in effect:
    * Complicated to scale all objects from an anchor point (because of text fonts, etc.)

Tests passed: FT_AutoZoomTest, FT_ZoomToAreaTest, FT_EffectsLabTest