### PR TITLE
SyncLabs V2

### DIFF
--- a/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/FillFormat.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/FillFormat.cs
@@ -1,5 +1,7 @@
 ﻿using System.Drawing;
+
 using Microsoft.Office.Interop.PowerPoint;
+
 using Graphics = PowerPointLabs.Utils.Graphics;
 
 namespace PowerPointLabs.SyncLab.ObjectFormats

--- a/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/FillFormat.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/FillFormat.cs
@@ -1,5 +1,6 @@
 ﻿using System.Drawing;
 using Microsoft.Office.Interop.PowerPoint;
+using Graphics = PowerPointLabs.Utils.Graphics;
 
 namespace PowerPointLabs.SyncLab.ObjectFormats
 {
@@ -19,10 +20,16 @@ namespace PowerPointLabs.SyncLab.ObjectFormats
 
         public static Bitmap DisplayImage(Shape formatShape)
         {
-            Bitmap b = new Bitmap(200, 200);
-            Graphics g = Graphics.FromImage(b);
-            g.FillRectangle(Brushes.DarkBlue, 0, 0, 200, 200);
-            return b;
+            Shapes shapes = SyncFormatUtil.GetTemplateShapes();
+            Shape shape = shapes.AddShape(
+                    Microsoft.Office.Core.MsoAutoShapeType.msoShapeRectangle, 0, 0, 
+                    SyncFormatConstants.DisplayImageSize.Width,
+                    SyncFormatConstants.DisplayImageSize.Height);
+            shape.Line.Visible = Microsoft.Office.Core.MsoTriState.msoFalse;
+            SyncFormat(formatShape, shape);
+            Bitmap image = new Bitmap(Graphics.ShapeToImage(shape));
+            shape.Delete();
+            return image;
         }
     }
 }

--- a/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/FontColorFormat.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/FontColorFormat.cs
@@ -1,5 +1,7 @@
 ﻿using System.Drawing;
+
 using Microsoft.Office.Interop.PowerPoint;
+
 using Graphics = PowerPointLabs.Utils.Graphics;
 
 namespace PowerPointLabs.SyncLab.ObjectFormats

--- a/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/FontColorFormat.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/FontColorFormat.cs
@@ -1,6 +1,6 @@
 ﻿using System.Drawing;
 using Microsoft.Office.Interop.PowerPoint;
-
+using Graphics = PowerPointLabs.Utils.Graphics;
 
 namespace PowerPointLabs.SyncLab.ObjectFormats
 {
@@ -18,10 +18,18 @@ namespace PowerPointLabs.SyncLab.ObjectFormats
 
         public static Bitmap DisplayImage(Shape formatShape)
         {
-            Bitmap b = new Bitmap(200, 200);
-            Graphics g = Graphics.FromImage(b);
-            g.FillRectangle(Brushes.DarkBlue, 0, 0, 200, 200);
-            return b;
+            Shapes shapes = SyncFormatUtil.GetTemplateShapes();
+            Shape shape = shapes.AddShape(
+                    Microsoft.Office.Core.MsoAutoShapeType.msoShapeRectangle, 0, 0,
+                    SyncFormatConstants.DisplayImageSize.Width,
+                    SyncFormatConstants.DisplayImageSize.Height);
+            shape.Line.Visible = Microsoft.Office.Core.MsoTriState.msoFalse;
+            shape.Fill.ForeColor.RGB = formatShape.TextFrame.TextRange.Font.Color.RGB;
+            shape.Fill.BackColor.RGB = formatShape.TextFrame.TextRange.Font.Color.RGB;
+            shape.Fill.Solid();
+            Bitmap image = new Bitmap(Graphics.ShapeToImage(shape));
+            shape.Delete();
+            return image;
         }
     }
 }

--- a/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/FontFormat.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/FontFormat.cs
@@ -1,4 +1,5 @@
 ﻿using System.Drawing;
+
 using Microsoft.Office.Interop.PowerPoint;
 
 namespace PowerPointLabs.SyncLab.ObjectFormats

--- a/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/FontFormat.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/FontFormat.cs
@@ -17,10 +17,11 @@ namespace PowerPointLabs.SyncLab.ObjectFormats
 
         public static Bitmap DisplayImage(Shape formatShape)
         {
-            Bitmap b = new Bitmap(200, 200);
-            Graphics g = Graphics.FromImage(b);
-            g.FillRectangle(Brushes.DarkBlue, 0, 0, 200, 200);
-            return b;
+            return SyncFormatUtil.GetTextDisplay(
+                "T",
+                new System.Drawing.Font(formatShape.TextEffect.FontName,
+                                        SyncFormatConstants.DisplayImageFontSize),
+                SyncFormatConstants.DisplayImageSize);
         }
     }
 }

--- a/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/FontSizeFormat.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/FontSizeFormat.cs
@@ -1,4 +1,5 @@
-﻿using System.Drawing;
+﻿using System;
+using System.Drawing;
 using Microsoft.Office.Interop.PowerPoint;
 
 namespace PowerPointLabs.SyncLab.ObjectFormats
@@ -17,10 +18,10 @@ namespace PowerPointLabs.SyncLab.ObjectFormats
 
         public static Bitmap DisplayImage(Shape formatShape)
         {
-            Bitmap b = new Bitmap(200, 200);
-            Graphics g = Graphics.FromImage(b);
-            g.FillRectangle(Brushes.DarkBlue, 0, 0, 200, 200);
-            return b;
+            return SyncFormatUtil.GetTextDisplay(
+                Math.Round(formatShape.TextEffect.FontSize).ToString(),
+                SyncFormatConstants.DisplayImageFont,
+                SyncFormatConstants.DisplayImageSize);
         }
     }
 }

