### PR TITLE
Sync Lab: Default to shape name if name text box is empty #1239

### DIFF
--- a/PowerPointLabs/PowerPointLabs/SyncLab/SyncFormatUtil.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/SyncFormatUtil.cs
@@ -14,10 +14,10 @@ namespace PowerPointLabs.SyncLab
 
         public static Shapes GetTemplateShapes()
         {
-            Design design = Graphics.GetDesign(TextCollection.StorageTemplateName);
+            Design design = Graphics.GetDesign(TextCollection.SyncLabStorageTemplateName);
             if (design == null)
             {
-                design = Graphics.CreateDesign(TextCollection.StorageTemplateName);
+                design = Graphics.CreateDesign(TextCollection.SyncLabStorageTemplateName);
             }
             return design.TitleMaster.Shapes;
         }
@@ -45,6 +45,15 @@ namespace PowerPointLabs.SyncLab
             g.DrawString(text, font, Brushes.Black, xPos, yPos);
             g.Dispose();
             return image;
+        }
+
+        #endregion
+
+        #region Shape Name Utils
+        public static bool IsValidFormatName(string name)
+        {
+            name = name.Trim();
+            return name.Length > 0;
         }
 
         #endregion

--- a/PowerPointLabs/PowerPointLabs/SyncLab/View/SyncFormatDialog.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/View/SyncFormatDialog.xaml.cs
@@ -16,15 +16,26 @@ namespace PowerPointLabs.SyncLab.View
     public partial class SyncFormatDialog : Window
     {
 
+        string originalName;
         FormatTreeNode[] formats = null;
 
-        public SyncFormatDialog(Shape shape) : this(shape, SyncFormatConstants.FormatCategories)
+        public SyncFormatDialog(Shape shape) : this(shape, shape.Name, SyncFormatConstants.FormatCategories)
         {
         }
 
-        public SyncFormatDialog(Shape shape, FormatTreeNode[] formats)
+        public SyncFormatDialog(Shape shape, string formatName, FormatTreeNode[] formats)
         {
             InitializeComponent();
+            formatName = formatName.Trim();
+            if (SyncFormatUtil.IsValidFormatName(formatName))
+            {
+                this.originalName = formatName;
+            }
+            else
+            {
+                this.originalName = TextCollection.SyncLabDefaultFormatName;
+            }
+            this.originalName = formatName;
             this.formats = formats;
             foreach (FormatTreeNode format in formats)
             {
@@ -114,7 +125,14 @@ namespace PowerPointLabs.SyncLab.View
         {
             get
             {
-                return nameTextBox.Text;
+                if (SyncFormatUtil.IsValidFormatName(nameTextBox.Text))
+                {
+                    return nameTextBox.Text.Trim();
+                }
+                else
+                {
+                    return this.originalName;
+                }
             }
             set
             {

--- a/PowerPointLabs/PowerPointLabs/SyncLab/View/SyncFormatPaneItem.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/View/SyncFormatPaneItem.cs
@@ -76,7 +76,7 @@ namespace PowerPointLabs.SyncLab.View
 
         private void OnMouseDoubleClick(object sender, MouseButtonEventArgs e)
         {
-            SyncFormatDialog dialog = new SyncFormatDialog(shape, this.formats);
+            SyncFormatDialog dialog = new SyncFormatDialog(shape, this.Text, this.formats);
             dialog.ObjectName = this.Text;
             bool? result = dialog.ShowDialog();
             if (!result.HasValue || !(bool)result)

--- a/PowerPointLabs/PowerPointLabs/SyncLab/View/SyncPaneWPF.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/View/SyncPaneWPF.xaml.cs
@@ -152,10 +152,10 @@ namespace PowerPointLabs.SyncLab.View
 
         private Shape CopyShape(Shape shape)
         {
-            Design design = Graphics.GetDesign(TextCollection.StorageTemplateName);
+            Design design = Graphics.GetDesign(TextCollection.SyncLabStorageTemplateName);
             if (design == null)
             {
-                design = Graphics.CreateDesign(TextCollection.StorageTemplateName);
+                design = Graphics.CreateDesign(TextCollection.SyncLabStorageTemplateName);
             }
             shape.Copy();
             ShapeRange newShapeRange = design.TitleMaster.Shapes.Paste();
@@ -164,7 +164,7 @@ namespace PowerPointLabs.SyncLab.View
 
         private void ClearStorageTemplate()
         {
-            Design design = Graphics.GetDesign(TextCollection.StorageTemplateName);
+            Design design = Graphics.GetDesign(TextCollection.SyncLabStorageTemplateName);
             if (design != null)
             {
                 design.Delete();

--- a/PowerPointLabs/PowerPointLabs/TextCollection.cs
+++ b/PowerPointLabs/PowerPointLabs/TextCollection.cs
@@ -157,7 +157,8 @@
         public const string SyncLabButtonSupertip = "Opens the Sync Lab Interface";
         public const string SyncLabCopySelectError = "Please select one item to copy.";
         public const string SyncLabPasteSelectError = "Please select at least one item to apply.";
-        public const string StorageTemplateName = "Sync Labs - Do not edit";
+        public const string SyncLabStorageTemplateName = "Sync Labs - Do not edit";
+        public const string SyncLabDefaultFormatName = "Format";
         #endregion
 
         #endregion


### PR DESCRIPTION
Fixes #1239

Behaviour:
1) Text box will show name of shape when copy button is pressed
2) If text box is left blank, the shape's name will be used as the list name
3) On double-clicking to modify the format, leaving a blank text box will not result in a name change