### PR TITLE
Sync Labs: Sync line fill not working #1194

### DIFF
--- a/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/LineFillFormat.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/LineFillFormat.cs
@@ -12,8 +12,7 @@ namespace PowerPointLabs.SyncLab.ObjectFormats
 
         public static void SyncFormat(Shape formatShape, Shape newShape)
         {
-            //TODO not working
-            newShape.Line.ForeColor = newShape.Line.ForeColor;
+            newShape.Line.ForeColor = formatShape.Line.ForeColor;
             newShape.Line.BackColor = formatShape.Line.BackColor;
         }
 


### PR DESCRIPTION
Fixes #1194 
Problem was caused by line referencing it's own fill instead of the other line's fill