--- a/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/FontSizeFormat.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/FontSizeFormat.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Drawing;
+
 using Microsoft.Office.Interop.PowerPoint;
 
 namespace PowerPointLabs.SyncLab.ObjectFormats

--- a/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/FontStyleFormat.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/FontStyleFormat.cs
@@ -1,4 +1,5 @@
 ﻿using System.Drawing;
+
 using Microsoft.Office.Interop.PowerPoint;
 
 namespace PowerPointLabs.SyncLab.ObjectFormats

--- a/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/FontStyleFormat.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/FontStyleFormat.cs
@@ -18,10 +18,23 @@ namespace PowerPointLabs.SyncLab.ObjectFormats
 
         public static Bitmap DisplayImage(Shape formatShape)
         {
-            Bitmap b = new Bitmap(200, 200);
-            Graphics g = Graphics.FromImage(b);
-            g.FillRectangle(Brushes.DarkBlue, 0, 0, 200, 200);
-            return b;
+            System.Drawing.Font font = SyncFormatConstants.DisplayImageFont;
+            Microsoft.Office.Interop.PowerPoint.Font formatFont = formatShape.TextFrame.TextRange.Font;
+            FontStyle style = 0;
+            if (formatFont.Underline == Microsoft.Office.Core.MsoTriState.msoTrue)
+            {
+                style |= FontStyle.Underline;
+            }
+            if (formatFont.Bold == Microsoft.Office.Core.MsoTriState.msoTrue)
+            {
+                style |= FontStyle.Bold;
+            }
+            if (formatFont.Italic == Microsoft.Office.Core.MsoTriState.msoTrue)
+            {
+                style |= FontStyle.Italic;
+            }
+            font = new System.Drawing.Font(font.FontFamily, font.Size, style);
+            return SyncFormatUtil.GetTextDisplay( "T", font, SyncFormatConstants.DisplayImageSize);
         }
 
         private static void SyncTextRange(TextRange formatTextRange, TextRange newTextRange)

--- a/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/Format.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/Format.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Drawing;
 using System.Reflection;
+
 using Microsoft.Office.Interop.PowerPoint;
 
 namespace PowerPointLabs.SyncLab.ObjectFormats

--- a/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/Format.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/Format.cs
@@ -15,6 +15,14 @@ namespace PowerPointLabs.SyncLab.ObjectFormats
             this.format = format;
         }
 
