### PR TITLE
Sync Lab: Copy should create multiple undo entries #1214

### DIFF
--- a/PowerPointLabs/PowerPointLabs/SyncLab/View/SyncPaneWPF.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/View/SyncPaneWPF.xaml.cs
@@ -4,6 +4,7 @@ using System.Windows.Controls;
 using System.Windows.Media.Imaging;
 
 using Microsoft.Office.Interop.PowerPoint;
+using PowerPointLabs.ActionFramework.Common.Extension;
 using PowerPointLabs.Utils;
 
 namespace PowerPointLabs.SyncLab.View
@@ -134,6 +135,7 @@ namespace PowerPointLabs.SyncLab.View
                 MessageBox.Show(TextCollection.SyncLabPasteSelectError);
                 return;
             }
+            this.StartNewUndoEntry();
             SyncFormatPaneItem selectedItem = null;
             foreach (Object obj in formatListBox.Items)
             {


### PR DESCRIPTION
Fixes: #1214 

A new undo entry will be created every time the user clicks the paste button in Sync Lab.
This will allow the user to undo his most recent paste.
Note that if the user pastes the format to multiple objects at once, undo will remove the format from all the objects (Not just one of them)