### PR TITLE
Context menu: empty menu item #1178

### DIFF
--- a/PowerPointLabs/PowerPointLabs/ActionFramework/Action/AddShapeActionHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/Action/AddShapeActionHandler.cs
@@ -6,7 +6,7 @@ using PowerPointLabs.ActionFramework.Common.Interface;
 
 namespace PowerPointLabs.ActionFramework.Action
 {
-    [ExportActionRibbonId("AddCustomShape")]
+    [ExportActionRibbonId("AddCustomShape", "addCustomShapePictureGroup")]
     class AddShapeActionHandler : ShapesLabActionHandler
     {
         protected override void ExecuteAction(string ribbonId)

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/Image/AddShapeImageHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/Image/AddShapeImageHandler.cs
@@ -4,7 +4,7 @@ using PowerPointLabs.ActionFramework.Common.Interface;
 
 namespace PowerPointLabs.ActionFramework.Image
 {
-    [ExportImageRibbonId("AddCustomShape")]
+    [ExportImageRibbonId("AddCustomShape", "addCustomShapePictureGroup")]
     class AddShapeImageHandler : ImageHandler
     {
         protected override Bitmap GetImage(string ribbonId)

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/Label/AddShapeLabelHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/Label/AddShapeLabelHandler.cs
@@ -3,7 +3,7 @@ using PowerPointLabs.ActionFramework.Common.Interface;
 
 namespace PowerPointLabs.ActionFramework.Label
 {
-    [ExportLabelRibbonId("AddCustomShape")]
+    [ExportLabelRibbonId("AddCustomShape", "addCustomShapePictureGroup")]
     class AddShapeLabelHandler : LabelHandler
     {
         protected override string GetLabel(string ribbonId)

--- a/PowerPointLabs/PowerPointLabs/Ribbon1.xml
+++ b/PowerPointLabs/PowerPointLabs/Ribbon1.xml
@@ -618,9 +618,9 @@
                getImage="GetConvertToPicMenuImage"
                onAction="ConvertToPictureButtonClick"/>
         <button id="addCustomShapePictureGroup"
-               getLabel ="GetAddCustomShapeShapeLabel"
-               getImage="GetAddToCustomShapeContextImage"
-               onAction="AddShapeButtonClick"/>
+               getLabel ="GetLabel"
+               getImage="GetImage"
+               onAction="OnAction"/>
         <button id="cutOutShapeGroup"
                 getLabel="GetCutOutShapeShapeLabel"
                 getImage="GetCutOutShapeMenuImage"


### PR DESCRIPTION
Fixes #1178.

Missing menu item was shapes lab menu item, which was accidentally dropped off when migrating to action framework.

![image](https://cloud.githubusercontent.com/assets/19278089/23983191/96c592da-0a4d-11e7-9f15-64af752d3503.png)
