### PR TITLE
Colors Lab: Selected color shifts to a certain brightness/saturation #1162 

### DIFF
--- a/PowerPointLabs/PowerPointLabs/ColorPicker/HSLColor.cs
+++ b/PowerPointLabs/PowerPointLabs/ColorPicker/HSLColor.cs
@@ -71,7 +71,7 @@ namespace PowerPointLabs
                     b = GetColorComponent(temp1, temp2, hslColor.hue - 1.0 / 3.0);
                 }
             }
-            return Color.FromArgb((int)(255 * r), (int)(255 * g), (int)(255 * b));
+            return Color.FromArgb((int)Math.Round(255 * r), (int)Math.Round(255 * g), (int)Math.Round(255 * b));
         }
 
         private static double GetColorComponent(double temp1, double temp2, double temp3)


### PR DESCRIPTION
Fixes #1162 

The problem was caused by a loss of precision when converting Color from HSL to ARGB.
FT_ColorsLabTest passed.