+        public Type FormatType
+        {
+            get
+            {
+                return format;
+            }
+        }
+
         public bool CanCopy(Shape formatShape)
         {
             MethodInfo method = format.GetMethod("CanCopy", BindingFlags.Public | BindingFlags.Static);

--- a/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/LineArrowFormat.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/LineArrowFormat.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Drawing;
+
 using Microsoft.Office.Interop.PowerPoint;
+
 using Graphics = PowerPointLabs.Utils.Graphics;
 
 namespace PowerPointLabs.SyncLab.ObjectFormats

--- a/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/LineArrowFormat.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/LineArrowFormat.cs
@@ -1,5 +1,7 @@
-﻿using System.Drawing;
+﻿using System;
+using System.Drawing;
 using Microsoft.Office.Interop.PowerPoint;
+using Graphics = PowerPointLabs.Utils.Graphics;
 
 namespace PowerPointLabs.SyncLab.ObjectFormats
 {
@@ -7,6 +9,14 @@ namespace PowerPointLabs.SyncLab.ObjectFormats
     {
         public static bool CanCopy(Shape formatShape)
         {
+            try
+            {
+                SyncFormat(formatShape, formatShape);
+            }
+            catch (Exception)
+            {
+                return false;
+            }
             return true;
         }
 
@@ -23,10 +33,14 @@ namespace PowerPointLabs.SyncLab.ObjectFormats
 
         public static Bitmap DisplayImage(Shape formatShape)
         {
-            Bitmap b = new Bitmap(200, 200);
-            Graphics g = Graphics.FromImage(b);
-            g.FillRectangle(Brushes.DarkBlue, 0, 0, 200, 200);
-            return b;
+            Shapes shapes = SyncFormatUtil.GetTemplateShapes();
+            Shape shape = shapes.AddLine(
+                0, SyncFormatConstants.DisplayImageSize.Height,
+                SyncFormatConstants.DisplayImageSize.Width, 0);
+            SyncFormat(formatShape, shape);
+            Bitmap image = new Bitmap(Graphics.ShapeToImage(shape));
+            shape.Delete();
+            return image;
         }
     }
 }

--- a/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/LineFillFormat.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/LineFillFormat.cs
@@ -1,5 +1,7 @@
-﻿using System.Drawing;
+﻿using System;
+using System.Drawing;
 using Microsoft.Office.Interop.PowerPoint;
+using Graphics = PowerPointLabs.Utils.Graphics;
 
 namespace PowerPointLabs.SyncLab.ObjectFormats
 {
@@ -7,6 +9,14 @@ namespace PowerPointLabs.SyncLab.ObjectFormats
     {
         public static bool CanCopy(Shape formatShape)
         {
+            try
+            {
+                SyncFormat(formatShape, formatShape);
+            }
+            catch (Exception)
+            {
+                return false;
+            }
             return true;
         }
 
@@ -19,10 +29,16 @@ namespace PowerPointLabs.SyncLab.ObjectFormats
 
         public static Bitmap DisplayImage(Shape formatShape)
         {
-            Bitmap b = new Bitmap(200, 200);
-            Graphics g = Graphics.FromImage(b);
-            g.FillRectangle(Brushes.DarkBlue, 0, 0, 200, 200);
-            return b;
+            Shapes shapes = SyncFormatUtil.GetTemplateShapes();
+            Shape shape = shapes.AddShape(
+                    Microsoft.Office.Core.MsoAutoShapeType.msoShapeRectangle, 0, 0,
+                    SyncFormatConstants.DisplayImageSize.Width,
+                    SyncFormatConstants.DisplayImageSize.Height);
+            shape.Line.Visible = Microsoft.Office.Core.MsoTriState.msoFalse;
+            SyncFormat(formatShape, shape);
+            Bitmap image = new Bitmap(Graphics.ShapeToImage(shape));
+            shape.Delete();
+            return image;
         }
     }
 }

--- a/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/LineStyleFormat.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/LineStyleFormat.cs
@@ -1,5 +1,7 @@
-﻿using System.Drawing;
+﻿using System;
+using System.Drawing;
 using Microsoft.Office.Interop.PowerPoint;
+using Graphics = PowerPointLabs.Utils.Graphics;
 
 namespace PowerPointLabs.SyncLab.ObjectFormats
 {
@@ -7,6 +9,14 @@ namespace PowerPointLabs.SyncLab.ObjectFormats
     {
         public static bool CanCopy(Shape formatShape)
         {
+            try
+            {
+                SyncFormat(formatShape, formatShape);
+            }
+            catch (Exception)
+            {
+                return false;
+            }
             return true;
         }
 
@@ -18,10 +28,14 @@ namespace PowerPointLabs.SyncLab.ObjectFormats
 
         public static Bitmap DisplayImage(Shape formatShape)
         {
-            Bitmap b = new Bitmap(200, 200);
-            Graphics g = Graphics.FromImage(b);
-            g.FillRectangle(Brushes.DarkBlue, 0, 0, 200, 200);
-            return b;
+            Shapes shapes = SyncFormatUtil.GetTemplateShapes();
+            Shape shape = shapes.AddLine(
+                0, SyncFormatConstants.DisplayImageSize.Height,
+                SyncFormatConstants.DisplayImageSize.Width, 0);
+            SyncFormat(formatShape, shape);
+            Bitmap image = new Bitmap(Graphics.ShapeToImage(shape));
+            shape.Delete();
+            return image;
         }
     }
 }

--- a/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/LineStyleFormat.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/LineStyleFormat.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Drawing;
+
 using Microsoft.Office.Interop.PowerPoint;
+
 using Graphics = PowerPointLabs.Utils.Graphics;
 
 namespace PowerPointLabs.SyncLab.ObjectFormats

--- a/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/LineWeightFormat.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/LineWeightFormat.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Drawing;
+
 using Microsoft.Office.Interop.PowerPoint;
 
 namespace PowerPointLabs.SyncLab.ObjectFormats

--- a/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/LineWeightFormat.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/LineWeightFormat.cs
@@ -1,4 +1,5 @@
-﻿using System.Drawing;
+﻿using System;
+using System.Drawing;
 using Microsoft.Office.Interop.PowerPoint;
 
 namespace PowerPointLabs.SyncLab.ObjectFormats
@@ -17,10 +18,10 @@ namespace PowerPointLabs.SyncLab.ObjectFormats
 
         public static Bitmap DisplayImage(Shape formatShape)
         {
-            Bitmap b = new Bitmap(200, 200);
-            Graphics g = Graphics.FromImage(b);
-            g.FillRectangle(Brushes.DarkBlue, 0, 0, 200, 200);
-            return b;
+            return SyncFormatUtil.GetTextDisplay(
+                Math.Round(Math.Max(formatShape.Line.Weight, 0)).ToString(),
+                SyncFormatConstants.DisplayImageFont,
+                SyncFormatConstants.DisplayImageSize);
         }
     }
 }

--- a/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/PositionHeightFormat.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/PositionHeightFormat.cs
@@ -1,4 +1,6 @@
-﻿using System.Drawing;
+﻿
+using System;
+using System.Drawing;
 using Microsoft.Office.Interop.PowerPoint;
 
 namespace PowerPointLabs.SyncLab.ObjectFormats
@@ -17,10 +19,10 @@ namespace PowerPointLabs.SyncLab.ObjectFormats
 
         public static Bitmap DisplayImage(Shape formatShape)
         {
-            Bitmap b = new Bitmap(200, 200);
-            Graphics g = Graphics.FromImage(b);
-            g.FillRectangle(Brushes.DarkBlue, 0, 0, 200, 200);
-            return b;
+            return SyncFormatUtil.GetTextDisplay(
+                Math.Round(formatShape.Height).ToString(),
+                SyncFormatConstants.DisplayImageFont,
+                SyncFormatConstants.DisplayImageSize);
         }
     }
 }

--- a/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/PositionHeightFormat.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/PositionHeightFormat.cs
@@ -1,6 +1,6 @@
-﻿
-using System;
+﻿using System;
 using System.Drawing;
+
 using Microsoft.Office.Interop.PowerPoint;
 
 namespace PowerPointLabs.SyncLab.ObjectFormats

--- a/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/PositionWidthFormat.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/PositionWidthFormat.cs
@@ -1,4 +1,5 @@
-﻿using System.Drawing;
+﻿using System;
+using System.Drawing;
 using Microsoft.Office.Interop.PowerPoint;
 
 namespace PowerPointLabs.SyncLab.ObjectFormats
