### PR TITLE
Help button redirecting to old docs site #1165

### DIFF
--- a/PowerPointLabs/PowerPointLabs/TextCollection.cs
+++ b/PowerPointLabs/PowerPointLabs/TextCollection.cs
@@ -9,8 +9,8 @@
         # endregion
 
         # region URLs
-        public const string FeedbackUrl = "http://powerpointlabs.info/contact.html";
-        public const string HelpDocumentUrl = "http://powerpointlabs.info/docs.html";
+        public const string FeedbackUrl = "http://www.comp.nus.edu.sg/~pptlabs/contact.html";
+        public const string HelpDocumentUrl = "http://www.comp.nus.edu.sg/~pptlabs/docs/";
         public const string PowerPointLabsWebsiteUrl = "http://PowerPointLabs.info";
         public const string SingleShapeDownloadUrl = "http://www.comp.nus.edu.sg/~pptlabs/gallery.html";
         # endregion


### PR DESCRIPTION
Fixes #1165.

Corrected docs link.
Also, 'Contact Us' is redirecting to
http://www.comp.nus.edu.sg/~pptlabs//contact.html
instead of
http://www.comp.nus.edu.sg/~pptlabs/contact.html
so changed to direct url.