### PR TITLE
Improve text display in SyncLab

### DIFF
--- a/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/LineWeightFormat.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/LineWeightFormat.cs
@@ -24,7 +24,7 @@ namespace PowerPointLabs.SyncLab.ObjectFormats
         public static Bitmap DisplayImage(Shape formatShape)
         {
             return SyncFormatUtil.GetTextDisplay(
-                Math.Round(Math.Max(formatShape.Line.Weight, 0)).ToString(),
+                Math.Max(formatShape.Line.Weight, 0).ToString(".#"),
                 SyncFormatConstants.DisplayImageFont,
                 SyncFormatConstants.DisplayImageSize);
         }

--- a/PowerPointLabs/PowerPointLabs/SyncLab/SyncFormatConstants.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/SyncFormatConstants.cs
@@ -7,7 +7,7 @@ namespace PowerPointLabs.SyncLab.ObjectFormats
 
         public static readonly Size DisplayImageSize = new Size(30, 30);
 
-        public static readonly int DisplayImageFontSize = DisplayImageSize.Height;
+        public static readonly int DisplayImageFontSize = 12;
         public static readonly Font DisplayImageFont = new Font("Arial", DisplayImageFontSize);
 
         private static FormatTreeNode[] formatCategories = InitFormatCategories();

--- a/PowerPointLabs/PowerPointLabs/SyncLab/SyncFormatUtil.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/SyncFormatUtil.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Drawing;
+using System.Drawing.Text;
 
 using Microsoft.Office.Interop.PowerPoint;
 
@@ -21,22 +22,23 @@ namespace PowerPointLabs.SyncLab
             return design.TitleMaster.Shapes;
         }
 
-        public static Bitmap GetTextDisplay(string text, System.Drawing.Font font, Size size)
+        public static Bitmap GetTextDisplay(string text, System.Drawing.Font font, Size imageSize)
         {
-            Bitmap image = new Bitmap(size.Width, size.Height);
+            Bitmap image = new Bitmap(imageSize.Width, imageSize.Height);
             System.Drawing.Graphics g = System.Drawing.Graphics.FromImage(image);
+            g.TextRenderingHint = TextRenderingHint.AntiAlias;
             SizeF textSize = g.MeasureString(text, font);
-            Bitmap textImage = new Bitmap((int)Math.Ceiling(textSize.Width), (int)Math.Ceiling(textSize.Height));
-            System.Drawing.Graphics g2 = System.Drawing.Graphics.FromImage(textImage);
-            g2.DrawString(text, font, Brushes.Black, 0, 0);
-
-            double scale = Math.Min(size.Width / textSize.Width, size.Height / textSize.Height);
-            double newWidth = textSize.Width * scale;
-            double newHeight = textSize.Height * scale;
-            double newX = (size.Width - newWidth) / 2;
-            double newY = (size.Height - newHeight) / 2;
-            g.DrawImage(textImage, Convert.ToSingle(newX), Convert.ToSingle(newY),
-                Convert.ToSingle(newWidth), Convert.ToSingle(newHeight));
+            if (textSize.Width > imageSize.Width || textSize.Height > imageSize.Height)
+            {
+                double scale = Math.Min(imageSize.Width / textSize.Width, imageSize.Height / textSize.Height);
+                System.Drawing.Font newFont = new System.Drawing.Font(font.FontFamily, Convert.ToSingle(font.Size * scale),
+                                                            font.Style, font.Unit, font.GdiCharSet, font.GdiVerticalFont);
+                return GetTextDisplay(text, newFont, imageSize);
+            }
+            float xPos = Convert.ToSingle((imageSize.Width - textSize.Width) / 2);
+            float yPos = Convert.ToSingle((imageSize.Height - textSize.Height) / 2);
+            g.DrawString(text, font, Brushes.Black, xPos, yPos);
+            g.Dispose();
             return image;
         }
 

--- a/PowerPointLabs/PowerPointLabs/SyncLab/SyncFormatUtil.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/SyncFormatUtil.cs
@@ -28,12 +28,17 @@ namespace PowerPointLabs.SyncLab
             System.Drawing.Graphics g = System.Drawing.Graphics.FromImage(image);
             g.TextRenderingHint = TextRenderingHint.AntiAlias;
             SizeF textSize = g.MeasureString(text, font);
+            if (textSize.Width == 0 || textSize.Height == 0)
+            {
+                // nothing to print
+                return image;
+            }
             if (textSize.Width > imageSize.Width || textSize.Height > imageSize.Height)
             {
                 double scale = Math.Min(imageSize.Width / textSize.Width, imageSize.Height / textSize.Height);
-                System.Drawing.Font newFont = new System.Drawing.Font(font.FontFamily, Convert.ToSingle(font.Size * scale),
+                font = new System.Drawing.Font(font.FontFamily, Convert.ToSingle(font.Size * scale),
                                                             font.Style, font.Unit, font.GdiCharSet, font.GdiVerticalFont);
-                return GetTextDisplay(text, newFont, imageSize);
+                textSize = g.MeasureString(text, font);
             }
             float xPos = Convert.ToSingle((imageSize.Width - textSize.Width) / 2);
             float yPos = Convert.ToSingle((imageSize.Height - textSize.Height) / 2);


### PR DESCRIPTION
Fixes #1228 

![image](https://cloud.githubusercontent.com/assets/21071217/24137030/d36063b6-0e4c-11e7-921e-cedc0c610755.png)

Font size is now standardized (See Width/Height/X/Y). For line weight I displayed it with a placeholder to show that the font shrinks to fit longer text.