@@ -17,10 +18,10 @@ namespace PowerPointLabs.SyncLab.ObjectFormats
 
         public static Bitmap DisplayImage(Shape formatShape)
         {
-            Bitmap b = new Bitmap(200, 200);
-            Graphics g = Graphics.FromImage(b);
-            g.FillRectangle(Brushes.DarkBlue, 0, 0, 200, 200);
-            return b;
+            return SyncFormatUtil.GetTextDisplay(
+                Math.Round(formatShape.Width).ToString(),
+                SyncFormatConstants.DisplayImageFont,
+                SyncFormatConstants.DisplayImageSize);
         }
     }
 }

--- a/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/PositionWidthFormat.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/PositionWidthFormat.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Drawing;
+
 using Microsoft.Office.Interop.PowerPoint;
 
 namespace PowerPointLabs.SyncLab.ObjectFormats

--- a/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/PositionXFormat.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/PositionXFormat.cs
@@ -1,4 +1,5 @@
-﻿using System.Drawing;
+﻿using System;
+using System.Drawing;
 using Microsoft.Office.Interop.PowerPoint;
 
 namespace PowerPointLabs.SyncLab.ObjectFormats
@@ -17,10 +18,10 @@ namespace PowerPointLabs.SyncLab.ObjectFormats
 
         public static Bitmap DisplayImage(Shape formatShape)
         {
-            Bitmap b = new Bitmap(200, 200);
-            Graphics g = Graphics.FromImage(b);
-            g.FillRectangle(Brushes.DarkBlue, 0, 0, 200, 200);
-            return b;
+            return SyncFormatUtil.GetTextDisplay(
+                Math.Round(formatShape.Left).ToString(),
+                SyncFormatConstants.DisplayImageFont,
+                SyncFormatConstants.DisplayImageSize);
         }
     }
 }

--- a/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/PositionXFormat.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/PositionXFormat.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Drawing;
+
 using Microsoft.Office.Interop.PowerPoint;
 
 namespace PowerPointLabs.SyncLab.ObjectFormats

--- a/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/PositionYFormat.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/PositionYFormat.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Drawing;
+
 using Microsoft.Office.Interop.PowerPoint;
 
 namespace PowerPointLabs.SyncLab.ObjectFormats

--- a/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/PositionYFormat.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/PositionYFormat.cs
@@ -1,4 +1,5 @@
-﻿using System.Drawing;
+﻿using System;
+using System.Drawing;
 using Microsoft.Office.Interop.PowerPoint;
 
 namespace PowerPointLabs.SyncLab.ObjectFormats
@@ -17,10 +18,10 @@ namespace PowerPointLabs.SyncLab.ObjectFormats
 
         public static Bitmap DisplayImage(Shape formatShape)
         {
-            Bitmap b = new Bitmap(200, 200);
-            Graphics g = Graphics.FromImage(b);
-            g.FillRectangle(Brushes.DarkBlue, 0, 0, 200, 200);
-            return b;
+            return SyncFormatUtil.GetTextDisplay(
+                Math.Round(formatShape.Top).ToString(),
+                SyncFormatConstants.DisplayImageFont,
+                SyncFormatConstants.DisplayImageSize);
         }
     }
 }

--- a/PowerPointLabs/PowerPointLabs/SyncLab/SyncFormatConstants.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/SyncFormatConstants.cs
@@ -1,19 +1,33 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
-using System.Text;
+﻿using System.Drawing;
 
 namespace PowerPointLabs.SyncLab.ObjectFormats
 {
-    class SyncFormatConstants
+    public class SyncFormatConstants
     {
+
+        public static readonly Size DisplayImageSize = new Size(30, 30);
+
+        public static readonly int DisplayImageFontSize = DisplayImageSize.Height;
+        public static readonly Font DisplayImageFont = new Font("Arial", DisplayImageFontSize);
+
+        private static FormatTreeNode[] formatCategories = InitFormatCategories();
 
         public static FormatTreeNode[] FormatCategories
         {
             get
             {
-                return new FormatTreeNode[]
+                FormatTreeNode[] result = new FormatTreeNode[formatCategories.Length];
+                for (int i = 0; i < result.Length; i++)
+                {
+                    result[i] = formatCategories[i].Clone();
+                }
+                return result;
+            }
+        }
+
+        private static FormatTreeNode[] InitFormatCategories()
+        {
+            FormatTreeNode[] formats = new FormatTreeNode[]
                 {
                     new FormatTreeNode(
                             "Text",
@@ -57,65 +71,7 @@ namespace PowerPointLabs.SyncLab.ObjectFormats
                             new FormatTreeNode("Y", new Format(typeof(PositionYFormat)))
                         )
                 };
-                /*
-                KeyValuePair<String, Type>[] types = new KeyValuePair<String, Type>[]
-                {
-                    new KeyValuePair<string, Type>("Fill\\Fill Style", typeof(FillFormat)),
-                    new KeyValuePair<string, Type>("Fill\\Fill Style 2", typeof(FillFormat)),
-                    new KeyValuePair<string, Type>("Fill\\Fill Style 3", typeof(FillFormat)),
-                    new KeyValuePair<string, Type>("Fill\\Fill Style 4", typeof(FillFormat)),
-                    new KeyValuePair<string, Type>("Line\\Line Fill", typeof(LineFormat))
-                };
-                KeyValuePair<String, Format>[] categories =
-                        new KeyValuePair<String, Format>[types.Length];
-                HashSet<String> seenCategories = new HashSet<String>();
-                for (int i = 0; i < categories.Length; i++)
-                {
-                    string category = types[i].Key;
-                    Type formatType = types[i].Value;
-                    Debug.Assert(!seenCategories.Contains(types[i].Key), "Duplicate key");
-                    seenCategories.Add(types[i].Key);
-                    categories[i] = new KeyValuePair<string, Format>(
-                            types[i].Key,
-                            new Format(types[i].Value)
-                        );
-                }
-                return categories;
-                */
-                /*
-                FormatCategory[] categories = new FormatCategory[]
-                {
-                    new FormatCategory(
-                        "Text",
-                        new Type[] {
-                        }
-                    ),
-                    new FormatCategory(
-                        "Fill",
-                        new Type[] {
-                            typeof(FillFormat)
-                        }
-                    ),
-                    new FormatCategory(
-                        "Line",
-                        new Type[] {
-                            typeof(LineFormat)
-                        }
-                    ),
-                    new FormatCategory(
-                        "Effect",
-                        new Type[] {
-                        }
-                    ),
-                    new FormatCategory(
-                        "Size/Position",
-                        new Type[] {
-                        }
-                    )
-                };
-                return categories;
-                */
-            }
+            return formats;
         }
     }
 }

