### PR TITLE
PowerPointPresentation: Presentation name not defined #1198

### DIFF
--- a/PowerPointLabs/PowerPointLabs/Models/PowerPointPresentation.cs
+++ b/PowerPointLabs/PowerPointLabs/Models/PowerPointPresentation.cs
@@ -14,6 +14,7 @@ namespace PowerPointLabs.Models
 #pragma warning disable 0618
         #region Properties
         private string _name;
+        private const string extensionRegex = "\\.pptx?$";
 
         public static Application Application { get; set; }
 
@@ -30,7 +31,14 @@ namespace PowerPointLabs.Models
         {
             get
             {
-                return Path + @"\" + Name;
+                if (Regex.IsMatch(Name, extensionRegex, RegexOptions.IgnoreCase))
+                {
+                    return Path + @"\" + Name;
+                }
+                else
+                {
+                    return Path + @"\" + Name + ".pptx";
+                }
             }
         }
 
@@ -79,8 +87,16 @@ namespace PowerPointLabs.Models
             get { return _name; }
             set
             {
-                NameNoExtension = value;
-                _name = value + ".pptx";
+                if (Regex.IsMatch(value, extensionRegex, RegexOptions.IgnoreCase))
+                {
+                    NameNoExtension = Regex.Replace(value, extensionRegex, "", RegexOptions.IgnoreCase);
+                }
+                else
+                {
+                    NameNoExtension = value;
+                }
+
+                _name = value;
             }
         }
 
@@ -222,12 +238,13 @@ namespace PowerPointLabs.Models
         public PowerPointPresentation(string path, string name)
         {
             Path = path;
-            Name = name;
+            Name = name + ".pptx";
         }
 
         public PowerPointPresentation(Presentation presentation)
         {
             Presentation = presentation;
+            Name = presentation.Name;
         }
         # endregion
 

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/StylesDesigner.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/StylesDesigner.cs
@@ -41,7 +41,7 @@ namespace PowerPointLabs.PictureSlidesLab.Service
         public StylesDesigner(Application app = null)
         {
             Path = TempPath.TempFolder;
-            Name = "PictureSlidesLabPreview" + Guid.NewGuid().ToString().Substring(0, 7);
+            Name = "PictureSlidesLabPreview" + Guid.NewGuid().ToString().Substring(0, 7) + ".pptx";
             Option = new StyleOption();
             Application = app;
             OpenInBackground();


### PR DESCRIPTION
Fixes #1198

As a Presentation name does not necessarily have an extension (for instance, a new presentation), this commit allows setting of Name without the extension.