### PR TITLE
Sync Lab: Add crash-prevention in Copy/Paste #1206

### DIFF
--- a/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/FillFormat.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/FillFormat.cs
@@ -1,4 +1,5 @@
-﻿using System.Drawing;
+﻿using System;
+using System.Drawing;
 
 using Microsoft.Office.Interop.PowerPoint;
 
@@ -10,14 +11,22 @@ namespace PowerPointLabs.SyncLab.ObjectFormats
     {
         public static bool CanCopy(Shape formatShape)
         {
-            return true;
+            return SyncFormat(formatShape, formatShape);
         }
 
-        public static void SyncFormat(Shape formatShape, Shape newShape)
+        public static bool SyncFormat(Shape formatShape, Shape newShape)
         {
-            newShape.Fill.ForeColor = formatShape.Fill.ForeColor;
-            newShape.Fill.BackColor = formatShape.Fill.BackColor;
-            newShape.Fill.Solid();
+            try
+            {
+                newShape.Fill.ForeColor = formatShape.Fill.ForeColor;
+                newShape.Fill.BackColor = formatShape.Fill.BackColor;
+                newShape.Fill.Solid();
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+            return true;
         }
 
         public static Bitmap DisplayImage(Shape formatShape)

--- a/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/FillFormat.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/FillFormat.cs
@@ -17,23 +17,10 @@ namespace PowerPointLabs.SyncLab.ObjectFormats
 
         public static void SyncFormat(Shape formatShape, Shape newShape)
         {
-            Sync(formatShape, newShape);
-        }
-
-        public static bool Sync(Shape formatShape, Shape newShape)
-        {
-            try
-            {
-                newShape.Fill.ForeColor = formatShape.Fill.ForeColor;
-                newShape.Fill.BackColor = formatShape.Fill.BackColor;
-                newShape.Fill.Solid();
-            }
-            catch (Exception)
+            if (!Sync(formatShape, newShape))
             {
                 Logger.Log(newShape.Type + " unable to sync Fill");
-                return false;
             }
-            return true;
         }
 
         public static Bitmap DisplayImage(Shape formatShape)
@@ -48,6 +35,21 @@ namespace PowerPointLabs.SyncLab.ObjectFormats
             Bitmap image = new Bitmap(Graphics.ShapeToImage(shape));
             shape.Delete();
             return image;
+        }
+
+        private static bool Sync(Shape formatShape, Shape newShape)
+        {
+            try
+            {
+                newShape.Fill.ForeColor = formatShape.Fill.ForeColor;
+                newShape.Fill.BackColor = formatShape.Fill.BackColor;
+                newShape.Fill.Solid();
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+            return true;
         }
     }
 }

--- a/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/FillFormat.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/FillFormat.cs
@@ -2,6 +2,7 @@
 using System.Drawing;
 
 using Microsoft.Office.Interop.PowerPoint;
+using PowerPointLabs.ActionFramework.Common.Log;
 
 using Graphics = PowerPointLabs.Utils.Graphics;
 
@@ -11,10 +12,15 @@ namespace PowerPointLabs.SyncLab.ObjectFormats
     {
         public static bool CanCopy(Shape formatShape)
         {
-            return SyncFormat(formatShape, formatShape);
+            return Sync(formatShape, formatShape);
         }
 
-        public static bool SyncFormat(Shape formatShape, Shape newShape)
+        public static void SyncFormat(Shape formatShape, Shape newShape)
+        {
+            Sync(formatShape, newShape);
+        }
+
+        public static bool Sync(Shape formatShape, Shape newShape)
         {
             try
             {
@@ -24,6 +30,7 @@ namespace PowerPointLabs.SyncLab.ObjectFormats
             }
             catch (Exception)
             {
+                Logger.Log(newShape.Type + " unable to sync Fill");
                 return false;
             }
             return true;

--- a/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/FontColorFormat.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/FontColorFormat.cs
@@ -17,21 +17,10 @@ namespace PowerPointLabs.SyncLab.ObjectFormats
 
         public static void SyncFormat(Shape formatShape, Shape newShape)
         {
-            Sync(formatShape, newShape);
-        }
-
-        public static bool Sync(Shape formatShape, Shape newShape)
-        {
-            try
-            {
-                newShape.TextFrame.TextRange.Font.Color.RGB = formatShape.TextFrame.TextRange.Font.Color.RGB;
-            }
-            catch (Exception)
+            if (!Sync(formatShape, newShape))
             {
                 Logger.Log(newShape.Type + " unable to sync Font Color");
-                return false;
             }
-            return true;
         }
 
         public static Bitmap DisplayImage(Shape formatShape)
@@ -48,6 +37,19 @@ namespace PowerPointLabs.SyncLab.ObjectFormats
             Bitmap image = new Bitmap(Graphics.ShapeToImage(shape));
             shape.Delete();
             return image;
+        }
+
+        private static bool Sync(Shape formatShape, Shape newShape)
+        {
+            try
+            {
+                newShape.TextFrame.TextRange.Font.Color.RGB = formatShape.TextFrame.TextRange.Font.Color.RGB;
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+            return true;
         }
     }
 }