--- a/PowerPointLabs/PowerPointLabs/SyncLab/SyncFormatUtil.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/SyncFormatUtil.cs
@@ -1,85 +1,45 @@
 ﻿using System;
+using System.Drawing;
+
 using Microsoft.Office.Interop.PowerPoint;
+
+using Graphics = PowerPointLabs.Utils.Graphics;
 
 namespace PowerPointLabs.SyncLab
 {
-    class SyncFormatUtil
+    public class SyncFormatUtil
     {
+        #region Display Image Utils
 
-        public static void SyncColorFormat(ColorFormat formatToApplyOn, ColorFormat formatToApply)
+        public static Shapes GetTemplateShapes()
         {
-            try
+            Design design = Graphics.GetDesign(TextCollection.StorageTemplateName);
+            if (design == null)
             {
-                formatToApplyOn.ObjectThemeColor = formatToApply.ObjectThemeColor;
+                design = Graphics.CreateDesign(TextCollection.StorageTemplateName);
             }
-            catch (ArgumentException)
-            {
-            }
-            try
-            {
-                formatToApplyOn.SchemeColor = formatToApply.SchemeColor;
-            }
-            catch (ArgumentException)
-            {
-            }
-            formatToApplyOn.RGB = formatToApply.RGB;
-            formatToApplyOn.Brightness = formatToApply.Brightness;
-            formatToApplyOn.TintAndShade = formatToApply.TintAndShade;
+            return design.TitleMaster.Shapes;
         }
 
-        public static void SyncFillFormat(FillFormat formatToApplyOn, FillFormat formatToApply)
+        public static Bitmap GetTextDisplay(string text, System.Drawing.Font font, Size size)
         {
-            
+            Bitmap image = new Bitmap(size.Width, size.Height);
+            System.Drawing.Graphics g = System.Drawing.Graphics.FromImage(image);
+            SizeF textSize = g.MeasureString(text, font);
+            Bitmap textImage = new Bitmap((int)Math.Ceiling(textSize.Width), (int)Math.Ceiling(textSize.Height));
+            System.Drawing.Graphics g2 = System.Drawing.Graphics.FromImage(textImage);
+            g2.DrawString(text, font, Brushes.Black, 0, 0);
+
+            double scale = Math.Min(size.Width / textSize.Width, size.Height / textSize.Height);
+            double newWidth = textSize.Width * scale;
+            double newHeight = textSize.Height * scale;
+            double newX = (size.Width - newWidth) / 2;
+            double newY = (size.Height - newHeight) / 2;
+            g.DrawImage(textImage, Convert.ToSingle(newX), Convert.ToSingle(newY),
+                Convert.ToSingle(newWidth), Convert.ToSingle(newHeight));
+            return image;
         }
 
-        public static void SyncFontFormat(Font formatToApplyOn, Font formatToApply)
-        {
-            formatToApplyOn.AutoRotateNumbers = formatToApply.AutoRotateNumbers;
-            formatToApplyOn.BaselineOffset = formatToApply.BaselineOffset;
-            formatToApplyOn.Bold = formatToApply.Bold;
-            formatToApplyOn.Emboss = formatToApply.Emboss;
-            formatToApplyOn.Italic = formatToApply.Italic;
-            formatToApplyOn.Name = formatToApply.Name;
-            formatToApplyOn.NameAscii = formatToApply.NameAscii;
-            formatToApplyOn.NameComplexScript = formatToApply.NameComplexScript;
-            formatToApplyOn.NameFarEast = formatToApply.NameFarEast;
-            formatToApplyOn.NameOther = formatToApply.NameOther;
-            formatToApplyOn.Shadow = formatToApply.Shadow;
-            formatToApplyOn.Size = formatToApply.Size;
-            formatToApplyOn.Subscript = formatToApply.Subscript;
-            formatToApplyOn.Superscript = formatToApply.Superscript;
-            formatToApplyOn.Underline = formatToApply.Underline;
-            SyncColorFormat(formatToApplyOn.Color, formatToApply.Color);
-        }
-
-        public static void SyncLineFormat(LineFormat formatToApplyOn, LineFormat formatToApply)
-        {
-            try
-            {
-                formatToApplyOn.BeginArrowheadLength = formatToApply.BeginArrowheadLength;
-                formatToApplyOn.BeginArrowheadStyle = formatToApply.BeginArrowheadStyle;
-                formatToApplyOn.BeginArrowheadWidth = formatToApply.BeginArrowheadWidth;
-                formatToApplyOn.EndArrowheadLength = formatToApply.EndArrowheadLength;
-                formatToApplyOn.EndArrowheadStyle = formatToApply.EndArrowheadStyle;
-                formatToApplyOn.EndArrowheadWidth = formatToApply.EndArrowheadWidth;
-            }
-            catch (ArgumentException)
-            {
-            }
-            formatToApplyOn.DashStyle = formatToApply.DashStyle;
-            SyncColorFormat(formatToApplyOn.ForeColor, formatToApply.ForeColor);
-            formatToApplyOn.InsetPen = formatToApply.InsetPen;
-            try
-            {
-                formatToApplyOn.Pattern = formatToApply.Pattern;
-            }
-            catch (ArgumentException)
-            {
-            }
-            formatToApplyOn.Style = formatToApply.Style;
-            formatToApplyOn.Transparency = formatToApply.Transparency;
-            formatToApplyOn.Weight = formatToApply.Weight;
-        }
-
+        #endregion
     }
 }

