### PR TITLE
Timer Lab: Allow customization of timer #1199

### DIFF
--- a/PowerPointLabs/PowerPointLabs/PowerPointLabs.csproj
+++ b/PowerPointLabs/PowerPointLabs/PowerPointLabs.csproj
@@ -771,6 +771,7 @@
     </Compile>
     <Compile Include="TagMatchers\NoEffectTagMatcher.cs" />
     <Compile Include="Tags\NoEffectTag.cs" />
+    <Compile Include="TimerLab\TimerLabConstants.cs" />
     <Compile Include="TimerLab\TimerLabPaneWPF.xaml.cs">
       <DependentUpon>TimerLabPaneWPF.xaml</DependentUpon>
     </Compile>

--- a/PowerPointLabs/PowerPointLabs/TimerLab/TimerLabConstants.cs
+++ b/PowerPointLabs/PowerPointLabs/TimerLab/TimerLabConstants.cs
@@ -1,0 +1,28 @@
+﻿
+namespace PowerPointLabs.TimerLab
+{
+    static class TimerLabConstants
+    {
+        public const double DefaultDisplayDuration = 1.00;
+        public const int DefaultDenomination = 10;
+        public const float DefaultTimerWidth = 500;
+        public const float DefaultTimerHeight = 50;
+        public const float DefaultMinutesLineMarkerWidth = 4;
+        public const float DefaultSecondsLineMarkerWidth = 2;
+        public const float DefaultTimeMarkerHeight = 50;
+        public const float DefaultTimeMarkerWidth = 50;
+        public const float DefaultSliderBodyWidth = 4;
+        public const float DefaultSliderHeadSize = 20;
+
+        public const int TransparencyTranparent = 1;
+        public const int Rotate180Degrees = 180;
+        public const float ColorChangeDuration = 0.001f;
+
+        public const int SecondsInMinute = 60;
+        public const int StartTime = 0;
+        public const double FractionalDecrementOffset = 0.60;
+        public const double FractionalDecrementLowerBound = 0.00;
+        public const double FractionalIncrementOffset = 0.99;
+        public const double FractionalIncrementUpperBound = 0.59;
+    }
+}

--- a/PowerPointLabs/PowerPointLabs/TimerLab/TimerLabPaneWPF.xaml
+++ b/PowerPointLabs/PowerPointLabs/TimerLab/TimerLabPaneWPF.xaml
@@ -4,19 +4,52 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              xmlns:local="clr-namespace:PowerPointLabs.TimerLab"
+             xmlns:Controls="clr-namespace:MahApps.Metro.Controls;assembly=MahApps.Metro"
              mc:Ignorable="d" 
              d:DesignHeight="300" d:DesignWidth="300">
-    <Grid>
-        <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="*" />
-            <ColumnDefinition Width="*" />
-            <ColumnDefinition Width="*" />
-        </Grid.ColumnDefinitions>
-        <Grid.RowDefinitions>
-            <RowDefinition Height="100" />
-            <RowDefinition Height="*" />
-        </Grid.RowDefinitions>
-
-        <Button Grid.Column="0" Grid.Row="0" Click="BlocksTimer_Click">Blocks Timer</Button>
-    </Grid>
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Controls.xaml" />
+                <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Fonts.xaml" />
+                <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Colors.xaml" />
+                <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Accents/steel.xaml" />
+                <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Accents/BaseLight.xaml" />
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </UserControl.Resources>
+    <ScrollViewer x:Name="PaneScroll">
+        <Grid>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="200" />
+                <RowDefinition Height="*" />
+            </Grid.RowDefinitions>
+            <GroupBox x:Name="PropertiesGroupBox" Header="Properties" Grid.Row="0" VerticalAlignment="Stretch" HorizontalAlignment="Stretch">
+                <Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="10" />
+                        <RowDefinition Height="1*" />
+                        <RowDefinition Height="1*" />
+                        <RowDefinition Height="1*" />
+                        <RowDefinition Height="1*" />
+                        <RowDefinition Height="10" />
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="10" />
+                        <ColumnDefinition Width="1*" />
+                        <ColumnDefinition Width="1*" />
+                        <ColumnDefinition Width="1*" />
+                        <ColumnDefinition Width="10" />
+                    </Grid.ColumnDefinitions>
+                    <TextBlock Grid.Row="1" Grid.Column="1" HorizontalAlignment="Left" VerticalAlignment="Center">Duration</TextBlock>
+                    <Controls:NumericUpDown x:Name="DurationTextBox" Grid.Row="1" Grid.Column="2" Grid.ColumnSpan="2" VerticalAlignment="Center" Controls:TextBoxHelper.Watermark="1.00" Minimum="0.01" Maximum="10" Interval="0.01" HorizontalContentAlignment="Left" StringFormat="N2" ValueDecremented="DurationTextBox_ValueDecremented" ValueIncremented="DurationTextBox_ValueIncremented" LostFocus="DurationTextBox_LostFocus"/>
+                    <TextBlock Grid.Row="2" Grid.Column="1" HorizontalAlignment="Left" VerticalAlignment="Center">Width</TextBlock>
+                    <TextBox x:Name="WidthTextBox" Grid.Row="2" Grid.Column="2" Grid.ColumnSpan="2" VerticalAlignment="Center" Height="25" Controls:TextBoxHelper.Watermark="500"/>
+                    <TextBlock Grid.Row="3" Grid.Column="1" HorizontalAlignment="Left" VerticalAlignment="Center">Height</TextBlock>
+                    <TextBox x:Name="HeightTextBox" Grid.Row="3" Grid.Column="2" Grid.ColumnSpan="2" VerticalAlignment="Center" Height="25" Controls:TextBoxHelper.Watermark="50"/>
+                    <Button Grid.Row="4" Grid.Column="3" VerticalAlignment="Center" Click="CreateButton_Click">Create</Button>
+                </Grid>
+            </GroupBox>
+        </Grid>
+    </ScrollViewer>
 </UserControl>