--- a/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/FontColorFormat.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/FontColorFormat.cs
@@ -1,4 +1,5 @@
-﻿using System.Drawing;
+﻿using System;
+using System.Drawing;
 
 using Microsoft.Office.Interop.PowerPoint;
 
@@ -10,12 +11,20 @@ namespace PowerPointLabs.SyncLab.ObjectFormats
     {
         public static bool CanCopy(Shape formatShape)
         {
-            return true;
+            return SyncFormat(formatShape, formatShape);
         }
 
-        public static void SyncFormat(Shape formatShape, Shape newShape)
+        public static bool SyncFormat(Shape formatShape, Shape newShape)
         {
-            newShape.TextFrame.TextRange.Font.Color.RGB = formatShape.TextFrame.TextRange.Font.Color.RGB;
+            try
+            {
+                newShape.TextFrame.TextRange.Font.Color.RGB = formatShape.TextFrame.TextRange.Font.Color.RGB;
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+            return true;
         }
 
         public static Bitmap DisplayImage(Shape formatShape)

--- a/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/FontColorFormat.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/FontColorFormat.cs
@@ -2,6 +2,7 @@
 using System.Drawing;
 
 using Microsoft.Office.Interop.PowerPoint;
+using PowerPointLabs.ActionFramework.Common.Log;
 
 using Graphics = PowerPointLabs.Utils.Graphics;
 
@@ -11,10 +12,15 @@ namespace PowerPointLabs.SyncLab.ObjectFormats
     {
         public static bool CanCopy(Shape formatShape)
         {
-            return SyncFormat(formatShape, formatShape);
+            return Sync(formatShape, formatShape);
         }
 
-        public static bool SyncFormat(Shape formatShape, Shape newShape)
+        public static void SyncFormat(Shape formatShape, Shape newShape)
+        {
+            Sync(formatShape, newShape);
+        }
+
+        public static bool Sync(Shape formatShape, Shape newShape)
         {
             try
             {
@@ -22,6 +28,7 @@ namespace PowerPointLabs.SyncLab.ObjectFormats
             }
             catch (Exception)
             {
+                Logger.Log(newShape.Type + " unable to sync Font Color");
                 return false;
             }
             return true;

--- a/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/FontFormat.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/FontFormat.cs
@@ -2,6 +2,7 @@
 using System.Drawing;
 
 using Microsoft.Office.Interop.PowerPoint;
+using PowerPointLabs.ActionFramework.Common.Log;
 
 namespace PowerPointLabs.SyncLab.ObjectFormats
 {
@@ -9,10 +10,15 @@ namespace PowerPointLabs.SyncLab.ObjectFormats
     {
         public static bool CanCopy(Shape formatShape)
         {
-            return SyncFormat(formatShape, formatShape);
+            return Sync(formatShape, formatShape);
         }
 
-        public static bool SyncFormat(Shape formatShape, Shape newShape)
+        public static void SyncFormat(Shape formatShape, Shape newShape)
+        {
+            Sync(formatShape, newShape);
+        }
+
+        public static bool Sync(Shape formatShape, Shape newShape)
         {
             try
             {
@@ -20,6 +26,7 @@ namespace PowerPointLabs.SyncLab.ObjectFormats
             }
             catch (Exception)
             {
+                Logger.Log(newShape.Type + " unable to sync Font Format");
                 return false;
             }
             return true;

--- a/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/FontFormat.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/FontFormat.cs
@@ -1,4 +1,5 @@
-﻿using System.Drawing;
+﻿using System;
+using System.Drawing;
 
 using Microsoft.Office.Interop.PowerPoint;
 
@@ -8,12 +9,20 @@ namespace PowerPointLabs.SyncLab.ObjectFormats
     {
         public static bool CanCopy(Shape formatShape)
         {
-            return true;
+            return SyncFormat(formatShape, formatShape);
         }
 
-        public static void SyncFormat(Shape formatShape, Shape newShape)
+        public static bool SyncFormat(Shape formatShape, Shape newShape)
         {
-            newShape.TextEffect.FontName = formatShape.TextEffect.FontName;
+            try
+            {
+                newShape.TextEffect.FontName = formatShape.TextEffect.FontName;
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+            return true;
         }
 
         public static Bitmap DisplayImage(Shape formatShape)

--- a/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/FontFormat.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/FontFormat.cs
@@ -15,21 +15,10 @@ namespace PowerPointLabs.SyncLab.ObjectFormats
 
         public static void SyncFormat(Shape formatShape, Shape newShape)
         {
-            Sync(formatShape, newShape);
-        }
-
-        public static bool Sync(Shape formatShape, Shape newShape)
-        {
-            try
-            {
-                newShape.TextEffect.FontName = formatShape.TextEffect.FontName;
-            }
-            catch (Exception)
+            if (Sync(formatShape, newShape))
             {
                 Logger.Log(newShape.Type + " unable to sync Font Format");
-                return false;
             }
-            return true;
         }
 
         public static Bitmap DisplayImage(Shape formatShape)
@@ -39,6 +28,19 @@ namespace PowerPointLabs.SyncLab.ObjectFormats
                 new System.Drawing.Font(formatShape.TextEffect.FontName,
                                         SyncFormatConstants.DisplayImageFontSize),
                 SyncFormatConstants.DisplayImageSize);
+        }
+
+        private static bool Sync(Shape formatShape, Shape newShape)
+        {
+            try
+            {
+                newShape.TextEffect.FontName = formatShape.TextEffect.FontName;
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+            return true;
         }
     }
 }

--- a/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/FontSizeFormat.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/FontSizeFormat.cs
@@ -9,12 +9,20 @@ namespace PowerPointLabs.SyncLab.ObjectFormats
     {
         public static bool CanCopy(Shape formatShape)
         {
-            return true;
+            return SyncFormat(formatShape, formatShape);
         }
 
-        public static void SyncFormat(Shape formatShape, Shape newShape)
+        public static bool SyncFormat(Shape formatShape, Shape newShape)
         {
-            newShape.TextEffect.FontSize = formatShape.TextEffect.FontSize;
+            try
+            {
+                newShape.TextEffect.FontSize = formatShape.TextEffect.FontSize;
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+            return true;
         }
 
         public static Bitmap DisplayImage(Shape formatShape)

--- a/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/FontSizeFormat.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/FontSizeFormat.cs
@@ -15,21 +15,10 @@ namespace PowerPointLabs.SyncLab.ObjectFormats
 
         public static void SyncFormat(Shape formatShape, Shape newShape)
         {
-            Sync(formatShape, newShape);
-        }
-
-        public static bool Sync(Shape formatShape, Shape newShape)
-        {
-            try
-            {
-                newShape.TextEffect.FontSize = formatShape.TextEffect.FontSize;
-            }
-            catch (Exception)
+            if (!Sync(formatShape, newShape))
             {
                 Logger.Log(newShape.Type + " unable to sync Font Size");
-                return false;
             }
-            return true;
         }
 
         public static Bitmap DisplayImage(Shape formatShape)
@@ -38,6 +27,19 @@ namespace PowerPointLabs.SyncLab.ObjectFormats
                 Math.Round(formatShape.TextEffect.FontSize).ToString(),
                 SyncFormatConstants.DisplayImageFont,
                 SyncFormatConstants.DisplayImageSize);
+        }
+
+        private static bool Sync(Shape formatShape, Shape newShape)
+        {
+            try
+            {
+                newShape.TextEffect.FontSize = formatShape.TextEffect.FontSize;
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+            return true;
         }
     }
 }

--- a/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/FontSizeFormat.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/FontSizeFormat.cs
@@ -2,6 +2,7 @@
 using System.Drawing;
 
 using Microsoft.Office.Interop.PowerPoint;
+using PowerPointLabs.ActionFramework.Common.Log;
 
 namespace PowerPointLabs.SyncLab.ObjectFormats
 {
@@ -9,10 +10,15 @@ namespace PowerPointLabs.SyncLab.ObjectFormats
     {
         public static bool CanCopy(Shape formatShape)
         {
-            return SyncFormat(formatShape, formatShape);
+            return Sync(formatShape, formatShape);
         }
 
-        public static bool SyncFormat(Shape formatShape, Shape newShape)
+        public static void SyncFormat(Shape formatShape, Shape newShape)
+        {
+            Sync(formatShape, newShape);
+        }
+
+        public static bool Sync(Shape formatShape, Shape newShape)
         {
             try
             {
@@ -20,6 +26,7 @@ namespace PowerPointLabs.SyncLab.ObjectFormats
             }
             catch (Exception)
             {
+                Logger.Log(newShape.Type + " unable to sync Font Size");
                 return false;
             }
             return true;

--- a/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/FontStyleFormat.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/FontStyleFormat.cs
@@ -2,6 +2,7 @@
 using System.Drawing;
 
 using Microsoft.Office.Interop.PowerPoint;
+using PowerPointLabs.ActionFramework.Common.Log;
 
 namespace PowerPointLabs.SyncLab.ObjectFormats
 {
@@ -9,10 +10,15 @@ namespace PowerPointLabs.SyncLab.ObjectFormats
     {
         public static bool CanCopy(Shape formatShape)
         {
-            return SyncFormat(formatShape, formatShape);
+            return Sync(formatShape, formatShape);
         }
 
-        public static bool SyncFormat(Shape formatShape, Shape newShape)
+        public static void SyncFormat(Shape formatShape, Shape newShape)
+        {
+            Sync(formatShape, newShape);
+        }
+
+        public static bool Sync(Shape formatShape, Shape newShape)
         {
             try
             {
@@ -21,6 +27,7 @@ namespace PowerPointLabs.SyncLab.ObjectFormats
             }
             catch (Exception)
             {
+                Logger.Log(newShape.Type + " unable to sync Font Style");
                 return false;
             }
             return true;

--- a/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/FontStyleFormat.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/FontStyleFormat.cs
@@ -1,4 +1,5 @@
-﻿using System.Drawing;
+﻿using System;
+using System.Drawing;
 
 using Microsoft.Office.Interop.PowerPoint;
 
@@ -8,13 +9,21 @@ namespace PowerPointLabs.SyncLab.ObjectFormats
     {
         public static bool CanCopy(Shape formatShape)
         {
-            return true;
+            return SyncFormat(formatShape, formatShape);
         }
 
-        public static void SyncFormat(Shape formatShape, Shape newShape)
+        public static bool SyncFormat(Shape formatShape, Shape newShape)
         {
-            //What is the difference between TextFrame and TextFrame2?
-            SyncTextRange(formatShape.TextFrame.TextRange, newShape.TextFrame.TextRange);
+            try
+            {
+                //What is the difference between TextFrame and TextFrame2?
+                SyncTextRange(formatShape.TextFrame.TextRange, newShape.TextFrame.TextRange);
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+            return true;
         }
 
         public static Bitmap DisplayImage(Shape formatShape)

--- a/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/FontStyleFormat.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/FontStyleFormat.cs
@@ -15,22 +15,10 @@ namespace PowerPointLabs.SyncLab.ObjectFormats
 
         public static void SyncFormat(Shape formatShape, Shape newShape)
         {
-            Sync(formatShape, newShape);
-        }
-
-        public static bool Sync(Shape formatShape, Shape newShape)
-        {
-            try
-            {
-                //What is the difference between TextFrame and TextFrame2?
-                SyncTextRange(formatShape.TextFrame.TextRange, newShape.TextFrame.TextRange);
-            }
-            catch (Exception)
+            if (!Sync(formatShape, newShape))
             {
                 Logger.Log(newShape.Type + " unable to sync Font Style");
-                return false;
             }
-            return true;
         }
 
         public static Bitmap DisplayImage(Shape formatShape)
@@ -52,6 +40,20 @@ namespace PowerPointLabs.SyncLab.ObjectFormats
             }
             font = new System.Drawing.Font(font.FontFamily, font.Size, style);
             return SyncFormatUtil.GetTextDisplay( "T", font, SyncFormatConstants.DisplayImageSize);
+        }
+
+        private static bool Sync(Shape formatShape, Shape newShape)
+        {
+            try
+            {
+                //What is the difference between TextFrame and TextFrame2?
+                SyncTextRange(formatShape.TextFrame.TextRange, newShape.TextFrame.TextRange);
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+            return true;
         }
 
         private static void SyncTextRange(TextRange formatTextRange, TextRange newTextRange)

--- a/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/LineArrowFormat.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/LineArrowFormat.cs
@@ -11,26 +11,26 @@ namespace PowerPointLabs.SyncLab.ObjectFormats
     {
         public static bool CanCopy(Shape formatShape)
         {
+            return SyncFormat(formatShape, formatShape);
+        }
+
+        public static bool SyncFormat(Shape formatShape, Shape newShape)
+        {
             try
             {
-                SyncFormat(formatShape, formatShape);
+                newShape.Line.BeginArrowheadLength = formatShape.Line.BeginArrowheadLength;
+                newShape.Line.BeginArrowheadStyle = formatShape.Line.BeginArrowheadStyle;
+                newShape.Line.BeginArrowheadWidth = formatShape.Line.BeginArrowheadWidth;
+
+                newShape.Line.EndArrowheadLength = formatShape.Line.EndArrowheadLength;
+                newShape.Line.EndArrowheadStyle = formatShape.Line.EndArrowheadStyle;
+                newShape.Line.EndArrowheadWidth = formatShape.Line.EndArrowheadWidth;
             }
             catch (Exception)
             {
                 return false;
             }
             return true;
-        }
-
-        public static void SyncFormat(Shape formatShape, Shape newShape)
-        {
-            newShape.Line.BeginArrowheadLength = formatShape.Line.BeginArrowheadLength;
-            newShape.Line.BeginArrowheadStyle = formatShape.Line.BeginArrowheadStyle;
-            newShape.Line.BeginArrowheadWidth = formatShape.Line.BeginArrowheadWidth;
-
-            newShape.Line.EndArrowheadLength = formatShape.Line.EndArrowheadLength;
-            newShape.Line.EndArrowheadStyle = formatShape.Line.EndArrowheadStyle;
-            newShape.Line.EndArrowheadWidth = formatShape.Line.EndArrowheadWidth;
         }
 
         public static Bitmap DisplayImage(Shape formatShape)

--- a/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/LineArrowFormat.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/LineArrowFormat.cs
@@ -17,10 +17,25 @@ namespace PowerPointLabs.SyncLab.ObjectFormats
 
         public static void SyncFormat(Shape formatShape, Shape newShape)
         {
-            Sync(formatShape, newShape);
+            if (!Sync(formatShape, newShape))
+            {
+                Logger.Log(newShape.Type + " unable to sync Line Arrow");
+            }
         }
 
-        public static bool Sync(Shape formatShape, Shape newShape)
+        public static Bitmap DisplayImage(Shape formatShape)
+        {
+            Shapes shapes = SyncFormatUtil.GetTemplateShapes();
+            Shape shape = shapes.AddLine(
+                0, SyncFormatConstants.DisplayImageSize.Height,
+                SyncFormatConstants.DisplayImageSize.Width, 0);
+            SyncFormat(formatShape, shape);
+            Bitmap image = new Bitmap(Graphics.ShapeToImage(shape));
+            shape.Delete();
+            return image;
+        }
+
+        private static bool Sync(Shape formatShape, Shape newShape)
         {
             try
             {
@@ -34,22 +49,9 @@ namespace PowerPointLabs.SyncLab.ObjectFormats
             }
             catch (Exception)
             {
-                Logger.Log(newShape.Type + " unable to sync Line Arrow");
                 return false;
             }
             return true;
-        }
-
-        public static Bitmap DisplayImage(Shape formatShape)
-        {
-            Shapes shapes = SyncFormatUtil.GetTemplateShapes();
-            Shape shape = shapes.AddLine(
-                0, SyncFormatConstants.DisplayImageSize.Height,
-                SyncFormatConstants.DisplayImageSize.Width, 0);
-            SyncFormat(formatShape, shape);
-            Bitmap image = new Bitmap(Graphics.ShapeToImage(shape));
-            shape.Delete();
-            return image;
         }
     }
 }

--- a/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/LineArrowFormat.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/LineArrowFormat.cs
@@ -2,6 +2,7 @@
 using System.Drawing;
 
 using Microsoft.Office.Interop.PowerPoint;
+using PowerPointLabs.ActionFramework.Common.Log;
 
 using Graphics = PowerPointLabs.Utils.Graphics;
 
@@ -11,10 +12,15 @@ namespace PowerPointLabs.SyncLab.ObjectFormats
     {
         public static bool CanCopy(Shape formatShape)
         {
-            return SyncFormat(formatShape, formatShape);
+            return Sync(formatShape, formatShape);
         }
 
-        public static bool SyncFormat(Shape formatShape, Shape newShape)
+        public static void SyncFormat(Shape formatShape, Shape newShape)
+        {
+            Sync(formatShape, newShape);
+        }
+
+        public static bool Sync(Shape formatShape, Shape newShape)
         {
             try
             {
@@ -28,6 +34,7 @@ namespace PowerPointLabs.SyncLab.ObjectFormats
             }
             catch (Exception)
             {
+                Logger.Log(newShape.Type + " unable to sync Line Arrow");
                 return false;
             }
             return true;

--- a/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/LineFillFormat.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/LineFillFormat.cs
@@ -9,21 +9,21 @@ namespace PowerPointLabs.SyncLab.ObjectFormats
     {
         public static bool CanCopy(Shape formatShape)
         {
+            return SyncFormat(formatShape, formatShape);
+        }
+
+        public static bool SyncFormat(Shape formatShape, Shape newShape)
+        {
             try
             {
-                SyncFormat(formatShape, formatShape);
+                newShape.Line.ForeColor = formatShape.Line.ForeColor;
+                newShape.Line.BackColor = formatShape.Line.BackColor;
             }
             catch (Exception)
             {
                 return false;
             }
             return true;
-        }
-
-        public static void SyncFormat(Shape formatShape, Shape newShape)
-        {
-            newShape.Line.ForeColor = formatShape.Line.ForeColor;
-            newShape.Line.BackColor = formatShape.Line.BackColor;
         }
 
         public static Bitmap DisplayImage(Shape formatShape)

--- a/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/LineFillFormat.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/LineFillFormat.cs
@@ -17,22 +17,10 @@ namespace PowerPointLabs.SyncLab.ObjectFormats
 
         public static void SyncFormat(Shape formatShape, Shape newShape)
         {
-            Sync(formatShape, newShape);
-        }
-
-        public static bool Sync(Shape formatShape, Shape newShape)
-        {
-            try
-            {
-                newShape.Line.ForeColor = formatShape.Line.ForeColor;
-                newShape.Line.BackColor = formatShape.Line.BackColor;
-            }
-            catch (Exception)
+            if (!Sync(formatShape, newShape))
             {
                 Logger.Log(newShape.Type + " unable to sync Line Fill");
-                return false;
             }
-            return true;
         }
 
         public static Bitmap DisplayImage(Shape formatShape)
@@ -47,6 +35,20 @@ namespace PowerPointLabs.SyncLab.ObjectFormats
             Bitmap image = new Bitmap(Graphics.ShapeToImage(shape));
             shape.Delete();
             return image;
+        }
+
+        private static bool Sync(Shape formatShape, Shape newShape)
+        {
+            try
+            {
+                newShape.Line.ForeColor = formatShape.Line.ForeColor;
+                newShape.Line.BackColor = formatShape.Line.BackColor;
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+            return true;
         }
     }
 }

--- a/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/LineFillFormat.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/LineFillFormat.cs
@@ -1,6 +1,9 @@
 ﻿using System;
 using System.Drawing;
+
 using Microsoft.Office.Interop.PowerPoint;
+using PowerPointLabs.ActionFramework.Common.Log;
+
 using Graphics = PowerPointLabs.Utils.Graphics;
 
 namespace PowerPointLabs.SyncLab.ObjectFormats
@@ -9,10 +12,15 @@ namespace PowerPointLabs.SyncLab.ObjectFormats
     {
         public static bool CanCopy(Shape formatShape)
         {
-            return SyncFormat(formatShape, formatShape);
+            return Sync(formatShape, formatShape);
         }
 
-        public static bool SyncFormat(Shape formatShape, Shape newShape)
+        public static void SyncFormat(Shape formatShape, Shape newShape)
+        {
+            Sync(formatShape, newShape);
+        }
+
+        public static bool Sync(Shape formatShape, Shape newShape)
         {
             try
             {
@@ -21,6 +29,7 @@ namespace PowerPointLabs.SyncLab.ObjectFormats
             }
             catch (Exception)
             {
+                Logger.Log(newShape.Type + " unable to sync Line Fill");
                 return false;
             }
             return true;

--- a/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/LineStyleFormat.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/LineStyleFormat.cs
@@ -2,6 +2,7 @@
 using System.Drawing;
 
 using Microsoft.Office.Interop.PowerPoint;
+using PowerPointLabs.ActionFramework.Common.Log;
 
 using Graphics = PowerPointLabs.Utils.Graphics;
 
@@ -11,10 +12,15 @@ namespace PowerPointLabs.SyncLab.ObjectFormats
     {
         public static bool CanCopy(Shape formatShape)
         {
-            return SyncFormat(formatShape, formatShape);
+            return Sync(formatShape, formatShape);
         }
 
-        public static bool SyncFormat(Shape formatShape, Shape newShape)
+        public static void SyncFormat(Shape formatShape, Shape newShape)
+        {
+            Sync(formatShape, newShape);
+        }
+
+        public static bool Sync(Shape formatShape, Shape newShape)
         {
             try
             {
@@ -23,6 +29,7 @@ namespace PowerPointLabs.SyncLab.ObjectFormats
             }
             catch (Exception)
             {
+                Logger.Log(newShape.Type + " unable to sync Line Style");
                 return false;
             }
             return true;

--- a/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/LineStyleFormat.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/LineStyleFormat.cs
@@ -17,22 +17,10 @@ namespace PowerPointLabs.SyncLab.ObjectFormats
 
         public static void SyncFormat(Shape formatShape, Shape newShape)
         {
-            Sync(formatShape, newShape);
-        }
-
-        public static bool Sync(Shape formatShape, Shape newShape)
-        {
-            try
-            {
-                newShape.Line.Style = formatShape.Line.Style;
-                //missing dashstyle?
-            }
-            catch (Exception)
+            if (!Sync(formatShape, newShape))
             {
                 Logger.Log(newShape.Type + " unable to sync Line Style");
-                return false;
             }
-            return true;
         }
 
         public static Bitmap DisplayImage(Shape formatShape)
@@ -45,6 +33,20 @@ namespace PowerPointLabs.SyncLab.ObjectFormats
             Bitmap image = new Bitmap(Graphics.ShapeToImage(shape));
             shape.Delete();
             return image;
+        }
+
+        private static bool Sync(Shape formatShape, Shape newShape)
+        {
+            try
+            {
+                newShape.Line.Style = formatShape.Line.Style;
+                //missing dashstyle?
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+            return true;
         }
     }
 }

--- a/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/LineStyleFormat.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/LineStyleFormat.cs
@@ -11,21 +11,21 @@ namespace PowerPointLabs.SyncLab.ObjectFormats
     {
         public static bool CanCopy(Shape formatShape)
         {
+            return SyncFormat(formatShape, formatShape);
+        }
+
+        public static bool SyncFormat(Shape formatShape, Shape newShape)
+        {
             try
             {
-                SyncFormat(formatShape, formatShape);
+                newShape.Line.Style = formatShape.Line.Style;
+                //missing dashstyle?
             }
             catch (Exception)
             {
                 return false;
             }
             return true;
-        }
-
-        public static void SyncFormat(Shape formatShape, Shape newShape)
-        {
-            newShape.Line.Style = formatShape.Line.Style;
-            //missing dashstyle?
         }
 
         public static Bitmap DisplayImage(Shape formatShape)

--- a/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/LineWeightFormat.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/LineWeightFormat.cs
@@ -15,21 +15,10 @@ namespace PowerPointLabs.SyncLab.ObjectFormats
 
         public static void SyncFormat(Shape formatShape, Shape newShape)
         {
-            Sync(formatShape, newShape);
-        }
-
-        public static bool Sync(Shape formatShape, Shape newShape)
-        {
-            try
-            {
-                newShape.Line.Weight = formatShape.Line.Weight;
-            }
-            catch (Exception)
+            if (!Sync(formatShape, newShape))
             {
                 Logger.Log(newShape.Type + " unable to sync Line Weight");
-                return false;
             }
-            return true;
         }
 
         public static Bitmap DisplayImage(Shape formatShape)
@@ -38,6 +27,19 @@ namespace PowerPointLabs.SyncLab.ObjectFormats
                 Math.Round(Math.Max(formatShape.Line.Weight, 0)).ToString(),
                 SyncFormatConstants.DisplayImageFont,
                 SyncFormatConstants.DisplayImageSize);
+        }
+
+        private static bool Sync(Shape formatShape, Shape newShape)
+        {
+            try
+            {
+                newShape.Line.Weight = formatShape.Line.Weight;
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+            return true;
         }
     }
 }

--- a/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/LineWeightFormat.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/LineWeightFormat.cs
@@ -9,12 +9,20 @@ namespace PowerPointLabs.SyncLab.ObjectFormats
     {
         public static bool CanCopy(Shape formatShape)
         {
-            return true;
+            return SyncFormat(formatShape, formatShape);
         }
 
-        public static void SyncFormat(Shape formatShape, Shape newShape)
+        public static bool SyncFormat(Shape formatShape, Shape newShape)
         {
-            newShape.Line.Weight = formatShape.Line.Weight;
+            try
+            {
+                newShape.Line.Weight = formatShape.Line.Weight;
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+            return true;
         }
 
         public static Bitmap DisplayImage(Shape formatShape)

--- a/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/LineWeightFormat.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/LineWeightFormat.cs
@@ -2,6 +2,7 @@
 using System.Drawing;
 
 using Microsoft.Office.Interop.PowerPoint;
+using PowerPointLabs.ActionFramework.Common.Log;
 
 namespace PowerPointLabs.SyncLab.ObjectFormats
 {
@@ -9,10 +10,15 @@ namespace PowerPointLabs.SyncLab.ObjectFormats
     {
         public static bool CanCopy(Shape formatShape)
         {
-            return SyncFormat(formatShape, formatShape);
+            return Sync(formatShape, formatShape);
         }
 
-        public static bool SyncFormat(Shape formatShape, Shape newShape)
+        public static void SyncFormat(Shape formatShape, Shape newShape)
+        {
+            Sync(formatShape, newShape);
+        }
+
+        public static bool Sync(Shape formatShape, Shape newShape)
         {
             try
             {
@@ -20,6 +26,7 @@ namespace PowerPointLabs.SyncLab.ObjectFormats
             }
             catch (Exception)
             {
+                Logger.Log(newShape.Type + " unable to sync Line Weight");
                 return false;
             }
             return true;


### PR DESCRIPTION
There is no way to check if a format can be synced until you actually try to sync it.
When you try to sync an invalid format, an exception will be thrown.

What I did was to catch the exception and log that the format cannot be synced.
Moved the try catch statements to SyncFormat() so that we can catch such errors for pasting as well.

I did not add any try catch to Sync Positions because I believe that all objects have a position (Thus syncing will never fail). Do correct my if I am wrong.

Fixes #1206 