--- a/PowerPointLabs/PowerPointLabs/SyncLab/View/FormatTreeNode.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/View/FormatTreeNode.cs
@@ -76,6 +76,22 @@ namespace PowerPointLabs.SyncLab
             }
         }
 
+        public bool IsCategoryNode
+        {
+            get
+            {
+                return childrenNodes != null;
+            }
+        }
+
+        public bool IsFormatNode
+        {
+            get
+            {
+                return format != null;
+            }
+        }
+
         public FormatTreeNode Clone()
         {
             return Clone(null);
@@ -84,7 +100,7 @@ namespace PowerPointLabs.SyncLab
         public FormatTreeNode Clone(FormatTreeNode parent)
         {
             FormatTreeNode cloned = null;
-            if (this.format != null)
+            if (this.IsFormatNode)
             {
                 cloned = new FormatTreeNode(name, format);
             }

--- a/PowerPointLabs/PowerPointLabs/SyncLab/View/SyncFormatDialog.xaml
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/View/SyncFormatDialog.xaml
@@ -8,14 +8,6 @@
              Title="PowerPointLabs"
              d:DesignHeight="600" d:DesignWidth="300" Height="600"  Width="307">
     <Grid>
-        <Grid.RowDefinitions>
-            <RowDefinition Height="131*"/>
-            <RowDefinition Height="438*"/>
-        </Grid.RowDefinitions>
-        <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="173*"/>
-            <ColumnDefinition Width="119*"/>
-        </Grid.ColumnDefinitions>
         <TreeView x:Name="treeView" Margin="10,10,10,35" Grid.ColumnSpan="2" Grid.RowSpan="2" HorizontalContentAlignment="Stretch"/>
         <Button x:Name="okButton" IsDefault="True" Content="OK" Margin="0,0,90,10" HorizontalAlignment="Right" Width="75" Height="20" VerticalAlignment="Bottom" Grid.ColumnSpan="2" Click="OkButton_Click" Grid.Row="1"/>
         <Button x:Name="cancelButton" IsCancel="True" Content="Cancel" Margin="0,0,10,10" HorizontalAlignment="Right" Width="75" Height="20" VerticalAlignment="Bottom" Grid.Column="1" Grid.Row="1"/>

--- a/PowerPointLabs/PowerPointLabs/SyncLab/View/SyncFormatDialog.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/View/SyncFormatDialog.xaml.cs
@@ -98,73 +98,9 @@ namespace PowerPointLabs.SyncLab.View
         {
             if (treeView.Items.IsEmpty)
             {
+                // Todo: fix
                 treeView.Items.MoveCurrentToFirst();
-                //(treeView.Items[0] as TreeViewItem).BringIntoView();
-            } 
-            
-            /*
-            ScrollViewer scrollViewer = GetScrollViewer(treeView);
-            if (scrollViewer != null)
-            {
-                scrollViewer.ScrollToTop();
             }
-            scrollViewer = (ScrollViewer)this.FindVisualChildElement(treeView, typeof(ScrollViewer));
-            if (scrollViewer != null)
-            {
-                scrollViewer.ScrollToTop();
-            }*/
-        }
-        
-            private FrameworkElement FindVisualChildElement(DependencyObject element, Type childType)
-            {
-                int count = VisualTreeHelper.GetChildrenCount(element);
-
-                for (int i = 0; i < count; i++)
-                {
-                var dependencyObject = VisualTreeHelper.GetChild(element, i);
-                var fe = (FrameworkElement)dependencyObject;
-
-                if (fe.GetType() == childType)
-                {
-                    return fe;
-                }
-
-                FrameworkElement ret = null;
-
-                if (fe.GetType().Equals(typeof(ScrollViewer)))
-                {
-                    ret = FindVisualChildElement((fe as ScrollViewer).Content as FrameworkElement, childType);
-                }
-                else
-                {
-                    ret = FindVisualChildElement(fe, childType);
-                }
-
-                if (ret != null)
-                {
-                    return ret;
-                }
-            }
-
-            return null;
-        }
-
-        private ScrollViewer GetScrollViewer(DependencyObject obj)
-        {
-            if (obj is ScrollViewer)
-            {
-                return (ScrollViewer)obj;
-            }
-            for (int i = 0; i < VisualTreeHelper.GetChildrenCount(obj); i++)
-            {
-                DependencyObject child = VisualTreeHelper.GetChild(obj, i);
-                ScrollViewer scrollViewer = GetScrollViewer(child);
-                if (scrollViewer != null)
-                {
-                    return scrollViewer;
-                }
-            }
-            return null;
         }
 
         public FormatTreeNode[] Formats

--- a/PowerPointLabs/PowerPointLabs/SyncLab/View/SyncFormatDialog.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/View/SyncFormatDialog.xaml.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Media;
 
 using Microsoft.Office.Interop.PowerPoint;
 using PowerPointLabs.SyncLab.ObjectFormats;
@@ -32,7 +33,8 @@ namespace PowerPointLabs.SyncLab.View
                 {
                     treeView.Items.Add(treeItem);
                 }
-            }   
+            }
+            ScrollToTop();
         }
 
         private Object DialogItemFromFormatTree(Shape shape, FormatTreeNode node)
