### PR TITLE
Corrected unaligned highlighted agenda titles on sync

### DIFF
--- a/PowerPointLabs/PowerPointLabs/AgendaLab/AgendaLabMain.cs
+++ b/PowerPointLabs/PowerPointLabs/AgendaLab/AgendaLabMain.cs
@@ -1016,8 +1016,10 @@ namespace PowerPointLabs.AgendaLab
                                                                                             shape.Section.Index == section.Index))
                                                 .FirstOrDefault();
             var currentSectionText = currentSectionTextBox.TextFrame2.TextRange;
+            var originalAlignment = currentSectionTextBox.TextFrame2.TextRange.ParagraphFormat.Alignment;
 
             Graphics.SyncTextRange(beamFormats.Highlighted, currentSectionText, pickupTextContent: false);
+            currentSectionTextBox.TextFrame2.TextRange.ParagraphFormat.Alignment = originalAlignment;
         }
         #endregion
 

--- a/PowerPointLabs/PowerPointLabs/AgendaLab/AgendaLabMain.cs
+++ b/PowerPointLabs/PowerPointLabs/AgendaLab/AgendaLabMain.cs
@@ -1016,10 +1016,10 @@ namespace PowerPointLabs.AgendaLab
                                                                                             shape.Section.Index == section.Index))
                                                 .FirstOrDefault();
             var currentSectionText = currentSectionTextBox.TextFrame2.TextRange;
-            var originalAlignment = currentSectionTextBox.TextFrame2.TextRange.ParagraphFormat.Alignment;
+            var originalAlignment = currentSectionText.ParagraphFormat.Alignment;
 
             Graphics.SyncTextRange(beamFormats.Highlighted, currentSectionText, pickupTextContent: false);
-            currentSectionTextBox.TextFrame2.TextRange.ParagraphFormat.Alignment = originalAlignment;
+            currentSectionText.ParagraphFormat.Alignment = originalAlignment;
         }
         #endregion
 


### PR DESCRIPTION
Previously, highlighting the agenda title on each respective page caused it to lose its alignment settings as the properties of the Highlight textbox is copied instead of the title's textbox itself, in `Graphics.SyncTextRange`.

I saved the Alignment property of the title textBox, and reassigned it after passing it through `Graphics.SyncTextRange`.

![image](https://cloud.githubusercontent.com/assets/9067940/23548196/415a5ab2-0041-11e7-805f-4e90ab6b61fa.png)
