### PR TITLE
Support naming copied attributes #1224

### DIFF
--- a/PowerPointLabs/PowerPointLabs/SyncLab/View/SyncFormatDialog.xaml
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/View/SyncFormatDialog.xaml
@@ -8,7 +8,8 @@
              Title="PowerPointLabs"
              d:DesignHeight="600" d:DesignWidth="300" Height="600"  Width="307">
     <Grid>
-        <TreeView x:Name="treeView" Margin="10,10,10,35" HorizontalContentAlignment="Stretch"/>
+        <TextBox x:Name="nameTextBox" Height="23" Margin="10,10,10,0" TextWrapping="Wrap" Text="TextBox" VerticalAlignment="Top"/>
+        <TreeView x:Name="treeView" Margin="10,38,10,35" HorizontalContentAlignment="Stretch"/>
         <Button x:Name="okButton" IsDefault="True" Content="OK" Margin="0,0,90,10" HorizontalAlignment="Right" Width="75" Height="20" VerticalAlignment="Bottom" Grid.ColumnSpan="2" Click="OkButton_Click" Grid.Row="1"/>
         <Button x:Name="cancelButton" IsCancel="True" Content="Cancel" Margin="0,0,10,10" HorizontalAlignment="Right" Width="75" Height="20" VerticalAlignment="Bottom" Grid.Column="1" Grid.Row="1"/>
     </Grid>

--- a/PowerPointLabs/PowerPointLabs/SyncLab/View/SyncFormatDialog.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/View/SyncFormatDialog.xaml.cs
@@ -109,5 +109,17 @@ namespace PowerPointLabs.SyncLab.View
                 return formats;
             }
         }
+
+        public string ObjectName
+        {
+            get
+            {
+                return nameTextBox.Text;
+            }
+            set
+            {
+                nameTextBox.Text = value;
+            }
+        }
     }
 }

--- a/PowerPointLabs/PowerPointLabs/SyncLab/View/SyncFormatPaneItem.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/View/SyncFormatPaneItem.cs
@@ -77,12 +77,14 @@ namespace PowerPointLabs.SyncLab.View
         private void OnMouseDoubleClick(object sender, MouseButtonEventArgs e)
         {
             SyncFormatDialog dialog = new SyncFormatDialog(shape, this.formats);
+            dialog.ObjectName = this.Text;
             bool? result = dialog.ShowDialog();
             if (!result.HasValue || !(bool)result)
             {
                 return;
             }
             this.formats = dialog.Formats;
+            this.Text = dialog.ObjectName;
         }
     }
 }

--- a/PowerPointLabs/PowerPointLabs/SyncLab/View/SyncPaneWPF.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/View/SyncPaneWPF.xaml.cs
@@ -62,10 +62,10 @@ namespace PowerPointLabs.SyncLab.View
         #endregion
 
         #region Sync API
-        public void AddFormatToList(Shape shape, FormatTreeNode[] formats)
+        public void AddFormatToList(Shape shape, string name, FormatTreeNode[] formats)
         {
             SyncFormatPaneItem item = new SyncFormatPaneItem(formatListBox, CopyShape(shape), formats);
-            item.Text = shape.Name;
+            item.Text = name;
             item.Image = new System.Drawing.Bitmap(Utils.Graphics.ShapeToImage(shape));
             formatListBox.Items.Insert(0, item);
             item.IsChecked = true;
@@ -116,12 +116,13 @@ namespace PowerPointLabs.SyncLab.View
             }
             var shape = selection.ShapeRange[1];
             SyncFormatDialog dialog = new SyncFormatDialog(shape);
+            dialog.ObjectName = shape.Name;
             bool? result = dialog.ShowDialog();
             if (!result.HasValue || !(bool)result)
             {
                 return;
             }
-            AddFormatToList(shape, dialog.Formats);
+            AddFormatToList(shape, dialog.ObjectName, dialog.Formats);
         }
 
         private void PasteButton_Click(object sender, RoutedEventArgs e)


### PR DESCRIPTION
Fixes #1224 

A textbox has been added in the format dialog for users to specify the display name.

![image](https://cloud.githubusercontent.com/assets/21071217/24129783/d53c54e2-0e1f-11e7-8a94-c4c348d2710d.png)

![image](https://cloud.githubusercontent.com/assets/21071217/24129811/f461b664-0e1f-11e7-9111-fb881e542529.png)

When copying the shape, the default name will be the shape name. Users can change the display name through the textbox on the dialog.

When double-clicking the format to open the options dialog, the textbox will show the current display name, and allow users to change it if required.