@@ -70,10 +72,6 @@ namespace PowerPointLabs.SyncLab.View
                         {
                             children.Add((SyncFormatDialogItem)((TreeViewItem)treeItem).Header);
                         }
-                        else
-                        {
-                            throw new Exception("");
-                        }
                         result.Items.Add(treeItem);
                     }
                 }
@@ -94,6 +92,79 @@ namespace PowerPointLabs.SyncLab.View
         private void OkButton_Click(object sender, RoutedEventArgs e)
         {
             this.DialogResult = true;
+        }
+
+        private void ScrollToTop()
+        {
+            if (treeView.Items.IsEmpty)
+            {
+                treeView.Items.MoveCurrentToFirst();
+                //(treeView.Items[0] as TreeViewItem).BringIntoView();
+            } 
+            
+            /*
+            ScrollViewer scrollViewer = GetScrollViewer(treeView);
+            if (scrollViewer != null)
+            {
+                scrollViewer.ScrollToTop();
+            }
+            scrollViewer = (ScrollViewer)this.FindVisualChildElement(treeView, typeof(ScrollViewer));
+            if (scrollViewer != null)
+            {
+                scrollViewer.ScrollToTop();
+            }*/
+        }
+        
+            private FrameworkElement FindVisualChildElement(DependencyObject element, Type childType)
+            {
+                int count = VisualTreeHelper.GetChildrenCount(element);
+
+                for (int i = 0; i < count; i++)
+                {
+                var dependencyObject = VisualTreeHelper.GetChild(element, i);
+                var fe = (FrameworkElement)dependencyObject;
+
+                if (fe.GetType() == childType)
+                {
+                    return fe;
+                }
+
+                FrameworkElement ret = null;
+
+                if (fe.GetType().Equals(typeof(ScrollViewer)))
+                {
+                    ret = FindVisualChildElement((fe as ScrollViewer).Content as FrameworkElement, childType);
+                }
+                else
+                {
+                    ret = FindVisualChildElement(fe, childType);
+                }
+
+                if (ret != null)
+                {
+                    return ret;
+                }
+            }
+
+            return null;
+        }
+
+        private ScrollViewer GetScrollViewer(DependencyObject obj)
+        {
+            if (obj is ScrollViewer)
+            {
+                return (ScrollViewer)obj;
+            }
+            for (int i = 0; i < VisualTreeHelper.GetChildrenCount(obj); i++)
+            {
+                DependencyObject child = VisualTreeHelper.GetChild(obj, i);
+                ScrollViewer scrollViewer = GetScrollViewer(child);
+                if (scrollViewer != null)
+                {
+                    return scrollViewer;
+                }
+            }
+            return null;
         }
 
         public FormatTreeNode[] Formats

--- a/PowerPointLabs/PowerPointLabs/SyncLab/View/SyncFormatListItem.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/View/SyncFormatListItem.xaml.cs
@@ -27,6 +27,7 @@ namespace PowerPointLabs.SyncLab.View
         public SyncFormatListItem()
         {
             InitializeComponent();
+            UpdateImage();
         }
 
         public bool? IsChecked
@@ -50,12 +51,30 @@ namespace PowerPointLabs.SyncLab.View
             set
             {
                 image = value;
+                UpdateImage();
+            }
+        }
+
+        private void UpdateImage()
+        { // if image isn't set, fill the control with the text box
+            if (image == null)
+            {
+                imageBox.Visibility = Visibility.Hidden;
+                label.Margin = new Thickness(30, label.Margin.Top,
+                            label.Margin.Right, label.Margin.Bottom);
+                return;
+            }
+            else
+            {
                 BitmapSource source = Imaging.CreateBitmapSourceFromHBitmap(
-                        image.GetHbitmap(),
-                        IntPtr.Zero,
-                        Int32Rect.Empty,
-                        BitmapSizeOptions.FromEmptyOptions());
+                image.GetHbitmap(),
+                IntPtr.Zero,
+                Int32Rect.Empty,
+                BitmapSizeOptions.FromEmptyOptions());
                 imageBox.Source = source;
+                imageBox.Visibility = Visibility.Visible;
+                label.Margin = new Thickness(65, label.Margin.Top,
+                            label.Margin.Right, label.Margin.Bottom);
             }
         }
 

--- a/PowerPointLabs/PowerPointLabs/SyncLab/View/SyncFormatListItem.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/View/SyncFormatListItem.xaml.cs
@@ -56,7 +56,8 @@ namespace PowerPointLabs.SyncLab.View
         }
 
         private void UpdateImage()