--- a/PowerPointLabs/PowerPointLabs/TimerLab/TimerLabPaneWPF.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/TimerLab/TimerLabPaneWPF.xaml.cs
@@ -11,6 +11,27 @@ namespace PowerPointLabs.TimerLab
     /// </summary>
     public partial class TimerLabPaneWPF : UserControl
     {
+        public const int DefaultDenomination = 10;
+        public const float DefaultTimerWidth = 500;
+        public const float DefaultTimerHeight = 50;
+        public const float DefaultMinutesLineMarkerWidth = 4;
+        public const float DefaultSecondsLineMarkerWidth = 2;
+        public const float DefaultTimeMarkerHeight = 50;
+        public const float DefaultTimeMarkerWidth = 50;
+        public const float DefaultSliderBodyWidth = 4;
+        public const float DefaultSliderHeadSize = 20;
+
+        public const int TransparencyTranparent = 1;
+        public const int Rotate180Degrees = 180;
+        public const float ColorChangeDuration = 0.001f;
+
+        public const int SecondsInMinute = 60;
+        public const int StartTime = 0;
+        public const double FractionalDecrementOffset = 0.60;
+        public const double FractionalDecrementLowerBound = 0.00;
+        public const double FractionalIncrementOffset = 0.99;
+        public const double FractionalIncrementUpperBound = 0.59;
+
         public TimerLabPaneWPF()
         {
             InitializeComponent();
@@ -24,7 +45,7 @@ namespace PowerPointLabs.TimerLab
 
             // Functionality
             int duration = Duration();
-            int denomination = 10;
+            int denomination = DefaultDenomination;
 
             // Aesthetics
             // Main
@@ -32,12 +53,12 @@ namespace PowerPointLabs.TimerLab
             float timerHeight = TimerHeight();
             int timerBodyColor = System.Drawing.Color.FromArgb(106, 84, 68).ToArgb();
             // Markers
-            float lineMarkerWidth = 2;
-            float timeMarkerWidth = 50;
-            float timeMarkerHeight = 50;
+            float lineMarkerWidth = DefaultSecondsLineMarkerWidth;
+            float timeMarkerWidth = DefaultTimeMarkerWidth;
+            float timeMarkerHeight = DefaultTimeMarkerHeight;
             // Slider
-            var sliderHeadSize = 20;
-            var sliderBodyWidth = 4;
+            var sliderHeadSize = DefaultSliderHeadSize;
+            var sliderBodyWidth = DefaultSliderBodyWidth;
             int sliderColor = System.Drawing.Color.FromArgb(70, 150, 247).ToArgb();
 
             // Position
@@ -45,13 +66,14 @@ namespace PowerPointLabs.TimerLab
             float timerTop = (slideHeight - timerHeight) / 2;         
 
             // Create timer
-            var timerBody = this.GetCurrentSlide().Shapes.AddShape(Microsoft.Office.Core.MsoAutoShapeType.msoShapeRectangle, timerLeft, timerTop, timerWidth, timerHeight);
+            var timerBody = this.GetCurrentSlide().Shapes.AddShape(Microsoft.Office.Core.MsoAutoShapeType.msoShapeRectangle, 
+                timerLeft, timerTop, timerWidth, timerHeight);
             timerBody.Name = "timerBody";
             timerBody.Fill.ForeColor.RGB = timerBodyColor;
             timerBody.Line.ForeColor.RGB = timerBodyColor;
             
             // Add markers
-            if (duration <= 60)
+            if (duration <= SecondsInMinute)
             {
                 AddSecondsMarker(duration, denomination, timerWidth, timerHeight, timerLeft, timerTop,
                     lineMarkerWidth, timeMarkerWidth, timeMarkerHeight);
@@ -63,42 +85,45 @@ namespace PowerPointLabs.TimerLab
             }
 
             // Add slider components
-            var sliderHead = this.GetCurrentSlide().Shapes.AddShape(Microsoft.Office.Core.MsoAutoShapeType.msoShapeIsoscelesTriangle, 
+            var sliderHead = this.GetCurrentSlide().Shapes.AddShape(
+                Microsoft.Office.Core.MsoAutoShapeType.msoShapeIsoscelesTriangle, 
                 timerLeft - (sliderHeadSize / 2), timerTop - (sliderHeadSize / 2), sliderHeadSize, sliderHeadSize);
             sliderHead.Name = "timerSliderHead";
-            sliderHead.Rotation = 180;
+            sliderHead.Rotation = Rotate180Degrees;
             sliderHead.Fill.ForeColor.RGB = sliderColor;
-            sliderHead.Line.Transparency = 1;
+            sliderHead.Line.Transparency = TransparencyTranparent;
 
             var sliderBody = this.GetCurrentSlide().Shapes.AddShape(Microsoft.Office.Core.MsoAutoShapeType.msoShapeRectangle, 
                 timerLeft - (sliderBodyWidth / 2), timerTop, sliderBodyWidth, timerHeight);
             sliderBody.Name = "timerSliderBody";
             sliderBody.Fill.ForeColor.RGB = sliderColor;
-            sliderBody.Line.Transparency = 1;
+            sliderBody.Line.Transparency = TransparencyTranparent;
 
             // Add slider animations
-            AddSliderMotionEffect(sliderHead, duration, timerWidth, slideWidth, PowerPoint.MsoAnimTriggerType.msoAnimTriggerOnPageClick);
-            AddSliderMotionEffect(sliderBody, duration, timerWidth, slideWidth, PowerPoint.MsoAnimTriggerType.msoAnimTriggerWithPrevious);
+            AddSliderMotionEffect(sliderHead, duration, timerWidth, slideWidth, 
+                PowerPoint.MsoAnimTriggerType.msoAnimTriggerOnPageClick);
+            AddSliderMotionEffect(sliderBody, duration, timerWidth, slideWidth, 
+                PowerPoint.MsoAnimTriggerType.msoAnimTriggerWithPrevious);
             AddSliderEndEffect(sliderHead, PowerPoint.MsoAnimTriggerType.msoAnimTriggerAfterPrevious);
             AddSliderEndEffect(sliderBody, PowerPoint.MsoAnimTriggerType.msoAnimTriggerWithPrevious);
         }
 
         private int Duration()
         {
-            int duration = 60; // default value
+            int duration = SecondsInMinute;
             if (DurationTextBox.Value != null)
             {
                 double value = Math.Round(DurationTextBox.Value.Value, 2);
                 int minutes = (int)value;
                 int seconds = (int)((value - minutes) * 100);
-                duration = (minutes * 60) + seconds;
+                duration = (minutes * SecondsInMinute) + seconds;
             }
             return duration;
         }
 
         private float TimerWidth()
         {
-            float width = 500; // default value
+            float width = DefaultTimerWidth;
             if (!string.IsNullOrEmpty(WidthTextBox.Text))
             {
                 width = float.Parse(WidthTextBox.Text);
@@ -108,7 +133,7 @@ namespace PowerPointLabs.TimerLab
 
         private float TimerHeight()
         {
-            float height = 50; // default value
+            float height = DefaultTimerHeight;
             if (!string.IsNullOrEmpty(HeightTextBox.Text))
             {
                 height = float.Parse(HeightTextBox.Text);
@@ -116,30 +141,33 @@ namespace PowerPointLabs.TimerLab
             return height;
         }
 
-        private void AddSecondsMarker(int duration, int denomination, float timerWidth, float timerHeight, float timerLeft, float timerTop, 
-            float lineMarkerWidth, float timeMarkerWidth, float timeMarkerHeight)
+        private void AddSecondsMarker(int duration, int denomination, float timerWidth, float timerHeight, float timerLeft, 
+            float timerTop, float lineMarkerWidth, float timeMarkerWidth, float timeMarkerHeight)
         {
             float widthPerSec = timerWidth / duration;
 
-            var currentMarker = 0;
+            var currentMarker = StartTime;
             while (currentMarker <= duration)
             {
                 // Add time marker
-                var timeMarker = this.GetCurrentSlide().Shapes.AddShape(Microsoft.Office.Core.MsoAutoShapeType.msoShapeRectangle,
-                    (timerLeft + (currentMarker * widthPerSec)) - (timeMarkerWidth / 2), timerTop + timerHeight, timeMarkerWidth, timeMarkerHeight);
+                var timeMarker = this.GetCurrentSlide().Shapes.AddShape(
+                    Microsoft.Office.Core.MsoAutoShapeType.msoShapeRectangle,
+                    (timerLeft + (currentMarker * widthPerSec)) - (timeMarkerWidth / 2), timerTop + timerHeight, 
+                    timeMarkerWidth, timeMarkerHeight);
                 timeMarker.Name = "timerTimeMarker";
-                timeMarker.Fill.Transparency = 1;
-                timeMarker.Line.Transparency = 1;
+                timeMarker.Fill.Transparency = TransparencyTranparent;
+                timeMarker.Line.Transparency = TransparencyTranparent;
                 timeMarker.TextFrame.TextRange.Font.Color.RGB = 0;
                 timeMarker.TextFrame.TextRange.Text = currentMarker.ToString();
 
                 // Add line marker if it is not the start or end
-                if (currentMarker != 0 && currentMarker != duration)
+                if (currentMarker != StartTime && currentMarker != duration)
                 {
-                    var lineMarker = this.GetCurrentSlide().Shapes.AddShape(Microsoft.Office.Core.MsoAutoShapeType.msoShapeRectangle, 
+                    var lineMarker = this.GetCurrentSlide().Shapes.AddShape
+                        (Microsoft.Office.Core.MsoAutoShapeType.msoShapeRectangle, 
                         timerLeft + (currentMarker * widthPerSec), timerTop, lineMarkerWidth, timerHeight);
                     lineMarker.Name = "timerLineMarker";
-                    lineMarker.Line.Transparency = 1;
+                    lineMarker.Line.Transparency = TransparencyTranparent;
                 }
 
                 if (currentMarker == duration)
@@ -155,48 +183,51 @@ namespace PowerPointLabs.TimerLab
             }
         }
 
-        private void AddMinutesMarker(int duration, int denomination, float timerWidth, float timerHeight, float timerLeft, float timerTop,
-                                        float lineMarkerWidth, float timeMarkerWidth, float timeMarkerHeight)
+        private void AddMinutesMarker(int duration, int denomination, float timerWidth, float timerHeight, float timerLeft, 
+            float timerTop, float lineMarkerWidth, float timeMarkerWidth, float timeMarkerHeight)
         {
             float widthPerSec = timerWidth / duration;
 
-            var currentMarker = 0;
+            var currentMarker = StartTime;
             while (currentMarker <= duration)
             {
                 // Add time markers for start, end and every minute
-                if (currentMarker % 60 == 0 || currentMarker == duration)
+                if (currentMarker % SecondsInMinute == 0 || currentMarker == duration)
                 {
-                    var timeMarker = this.GetCurrentSlide().Shapes.AddShape(Microsoft.Office.Core.MsoAutoShapeType.msoShapeRectangle, 
-                        (timerLeft + (currentMarker * widthPerSec)) - (timeMarkerWidth / 2), timerTop + timerHeight, timeMarkerWidth, timeMarkerHeight);
+                    var timeMarker = this.GetCurrentSlide().Shapes.AddShape(
+                        Microsoft.Office.Core.MsoAutoShapeType.msoShapeRectangle, 
+                        (timerLeft + (currentMarker * widthPerSec)) - (timeMarkerWidth / 2), timerTop + timerHeight, 
+                        timeMarkerWidth, timeMarkerHeight);
                     timeMarker.Name = "timerTimeMarker";
-                    timeMarker.Fill.Transparency = 1;
-                    timeMarker.Line.Transparency = 1;
+                    timeMarker.Fill.Transparency = TransparencyTranparent;
+                    timeMarker.Line.Transparency = TransparencyTranparent;
                     timeMarker.TextFrame.TextRange.Font.Color.RGB = 0;
 
-                    int remainingSeconds = currentMarker % 60;
+                    int remainingSeconds = currentMarker % SecondsInMinute;
                     if (currentMarker == duration && remainingSeconds != 0)
                     {
-                        timeMarker.TextFrame.TextRange.Text = (currentMarker / 60).ToString() + ":" + remainingSeconds.ToString();
+                        timeMarker.TextFrame.TextRange.Text = (currentMarker / SecondsInMinute).ToString() + ":" + remainingSeconds.ToString();
                     }
                     else
                     {
-                        timeMarker.TextFrame.TextRange.Text = (currentMarker / 60).ToString();
+                        timeMarker.TextFrame.TextRange.Text = (currentMarker / SecondsInMinute).ToString();
                     }
                 }
 
                 // Add line marker if it is not the start or end
-                if (currentMarker != 0 && currentMarker != duration)
+                if (currentMarker != StartTime && currentMarker != duration)
                 {
                     //Thicken the line if it is a minute marker
-                    if (currentMarker % 60 == 0)
+                    if (currentMarker % SecondsInMinute == 0)
                     {
-                        lineMarkerWidth = 4;
+                        lineMarkerWidth = DefaultMinutesLineMarkerWidth;
                     }
-                    var lineMarker = this.GetCurrentSlide().Shapes.AddShape(Microsoft.Office.Core.MsoAutoShapeType.msoShapeRectangle, 
+                    var lineMarker = this.GetCurrentSlide().Shapes.AddShape(
+                        Microsoft.Office.Core.MsoAutoShapeType.msoShapeRectangle, 
                         timerLeft + (currentMarker * widthPerSec), timerTop, lineMarkerWidth, timerHeight);
                     lineMarker.Name = "timerLineMarker";
-                    lineMarker.Line.Transparency = 1;
-                    lineMarkerWidth = 1;
+                    lineMarker.Line.Transparency = TransparencyTranparent;
+                    lineMarkerWidth = DefaultSecondsLineMarkerWidth;
                 }
 
                 if (currentMarker == duration)
@@ -212,7 +243,8 @@ namespace PowerPointLabs.TimerLab
             }
         }
 
-        private void AddSliderMotionEffect(PowerPoint.Shape shape, int duration, float timerWidth, float slideWidth, PowerPoint.MsoAnimTriggerType trigger)
+        private void AddSliderMotionEffect(PowerPoint.Shape shape, int duration, float timerWidth, float slideWidth, 
+            PowerPoint.MsoAnimTriggerType trigger)
         {
             PowerPoint.Effect sliderMotionEffect = this.GetCurrentSlide().TimeLine.MainSequence.AddEffect(shape,
                 PowerPoint.MsoAnimEffect.msoAnimEffectPathRight, PowerPoint.MsoAnimateByLevel.msoAnimateLevelNone, trigger);
@@ -229,11 +261,12 @@ namespace PowerPointLabs.TimerLab
             PowerPoint.Effect sliderEndEffect = this.GetCurrentSlide().TimeLine.MainSequence.AddEffect(shape,
                 PowerPoint.MsoAnimEffect.msoAnimEffectDarken, PowerPoint.MsoAnimateByLevel.msoAnimateLevelNone,
                 PowerPoint.MsoAnimTriggerType.msoAnimTriggerAfterPrevious);
-            sliderEndEffect.Timing.Duration = 0.001f;
+            sliderEndEffect.Timing.Duration = ColorChangeDuration;
         }
 
         # region NumericUpDown Control Customisation
-        private void DurationTextBox_ValueDecremented(object sender, MahApps.Metro.Controls.NumericUpDownChangedRoutedEventArgs args)
+        private void DurationTextBox_ValueDecremented(object sender, 
+            MahApps.Metro.Controls.NumericUpDownChangedRoutedEventArgs args)
         {
             if (DurationTextBox.Value == null)
             {
@@ -244,13 +277,14 @@ namespace PowerPointLabs.TimerLab
             int integerPart = (int)value;
             double fractionalPart = value - integerPart;
 
-            if (Math.Round(fractionalPart, 2) == 0.00)
+            if (Math.Round(fractionalPart, 2) == FractionalDecrementLowerBound)
             {
-                DurationTextBox.Value = (integerPart - 1) + 0.6;
+                DurationTextBox.Value = (integerPart - 1) + FractionalDecrementOffset;
             }
         }
 
-        private void DurationTextBox_ValueIncremented(object sender, MahApps.Metro.Controls.NumericUpDownChangedRoutedEventArgs args)
+        private void DurationTextBox_ValueIncremented(object sender, 
+            MahApps.Metro.Controls.NumericUpDownChangedRoutedEventArgs args)
         {
             if (DurationTextBox.Value == null)
             {
@@ -261,10 +295,9 @@ namespace PowerPointLabs.TimerLab
             int integerPart = (int)value;
             double fractionalPart = value - integerPart;
 
-            if (Math.Round(fractionalPart, 2) == 0.59)
+            if (Math.Round(fractionalPart, 2) == FractionalIncrementUpperBound)
             {
-                //0.99 because it will get incremented by 0.01 afterwards.
-                DurationTextBox.Value = integerPart + 0.99;
+                DurationTextBox.Value = integerPart + FractionalIncrementOffset;
             }
         }
 
@@ -279,7 +312,7 @@ namespace PowerPointLabs.TimerLab
             int integerPart = (int)value;
             double fractionalPart = value - integerPart;
 
-            if (Math.Round(fractionalPart, 2) > 0.59)
+            if (Math.Round(fractionalPart, 2) > FractionalIncrementUpperBound)
             {
                 DurationTextBox.Value = integerPart + 1;
             }

--- a/PowerPointLabs/PowerPointLabs/TimerLab/TimerLabPaneWPF.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/TimerLab/TimerLabPaneWPF.xaml.cs
@@ -1,4 +1,5 @@
-﻿using System.Windows;
+﻿using System;
+using System.Windows;
 using System.Windows.Controls;
 using PowerPointLabs.ActionFramework.Common.Extension;
 using PowerPoint = Microsoft.Office.Interop.PowerPoint;
@@ -15,73 +16,275 @@ namespace PowerPointLabs.TimerLab
             InitializeComponent();
         }
 
-        private void BlocksTimer_Click(object sender, RoutedEventArgs e)
+        private void CreateButton_Click(object sender, RoutedEventArgs e)
         {
-            // slide dimensions
-            var slideWidth = this.GetCurrentPresentation().SlideWidth;
-            var slideHeight = this.GetCurrentPresentation().SlideHeight;
+            // Slide dimensions
+            float slideWidth = this.GetCurrentPresentation().SlideWidth;
+            float slideHeight = this.GetCurrentPresentation().SlideHeight;
 
-            // timer specifications
-            var time = 60;
-            var timerWidth = 600;
-            var timerHeight = 50;
-            var lineIndicatorWidth = 1;
-            var timeIndicatorWidth = 50;
-            var timeIndicatorHeight = 50;
-            var denomination = 10;
+            // Functionality
+            int duration = Duration();
+            int denomination = 10;
 
-            var timerStartX = (slideWidth - timerWidth) / 2;
-            var timerStartY = (slideHeight - timerHeight) / 2;
-            var widthPerSec = timerWidth / time;
+            // Aesthetics
+            // Main
+            float timerWidth = TimerWidth();
+            float timerHeight = TimerHeight();
+            int timerBodyColor = System.Drawing.Color.FromArgb(106, 84, 68).ToArgb();
+            // Markers
+            float lineMarkerWidth = 2;
+            float timeMarkerWidth = 50;
+            float timeMarkerHeight = 50;
+            // Slider
+            var sliderHeadSize = 20;
+            var sliderBodyWidth = 4;
+            int sliderColor = System.Drawing.Color.FromArgb(70, 150, 247).ToArgb();
 
-            var timerBody = this.GetCurrentSlide().Shapes.AddShape(Microsoft.Office.Core.MsoAutoShapeType.msoShapeRectangle, timerStartX, timerStartY, timerWidth, timerHeight);
-            timerBody.Fill.ForeColor.RGB = System.Drawing.Color.FromArgb(106, 84, 68).ToArgb();
-            timerBody.Line.ForeColor.RGB = System.Drawing.Color.FromArgb(106, 84, 68).ToArgb();
+            // Position
+            float timerLeft = (slideWidth - timerWidth) / 2;
+            float timerTop = (slideHeight - timerHeight) / 2;         
+
+            // Create timer
+            var timerBody = this.GetCurrentSlide().Shapes.AddShape(Microsoft.Office.Core.MsoAutoShapeType.msoShapeRectangle, timerLeft, timerTop, timerWidth, timerHeight);
             timerBody.Name = "timerBody";
-
-            var curIndicator = 0;
-            while (curIndicator <= time)
+            timerBody.Fill.ForeColor.RGB = timerBodyColor;
+            timerBody.Line.ForeColor.RGB = timerBodyColor;
+            
+            // Add markers
+            if (duration <= 60)
             {
-                if (curIndicator != 0 && curIndicator != time)
-                {
-                    var lineIndicator = this.GetCurrentSlide().Shapes.AddShape(Microsoft.Office.Core.MsoAutoShapeType.msoShapeRectangle, timerStartX + (curIndicator * widthPerSec), timerStartY, lineIndicatorWidth, timerHeight);
-                    lineIndicator.Name = "lineIndicator";
-                }
-                var timeIndicator = this.GetCurrentSlide().Shapes.AddShape(Microsoft.Office.Core.MsoAutoShapeType.msoShapeRectangle, (timerStartX + (curIndicator * widthPerSec)) - (timeIndicatorWidth / 2), timerStartY + timerHeight, timeIndicatorWidth, timeIndicatorHeight);
-                timeIndicator.Name = "timeIndicator";
-                timeIndicator.TextFrame.TextRange.Text = curIndicator.ToString();
-                timeIndicator.TextFrame.TextRange.Font.Color.RGB = 0;
-                timeIndicator.Fill.Transparency = 1;
-                timeIndicator.Line.Transparency = 1;
-
-                curIndicator += denomination;
+                AddSecondsMarker(duration, denomination, timerWidth, timerHeight, timerLeft, timerTop,
+                    lineMarkerWidth, timeMarkerWidth, timeMarkerHeight);
+            }
+            else
+            {
+                AddMinutesMarker(duration, denomination, timerWidth, timerHeight, timerLeft, timerTop,
+                    lineMarkerWidth, timeMarkerWidth, timeMarkerHeight);
             }
 
-            var sliderHead = this.GetCurrentSlide().Shapes.AddShape(Microsoft.Office.Core.MsoAutoShapeType.msoShapeIsoscelesTriangle, timerStartX - (float)7.5, timerStartY - (float)7.5, 20, 20);
+            // Add slider components
+            var sliderHead = this.GetCurrentSlide().Shapes.AddShape(Microsoft.Office.Core.MsoAutoShapeType.msoShapeIsoscelesTriangle, 
+                timerLeft - (sliderHeadSize / 2), timerTop - (sliderHeadSize / 2), sliderHeadSize, sliderHeadSize);
+            sliderHead.Name = "timerSliderHead";
             sliderHead.Rotation = 180;
-            sliderHead.Fill.ForeColor.RGB = System.Drawing.Color.FromArgb(247, 149, 50).ToArgb();
-            sliderHead.Line.ForeColor.RGB = System.Drawing.Color.FromArgb(247, 149, 50).ToArgb();
-            var slider = this.GetCurrentSlide().Shapes.AddShape(Microsoft.Office.Core.MsoAutoShapeType.msoShapeRectangle, timerStartX, timerStartY, 5, timerHeight);
-            slider.Name = "slider";
-            slider.Fill.ForeColor.RGB = System.Drawing.Color.FromArgb(247, 149, 50).ToArgb();
-            slider.Line.ForeColor.RGB = System.Drawing.Color.FromArgb(247, 149, 50).ToArgb();
-            sliderHead.Select();
-            slider.Select(Microsoft.Office.Core.MsoTriState.msoFalse);
-            PowerPoint.ShapeRange shapeRange = this.GetCurrentSelection().ShapeRange;
-            shapeRange.Group().Select();
+            sliderHead.Fill.ForeColor.RGB = sliderColor;
+            sliderHead.Line.Transparency = 1;
 
-            var sliderIndicator = this.GetCurrentSelection().ShapeRange[1];
-            
-            PowerPoint.Effect sliderMotionEffect = this.GetCurrentSlide().TimeLine.MainSequence.AddEffect(sliderIndicator,
-                PowerPoint.MsoAnimEffect.msoAnimEffectPathRight,
-                PowerPoint.MsoAnimateByLevel.msoAnimateLevelNone,
-                PowerPoint.MsoAnimTriggerType.msoAnimTriggerOnPageClick);
+            var sliderBody = this.GetCurrentSlide().Shapes.AddShape(Microsoft.Office.Core.MsoAutoShapeType.msoShapeRectangle, 
+                timerLeft - (sliderBodyWidth / 2), timerTop, sliderBodyWidth, timerHeight);
+            sliderBody.Name = "timerSliderBody";
+            sliderBody.Fill.ForeColor.RGB = sliderColor;
+            sliderBody.Line.Transparency = 1;
+
+            // Add slider animations
+            AddSliderMotionEffect(sliderHead, duration, timerWidth, slideWidth, PowerPoint.MsoAnimTriggerType.msoAnimTriggerOnPageClick);
+            AddSliderMotionEffect(sliderBody, duration, timerWidth, slideWidth, PowerPoint.MsoAnimTriggerType.msoAnimTriggerWithPrevious);
+            AddSliderEndEffect(sliderHead, PowerPoint.MsoAnimTriggerType.msoAnimTriggerAfterPrevious);
+            AddSliderEndEffect(sliderBody, PowerPoint.MsoAnimTriggerType.msoAnimTriggerWithPrevious);
+        }
+
+        private int Duration()
+        {
+            int duration = 60; // default value
+            if (DurationTextBox.Value != null)
+            {
+                double value = Math.Round(DurationTextBox.Value.Value, 2);
+                int minutes = (int)value;
+                int seconds = (int)((value - minutes) * 100);
+                duration = (minutes * 60) + seconds;
+            }
+            return duration;
+        }
+
+        private float TimerWidth()
+        {
+            float width = 500; // default value
+            if (!string.IsNullOrEmpty(WidthTextBox.Text))
+            {
+                width = float.Parse(WidthTextBox.Text);
+            }
+            return width;
+        }
+
+        private float TimerHeight()
+        {
+            float height = 50; // default value
+            if (!string.IsNullOrEmpty(HeightTextBox.Text))
+            {
+                height = float.Parse(HeightTextBox.Text);
+            }
+            return height;
+        }
+
+        private void AddSecondsMarker(int duration, int denomination, float timerWidth, float timerHeight, float timerLeft, float timerTop, 
+            float lineMarkerWidth, float timeMarkerWidth, float timeMarkerHeight)
+        {
+            float widthPerSec = timerWidth / duration;
+
+            var currentMarker = 0;
+            while (currentMarker <= duration)
+            {
+                // Add time marker
+                var timeMarker = this.GetCurrentSlide().Shapes.AddShape(Microsoft.Office.Core.MsoAutoShapeType.msoShapeRectangle,
+                    (timerLeft + (currentMarker * widthPerSec)) - (timeMarkerWidth / 2), timerTop + timerHeight, timeMarkerWidth, timeMarkerHeight);
+                timeMarker.Name = "timerTimeMarker";
+                timeMarker.Fill.Transparency = 1;
+                timeMarker.Line.Transparency = 1;
+                timeMarker.TextFrame.TextRange.Font.Color.RGB = 0;
+                timeMarker.TextFrame.TextRange.Text = currentMarker.ToString();
+
+                // Add line marker if it is not the start or end
+                if (currentMarker != 0 && currentMarker != duration)
+                {
+                    var lineMarker = this.GetCurrentSlide().Shapes.AddShape(Microsoft.Office.Core.MsoAutoShapeType.msoShapeRectangle, 
+                        timerLeft + (currentMarker * widthPerSec), timerTop, lineMarkerWidth, timerHeight);
+                    lineMarker.Name = "timerLineMarker";
+                    lineMarker.Line.Transparency = 1;
+                }
+
+                if (currentMarker == duration)
+                {
+                    break;
+                }
+
+                currentMarker += denomination;
+                if (currentMarker > duration)
+                {
+                    currentMarker = duration;
+                }
+            }
+        }
+
+        private void AddMinutesMarker(int duration, int denomination, float timerWidth, float timerHeight, float timerLeft, float timerTop,
+                                        float lineMarkerWidth, float timeMarkerWidth, float timeMarkerHeight)
+        {
+            float widthPerSec = timerWidth / duration;
+
+            var currentMarker = 0;
+            while (currentMarker <= duration)
+            {
+                // Add time markers for start, end and every minute
+                if (currentMarker % 60 == 0 || currentMarker == duration)
+                {
+                    var timeMarker = this.GetCurrentSlide().Shapes.AddShape(Microsoft.Office.Core.MsoAutoShapeType.msoShapeRectangle, 
+                        (timerLeft + (currentMarker * widthPerSec)) - (timeMarkerWidth / 2), timerTop + timerHeight, timeMarkerWidth, timeMarkerHeight);
+                    timeMarker.Name = "timerTimeMarker";
+                    timeMarker.Fill.Transparency = 1;
+                    timeMarker.Line.Transparency = 1;
+                    timeMarker.TextFrame.TextRange.Font.Color.RGB = 0;
+
+                    int remainingSeconds = currentMarker % 60;
+                    if (currentMarker == duration && remainingSeconds != 0)
+                    {
+                        timeMarker.TextFrame.TextRange.Text = (currentMarker / 60).ToString() + ":" + remainingSeconds.ToString();
+                    }
+                    else
+                    {
+                        timeMarker.TextFrame.TextRange.Text = (currentMarker / 60).ToString();
+                    }
+                }
+
+                // Add line marker if it is not the start or end
+                if (currentMarker != 0 && currentMarker != duration)
+                {
+                    //Thicken the line if it is a minute marker
+                    if (currentMarker % 60 == 0)
+                    {
+                        lineMarkerWidth = 4;
+                    }
+                    var lineMarker = this.GetCurrentSlide().Shapes.AddShape(Microsoft.Office.Core.MsoAutoShapeType.msoShapeRectangle, 
+                        timerLeft + (currentMarker * widthPerSec), timerTop, lineMarkerWidth, timerHeight);
+                    lineMarker.Name = "timerLineMarker";
+                    lineMarker.Line.Transparency = 1;
+                    lineMarkerWidth = 1;
+                }
+
+                if (currentMarker == duration)
+                {
+                    break;
+                }
+
+                currentMarker += denomination;
+                if (currentMarker > duration)
+                {
+                    currentMarker = duration;
+                }
+            }
+        }
+
+        private void AddSliderMotionEffect(PowerPoint.Shape shape, int duration, float timerWidth, float slideWidth, PowerPoint.MsoAnimTriggerType trigger)
+        {
+            PowerPoint.Effect sliderMotionEffect = this.GetCurrentSlide().TimeLine.MainSequence.AddEffect(shape,
+                PowerPoint.MsoAnimEffect.msoAnimEffectPathRight, PowerPoint.MsoAnimateByLevel.msoAnimateLevelNone, trigger);
             PowerPoint.AnimationBehavior motion = sliderMotionEffect.Behaviors[1];
             float end = timerWidth / slideWidth;
             motion.MotionEffect.Path = "M 0 0 L " + end + " 0 E";
-            sliderMotionEffect.Timing.Duration = time;
+            sliderMotionEffect.Timing.Duration = duration;
             sliderMotionEffect.Timing.SmoothStart = Microsoft.Office.Core.MsoTriState.msoFalse;
             sliderMotionEffect.Timing.SmoothEnd = Microsoft.Office.Core.MsoTriState.msoFalse;
         }
+
+        private void AddSliderEndEffect(PowerPoint.Shape shape, PowerPoint.MsoAnimTriggerType trigger)
+        {
+            PowerPoint.Effect sliderEndEffect = this.GetCurrentSlide().TimeLine.MainSequence.AddEffect(shape,
+                PowerPoint.MsoAnimEffect.msoAnimEffectDarken, PowerPoint.MsoAnimateByLevel.msoAnimateLevelNone,
+                PowerPoint.MsoAnimTriggerType.msoAnimTriggerAfterPrevious);
+            sliderEndEffect.Timing.Duration = 0.001f;
+        }
+
+        # region NumericUpDown Control Customisation
+        private void DurationTextBox_ValueDecremented(object sender, MahApps.Metro.Controls.NumericUpDownChangedRoutedEventArgs args)
+        {
+            if (DurationTextBox.Value == null)
+            {
+                return;
+            }
+
+            double value = Math.Round(DurationTextBox.Value.Value, 2);
+            int integerPart = (int)value;
+            double fractionalPart = value - integerPart;
+
+            if (Math.Round(fractionalPart, 2) == 0.00)
+            {
+                DurationTextBox.Value = (integerPart - 1) + 0.6;
+            }
+        }
+
+        private void DurationTextBox_ValueIncremented(object sender, MahApps.Metro.Controls.NumericUpDownChangedRoutedEventArgs args)
+        {
+            if (DurationTextBox.Value == null)
+            {
+                return;
+            }
+
+            double value = Math.Round(DurationTextBox.Value.Value, 2);
+            int integerPart = (int)value;
+            double fractionalPart = value - integerPart;
+
+            if (Math.Round(fractionalPart, 2) == 0.59)
+            {
+                //0.99 because it will get incremented by 0.01 afterwards.
+                DurationTextBox.Value = integerPart + 0.99;
+            }
+        }
+
+        private void DurationTextBox_LostFocus(object sender, RoutedEventArgs e)
+        {
+            if (DurationTextBox.Value == null)
+            {
+                return;
+            }
+
+            double value = Math.Round(DurationTextBox.Value.Value, 2);
+            int integerPart = (int)value;
+            double fractionalPart = value - integerPart;
+
+            if (Math.Round(fractionalPart, 2) > 0.59)
+            {
+                DurationTextBox.Value = integerPart + 1;
+            }
+        }
+
+        #endregion
     }
 }

--- a/PowerPointLabs/PowerPointLabs/TimerLab/TimerLabPaneWPF.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/TimerLab/TimerLabPaneWPF.xaml.cs
@@ -10,28 +10,7 @@ namespace PowerPointLabs.TimerLab
     /// Interaction logic for TimerLabPaneWPF.xaml
     /// </summary>
     public partial class TimerLabPaneWPF : UserControl
-    {
-        public const int DefaultDenomination = 10;
-        public const float DefaultTimerWidth = 500;
-        public const float DefaultTimerHeight = 50;
-        public const float DefaultMinutesLineMarkerWidth = 4;
-        public const float DefaultSecondsLineMarkerWidth = 2;
-        public const float DefaultTimeMarkerHeight = 50;
-        public const float DefaultTimeMarkerWidth = 50;
-        public const float DefaultSliderBodyWidth = 4;
-        public const float DefaultSliderHeadSize = 20;
-
-        public const int TransparencyTranparent = 1;
-        public const int Rotate180Degrees = 180;
-        public const float ColorChangeDuration = 0.001f;
-
-        public const int SecondsInMinute = 60;
-        public const int StartTime = 0;
-        public const double FractionalDecrementOffset = 0.60;
-        public const double FractionalDecrementLowerBound = 0.00;
-        public const double FractionalIncrementOffset = 0.99;
-        public const double FractionalIncrementUpperBound = 0.59;
-
+    {    
         public TimerLabPaneWPF()
         {
             InitializeComponent();
@@ -45,7 +24,7 @@ namespace PowerPointLabs.TimerLab
 
             // Functionality
             int duration = Duration();
-            int denomination = DefaultDenomination;
+            int denomination = TimerLabConstants.DefaultDenomination;
 
             // Aesthetics
             // Main
@@ -53,12 +32,12 @@ namespace PowerPointLabs.TimerLab
             float timerHeight = TimerHeight();
             int timerBodyColor = System.Drawing.Color.FromArgb(106, 84, 68).ToArgb();
             // Markers
-            float lineMarkerWidth = DefaultSecondsLineMarkerWidth;
-            float timeMarkerWidth = DefaultTimeMarkerWidth;
-            float timeMarkerHeight = DefaultTimeMarkerHeight;
+            float lineMarkerWidth = TimerLabConstants.DefaultSecondsLineMarkerWidth;
+            float timeMarkerWidth = TimerLabConstants.DefaultTimeMarkerWidth;
+            float timeMarkerHeight = TimerLabConstants.DefaultTimeMarkerHeight;
             // Slider
-            var sliderHeadSize = DefaultSliderHeadSize;
-            var sliderBodyWidth = DefaultSliderBodyWidth;
+            var sliderHeadSize = TimerLabConstants.DefaultSliderHeadSize;
+            var sliderBodyWidth = TimerLabConstants.DefaultSliderBodyWidth;
             int sliderColor = System.Drawing.Color.FromArgb(70, 150, 247).ToArgb();
 
             // Position
@@ -73,7 +52,7 @@ namespace PowerPointLabs.TimerLab
             timerBody.Line.ForeColor.RGB = timerBodyColor;
             
             // Add markers
-            if (duration <= SecondsInMinute)
+            if (duration <= TimerLabConstants.SecondsInMinute)
             {
                 AddSecondsMarker(duration, denomination, timerWidth, timerHeight, timerLeft, timerTop,
                     lineMarkerWidth, timeMarkerWidth, timeMarkerHeight);
@@ -89,15 +68,15 @@ namespace PowerPointLabs.TimerLab
                 Microsoft.Office.Core.MsoAutoShapeType.msoShapeIsoscelesTriangle, 
                 timerLeft - (sliderHeadSize / 2), timerTop - (sliderHeadSize / 2), sliderHeadSize, sliderHeadSize);
             sliderHead.Name = "timerSliderHead";
-            sliderHead.Rotation = Rotate180Degrees;
+            sliderHead.Rotation = TimerLabConstants.Rotate180Degrees;
             sliderHead.Fill.ForeColor.RGB = sliderColor;
-            sliderHead.Line.Transparency = TransparencyTranparent;
+            sliderHead.Line.Transparency = TimerLabConstants.TransparencyTranparent;
 
             var sliderBody = this.GetCurrentSlide().Shapes.AddShape(Microsoft.Office.Core.MsoAutoShapeType.msoShapeRectangle, 
                 timerLeft - (sliderBodyWidth / 2), timerTop, sliderBodyWidth, timerHeight);
             sliderBody.Name = "timerSliderBody";
             sliderBody.Fill.ForeColor.RGB = sliderColor;
-            sliderBody.Line.Transparency = TransparencyTranparent;
+            sliderBody.Line.Transparency = TimerLabConstants.TransparencyTranparent;
 
             // Add slider animations
             AddSliderMotionEffect(sliderHead, duration, timerWidth, slideWidth, 
@@ -110,20 +89,20 @@ namespace PowerPointLabs.TimerLab
 
         private int Duration()
         {
-            int duration = SecondsInMinute;
+            int duration = TimerLabConstants.SecondsInMinute;
             if (DurationTextBox.Value != null)
             {
                 double value = Math.Round(DurationTextBox.Value.Value, 2);
                 int minutes = (int)value;
                 int seconds = (int)((value - minutes) * 100);
-                duration = (minutes * SecondsInMinute) + seconds;
+                duration = (minutes * TimerLabConstants.SecondsInMinute) + seconds;
             }
             return duration;
         }
 
         private float TimerWidth()
         {
-            float width = DefaultTimerWidth;
+            float width = TimerLabConstants.DefaultTimerWidth;
             if (!string.IsNullOrEmpty(WidthTextBox.Text))
             {
                 width = float.Parse(WidthTextBox.Text);
@@ -133,7 +112,7 @@ namespace PowerPointLabs.TimerLab
 
         private float TimerHeight()
         {
-            float height = DefaultTimerHeight;
+            float height = TimerLabConstants.DefaultTimerHeight;
             if (!string.IsNullOrEmpty(HeightTextBox.Text))
             {
                 height = float.Parse(HeightTextBox.Text);
@@ -146,7 +125,7 @@ namespace PowerPointLabs.TimerLab
         {
             float widthPerSec = timerWidth / duration;
 
-            var currentMarker = StartTime;
+            var currentMarker = TimerLabConstants.StartTime;
             while (currentMarker <= duration)
             {
                 // Add time marker
@@ -155,19 +134,19 @@ namespace PowerPointLabs.TimerLab
                     (timerLeft + (currentMarker * widthPerSec)) - (timeMarkerWidth / 2), timerTop + timerHeight, 
                     timeMarkerWidth, timeMarkerHeight);
                 timeMarker.Name = "timerTimeMarker";
-                timeMarker.Fill.Transparency = TransparencyTranparent;
-                timeMarker.Line.Transparency = TransparencyTranparent;
+                timeMarker.Fill.Transparency = TimerLabConstants.TransparencyTranparent;
+                timeMarker.Line.Transparency = TimerLabConstants.TransparencyTranparent;
                 timeMarker.TextFrame.TextRange.Font.Color.RGB = 0;
                 timeMarker.TextFrame.TextRange.Text = currentMarker.ToString();
 
                 // Add line marker if it is not the start or end
-                if (currentMarker != StartTime && currentMarker != duration)
+                if (currentMarker != TimerLabConstants.StartTime && currentMarker != duration)
                 {
                     var lineMarker = this.GetCurrentSlide().Shapes.AddShape
                         (Microsoft.Office.Core.MsoAutoShapeType.msoShapeRectangle, 
                         timerLeft + (currentMarker * widthPerSec), timerTop, lineMarkerWidth, timerHeight);
                     lineMarker.Name = "timerLineMarker";
-                    lineMarker.Line.Transparency = TransparencyTranparent;
+                    lineMarker.Line.Transparency = TimerLabConstants.TransparencyTranparent;
                 }
 
                 if (currentMarker == duration)
@@ -188,46 +167,47 @@ namespace PowerPointLabs.TimerLab
         {
             float widthPerSec = timerWidth / duration;
 
-            var currentMarker = StartTime;
+            var currentMarker = TimerLabConstants.StartTime;
             while (currentMarker <= duration)
             {
                 // Add time markers for start, end and every minute
-                if (currentMarker % SecondsInMinute == 0 || currentMarker == duration)
+                if (currentMarker % TimerLabConstants.SecondsInMinute == 0 || currentMarker == duration)
                 {
                     var timeMarker = this.GetCurrentSlide().Shapes.AddShape(
                         Microsoft.Office.Core.MsoAutoShapeType.msoShapeRectangle, 
                         (timerLeft + (currentMarker * widthPerSec)) - (timeMarkerWidth / 2), timerTop + timerHeight, 
                         timeMarkerWidth, timeMarkerHeight);
                     timeMarker.Name = "timerTimeMarker";
-                    timeMarker.Fill.Transparency = TransparencyTranparent;
-                    timeMarker.Line.Transparency = TransparencyTranparent;
+                    timeMarker.Fill.Transparency = TimerLabConstants.TransparencyTranparent;
+                    timeMarker.Line.Transparency = TimerLabConstants.TransparencyTranparent;
                     timeMarker.TextFrame.TextRange.Font.Color.RGB = 0;
 
-                    int remainingSeconds = currentMarker % SecondsInMinute;
+                    int remainingSeconds = currentMarker % TimerLabConstants.SecondsInMinute;
                     if (currentMarker == duration && remainingSeconds != 0)
                     {
-                        timeMarker.TextFrame.TextRange.Text = (currentMarker / SecondsInMinute).ToString() + ":" + remainingSeconds.ToString();
+                        timeMarker.TextFrame.TextRange.Text = (currentMarker / TimerLabConstants.SecondsInMinute).ToString() + ":"
+                            + remainingSeconds.ToString();
                     }
                     else
                     {
-                        timeMarker.TextFrame.TextRange.Text = (currentMarker / SecondsInMinute).ToString();
+                        timeMarker.TextFrame.TextRange.Text = (currentMarker / TimerLabConstants.SecondsInMinute).ToString();
                     }
                 }
 
                 // Add line marker if it is not the start or end
-                if (currentMarker != StartTime && currentMarker != duration)
+                if (currentMarker != TimerLabConstants.StartTime && currentMarker != duration)
                 {
                     //Thicken the line if it is a minute marker
-                    if (currentMarker % SecondsInMinute == 0)
+                    if (currentMarker % TimerLabConstants.SecondsInMinute == 0)
                     {
-                        lineMarkerWidth = DefaultMinutesLineMarkerWidth;
+                        lineMarkerWidth = TimerLabConstants.DefaultMinutesLineMarkerWidth;
                     }
                     var lineMarker = this.GetCurrentSlide().Shapes.AddShape(
                         Microsoft.Office.Core.MsoAutoShapeType.msoShapeRectangle, 
                         timerLeft + (currentMarker * widthPerSec), timerTop, lineMarkerWidth, timerHeight);
                     lineMarker.Name = "timerLineMarker";
-                    lineMarker.Line.Transparency = TransparencyTranparent;
-                    lineMarkerWidth = DefaultSecondsLineMarkerWidth;
+                    lineMarker.Line.Transparency = TimerLabConstants.TransparencyTranparent;
+                    lineMarkerWidth = TimerLabConstants.DefaultSecondsLineMarkerWidth;
                 }
 
                 if (currentMarker == duration)
@@ -261,7 +241,7 @@ namespace PowerPointLabs.TimerLab
             PowerPoint.Effect sliderEndEffect = this.GetCurrentSlide().TimeLine.MainSequence.AddEffect(shape,
                 PowerPoint.MsoAnimEffect.msoAnimEffectDarken, PowerPoint.MsoAnimateByLevel.msoAnimateLevelNone,
                 PowerPoint.MsoAnimTriggerType.msoAnimTriggerAfterPrevious);
-            sliderEndEffect.Timing.Duration = ColorChangeDuration;
+            sliderEndEffect.Timing.Duration = TimerLabConstants.ColorChangeDuration;
         }
 
         # region NumericUpDown Control Customisation
@@ -270,16 +250,16 @@ namespace PowerPointLabs.TimerLab
         {
             if (DurationTextBox.Value == null)
             {
-                return;
+                DurationTextBox.Value = TimerLabConstants.DefaultDisplayDuration;
             }
 
             double value = Math.Round(DurationTextBox.Value.Value, 2);
             int integerPart = (int)value;
             double fractionalPart = value - integerPart;
 
-            if (Math.Round(fractionalPart, 2) == FractionalDecrementLowerBound)
+            if (Math.Round(fractionalPart, 2) == TimerLabConstants.FractionalDecrementLowerBound)
             {
-                DurationTextBox.Value = (integerPart - 1) + FractionalDecrementOffset;
+                DurationTextBox.Value = (integerPart - 1) + TimerLabConstants.FractionalDecrementOffset;
             }
         }
 
@@ -288,16 +268,16 @@ namespace PowerPointLabs.TimerLab
         {
             if (DurationTextBox.Value == null)
             {
-                return;
+                DurationTextBox.Value = TimerLabConstants.DefaultDisplayDuration;
             }
 
             double value = Math.Round(DurationTextBox.Value.Value, 2);
             int integerPart = (int)value;
             double fractionalPart = value - integerPart;
 
-            if (Math.Round(fractionalPart, 2) == FractionalIncrementUpperBound)
+            if (Math.Round(fractionalPart, 2) == TimerLabConstants.FractionalIncrementUpperBound)
             {
-                DurationTextBox.Value = integerPart + FractionalIncrementOffset;
+                DurationTextBox.Value = integerPart + TimerLabConstants.FractionalIncrementOffset;
             }
         }
 
@@ -312,7 +292,7 @@ namespace PowerPointLabs.TimerLab
             int integerPart = (int)value;
             double fractionalPart = value - integerPart;
 
-            if (Math.Round(fractionalPart, 2) > FractionalIncrementUpperBound)
+            if (Math.Round(fractionalPart, 2) > TimerLabConstants.FractionalIncrementUpperBound)
             {
                 DurationTextBox.Value = integerPart + 1;
             }


### PR DESCRIPTION
Fixes #1199 

Changes:
1. Edited task pane to take in values on duration, width and height.
![propertiespanel](https://cloud.githubusercontent.com/assets/12497234/23955959/55f49912-09d6-11e7-85dd-df8b76f20678.png)

2. Duration under a minute will have every ten seconds marked and labeled. Duration over a minute will have seconds marked and minutes marked and labeled.
Under a minute:
![secondstimer](https://cloud.githubusercontent.com/assets/12497234/23955983/6d48103a-09d6-11e7-80f5-0e84b5f058ae.png)

Over a minute:
![minutestimer](https://cloud.githubusercontent.com/assets/12497234/23955982/6c073854-09d6-11e7-9cc1-1081626797ad.png)

Minor fixes:
1. Fixed slider to stop as slider's center hits the end of timer.
2. Slider color will now change to indicate time's up.