-        { // if image isn't set, fill the control with the text box
+        {
+            // if image isn't set, fill the control with the text box
             if (image == null)
             {
                 imageBox.Visibility = Visibility.Hidden;
@@ -67,10 +68,10 @@ namespace PowerPointLabs.SyncLab.View
             else
             {
                 BitmapSource source = Imaging.CreateBitmapSourceFromHBitmap(
-                image.GetHbitmap(),
-                IntPtr.Zero,
-                Int32Rect.Empty,
-                BitmapSizeOptions.FromEmptyOptions());
+                                        image.GetHbitmap(),
+                                        IntPtr.Zero,
+                                        Int32Rect.Empty,
+                                        BitmapSizeOptions.FromEmptyOptions());
                 imageBox.Source = source;
                 imageBox.Visibility = Visibility.Visible;
                 label.Margin = new Thickness(65, label.Margin.Top,

--- a/PowerPointLabs/PowerPointLabs/TextCollection.cs
+++ b/PowerPointLabs/PowerPointLabs/TextCollection.cs
@@ -155,6 +155,9 @@
           
         #region Sync Lab
         public const string SyncLabButtonSupertip = "Opens the Sync Lab Interface";
+        public const string SyncLabCopySelectError = "Please select one item to copy.";
+        public const string SyncLabPasteSelectError = "Please select at least one item to apply.";
+        public const string StorageTemplateName = "Sync Labs - Do not edit";
         #endregion
 
         #endregion

--- a/PowerPointLabs/Test/Test.csproj
+++ b/PowerPointLabs/Test/Test.csproj
@@ -154,6 +154,7 @@
     <Compile Include="UnitTest\ResizeLab\SlideNo.cs" />
     <Compile Include="UnitTest\ResizeLab\SlightAdjustTest.cs" />
     <Compile Include="UnitTest\ResizeLab\StretchShrinkTest.cs" />
+    <Compile Include="UnitTest\SyncLab\SyncLabFormatTest.cs" />
     <Compile Include="UnitTest\TagMatchers\EndSpeedTests.cs" />
     <Compile Include="UnitTest\TagMatchers\EndVoiceTests.cs" />
     <Compile Include="UnitTest\TagMatchers\PauseTest.cs" />

--- a/PowerPointLabs/Test/UnitTest/SyncLab/SyncLabFormatTest.cs
+++ b/PowerPointLabs/Test/UnitTest/SyncLab/SyncLabFormatTest.cs
@@ -1,0 +1,50 @@
+﻿using System;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using PowerPointLabs.SyncLab;
+using PowerPointLabs.SyncLab.ObjectFormats;
+using System.Reflection;
+
+namespace Test.UnitTest.SyncLab
+{
+    [TestClass]
+    public class SyncLabFormatTest
+    {
+        [TestMethod]
+        [TestCategory("UT")]
+        public void SyncLabValidFormats()
+        {
+            FormatTreeNode[] formatCategories = SyncFormatConstants.FormatCategories;
+            AssertValidFormat(formatCategories);
+        }
+
+        private void AssertValidFormat(FormatTreeNode[] nodes)
+        {
+            foreach (FormatTreeNode node in nodes)
+            {
+                AssertValidFormat(node);
+            }
+        }
+
+        private void AssertValidFormat(FormatTreeNode node)
+        {
+            if (node.IsFormatNode)
+            {
+                AssertValidFormatType(node.Format.FormatType);
+            } else
+            {
+                AssertValidFormat(node.ChildrenNodes);
+            }
+        }
+
+        private void AssertValidFormatType(Type type)
+        {
+            MethodInfo method = type.GetMethod("CanCopy", BindingFlags.Public | BindingFlags.Static);
+            Assert.IsNotNull(method);
+            method = type.GetMethod("SyncFormat", BindingFlags.Public | BindingFlags.Static);
+            Assert.IsNotNull(method);
+            method = type.GetMethod("DisplayImage", BindingFlags.Public | BindingFlags.Static);
+            Assert.IsNotNull(method);
+        }
+    }
+}

--- a/PowerPointLabs/Test/UnitTest/SyncLab/SyncLabFormatTest.cs
+++ b/PowerPointLabs/Test/UnitTest/SyncLab/SyncLabFormatTest.cs
@@ -1,9 +1,10 @@
 ﻿using System;
+using System.Reflection;
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+
 using PowerPointLabs.SyncLab;
 using PowerPointLabs.SyncLab.ObjectFormats;
-using System.Reflection;
 
 namespace Test.UnitTest.SyncLab
 {
@@ -31,7 +32,8 @@ namespace Test.UnitTest.SyncLab
             if (node.IsFormatNode)
             {
                 AssertValidFormatType(node.Format.FormatType);
-            } else
+            }
+            else
             {
                 AssertValidFormat(node.ChildrenNodes);
             }


### PR DESCRIPTION
Fixes #1196

Change Log:

1. List items with no images have their image box automatically hidden.
Before:
![image](https://cloud.githubusercontent.com/assets/21071217/23948478/17dc94ee-09be-11e7-9651-372b7baac274.png)

After:
![image](https://cloud.githubusercontent.com/assets/21071217/23948026/2ee6041a-09bc-11e7-8727-bd062832b6db.png)

2. Helpful error messages when no items are selected during copy/paste.
![image](https://cloud.githubusercontent.com/assets/21071217/23948098/7c6ece10-09bc-11e7-9dda-2d33adeef7c5.png)
![image](https://cloud.githubusercontent.com/assets/21071217/23948103/863a2444-09bc-11e7-8dff-27ee20617961.png)

3. New formats copied will automatically be selected.
![image](https://cloud.githubusercontent.com/assets/21071217/23948226/0d85dc4a-09bd-11e7-8016-846b64d51fa9.png)

4. The selected format will show the name of the original shape
Before:
![image](https://cloud.githubusercontent.com/assets/21071217/23948490/33c517e4-09be-11e7-8bd9-8a287399beb4.png)

After:
![image](https://cloud.githubusercontent.com/assets/21071217/23948226/0d85dc4a-09bd-11e7-8016-846b64d51fa9.png)

5. Effects being pasted will apply on ALL shapes in selection.

6. Formats will not appear when not applicable. E.g. Options for arrowhead will not show when copying a rectangle's format.

7. Display images have been added to the various formats.
![image](https://cloud.githubusercontent.com/assets/21071217/23948278/4ae0f26e-09bd-11e7-8628-296effc9a4b6.png)

8. Unit tests have been added to ensure that all new formats added by developers have implemented the required functionality.