### PR TITLE
User can still create multiple timers #1242

### DIFF
--- a/PowerPointLabs/PowerPointLabs/TimerLab/TimerLabPaneWPF.xaml
+++ b/PowerPointLabs/PowerPointLabs/TimerLab/TimerLabPaneWPF.xaml
@@ -60,7 +60,7 @@
                                             Minimum="0.01" Maximum="10" Interval="0.01" HorizontalContentAlignment="Left" 
                                             StringFormat="N2" ValueDecremented="DurationTextBox_ValueDecremented" 
                                             ValueIncremented="DurationTextBox_ValueIncremented"
-                                            MouseLeave="DurationTextBox_MouseLeave"/>
+                                            LostFocus="DurationTextBox_LostFocus"/>
                     <Image Grid.Row="3" Grid.Column="2" Grid.ColumnSpan="2" HorizontalAlignment="Center" VerticalAlignment="Bottom" 
                            Width="23" Height="15" Source="../Resources/TimerLab/MinWidth.png" RenderOptions.BitmapScalingMode="NearestNeighbor"/>
                     <Image Grid.Row="3" Grid.Column="5" Grid.ColumnSpan="2" HorizontalAlignment="Center" VerticalAlignment="Bottom" 
@@ -69,7 +69,8 @@
                            Width="23" Height="15" Source="../Resources/TimerLab/MaxWidth.png" RenderOptions.BitmapScalingMode="NearestNeighbor"/>
                     <TextBlock Grid.Row="4" Grid.Column="1" HorizontalAlignment="Left" VerticalAlignment="Center">Width</TextBlock>
                     <Slider x:Name="WidthSlider" Grid.Row="4" Grid.Column="3" Grid.ColumnSpan="7" VerticalAlignment="Center" 
-                            TickPlacement="BottomRight" TickFrequency="100" Loaded="WidthSlider_Loaded" ValueChanged="WidthSlider_ValueChanged"/>
+                            TickPlacement="BottomRight" TickFrequency="100" Loaded="WidthSlider_Loaded" ValueChanged="WidthSlider_ValueChanged" 
+                            PreviewMouseDown="WidthSlider_PreviewMouseDown"/>
                     <TextBox x:Name="WidthTextBox" Grid.Row="4" Grid.Column="11" VerticalAlignment="Center" MaxLength="3"
                              LostFocus="WidthTextBox_LostFocus" Loaded="WidthTextBox_Loaded" PreviewTextInput="WidthTextBox_PreviewTextInput"/>
 
@@ -81,7 +82,8 @@
                            Width="15" Height="23" Source="../Resources/TimerLab/MaxHeight.png" RenderOptions.BitmapScalingMode="NearestNeighbor"/>
                     <TextBlock Grid.Row="7" Grid.Column="1" HorizontalAlignment="Left" VerticalAlignment="Center" Margin="0,5">Height</TextBlock>
                     <Slider x:Name="HeightSlider" Grid.Row="7" Grid.Column="3" Grid.ColumnSpan="7" VerticalAlignment="Center" 
-                            TickPlacement="BottomRight" TickFrequency="100" Loaded="HeightSlider_Loaded" ValueChanged="HeightSlider_ValueChanged"/>
+                            TickPlacement="BottomRight" TickFrequency="100" Loaded="HeightSlider_Loaded" ValueChanged="HeightSlider_ValueChanged" 
+                            PreviewMouseDown="HeightSlider_PreviewMouseDown"/>
                     <TextBox x:Name="HeightTextBox" Grid.Row="7" Grid.Column="11" VerticalAlignment="Center" MaxLength="3"
                              LostFocus="HeightTextBox_LostFocus" Loaded="HeightTextBox_Loaded" PreviewTextInput="HeightTextBox_PreviewTextInput" />
 

--- a/PowerPointLabs/PowerPointLabs/TimerLab/TimerLabPaneWPF.xaml
+++ b/PowerPointLabs/PowerPointLabs/TimerLab/TimerLabPaneWPF.xaml
@@ -60,7 +60,7 @@
                                             Minimum="0.01" Maximum="10" Interval="0.01" HorizontalContentAlignment="Left" 
                                             StringFormat="N2" ValueDecremented="DurationTextBox_ValueDecremented" 
                                             ValueIncremented="DurationTextBox_ValueIncremented"
-                                            LostFocus="DurationTextBox_LostFocus"/>
+                                            MouseLeave="DurationTextBox_MouseLeave"/>
                     <Image Grid.Row="3" Grid.Column="2" Grid.ColumnSpan="2" HorizontalAlignment="Center" VerticalAlignment="Bottom" 
                            Width="23" Height="15" Source="../Resources/TimerLab/MinWidth.png" RenderOptions.BitmapScalingMode="NearestNeighbor"/>
                     <Image Grid.Row="3" Grid.Column="5" Grid.ColumnSpan="2" HorizontalAlignment="Center" VerticalAlignment="Bottom" 

--- a/PowerPointLabs/PowerPointLabs/TimerLab/TimerLabPaneWPF.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/TimerLab/TimerLabPaneWPF.xaml.cs
@@ -23,7 +23,7 @@ namespace PowerPointLabs.TimerLab
         private void CreateButton_Click(object sender, RoutedEventArgs e)
         {
             // check if timer is already created
-            if (IsTimerExist())
+            if (IsFullTimerExist())
             {
                 ShowErrorMessageBox(TimerLabConstants.ErrorMessageOneTimerOnly);
                 return;
@@ -33,71 +33,23 @@ namespace PowerPointLabs.TimerLab
             float slideWidth = this.GetCurrentPresentation().SlideWidth;
             float slideHeight = this.GetCurrentPresentation().SlideHeight;
 
-            // Functionality
+            // Properties
             int duration = Duration();
-            int denomination = TimerLabConstants.DefaultDenomination;
-
-            // Aesthetics
-            // Main
             float timerWidth = TimerWidth();
             float timerHeight = TimerHeight();
             int timerBodyColor = System.Drawing.Color.FromArgb(106, 84, 68).ToArgb();
-            // Markers
-            float lineMarkerWidth = TimerLabConstants.DefaultSecondsLineMarkerWidth;
-            float timeMarkerWidth = TimerLabConstants.DefaultTimeMarkerWidth;
-            float timeMarkerHeight = TimerLabConstants.DefaultTimeMarkerHeight;
-            // Slider
-            var sliderHeadSize = TimerLabConstants.DefaultSliderHeadSize;
-            var sliderBodyWidth = TimerLabConstants.DefaultSliderBodyWidth;
             int sliderColor = System.Drawing.Color.FromArgb(70, 150, 247).ToArgb();
 
             // Position
             float timerLeft = (slideWidth - timerWidth) / 2;
-            float timerTop = (slideHeight - timerHeight) / 2;         
+            float timerTop = (slideHeight - timerHeight) / 2;
 
-            // Create timer
-            var timerBody = this.GetCurrentSlide().Shapes.AddShape(Microsoft.Office.Core.MsoAutoShapeType.msoShapeRectangle, 
-                timerLeft, timerTop, timerWidth, timerHeight);
-            timerBody.Name = TimerLabConstants.TimerBody;
-            timerBody.Fill.ForeColor.RGB = timerBodyColor;
-            timerBody.Line.ForeColor.RGB = timerBodyColor;
-            
-            // Add markers
-            if (duration <= TimerLabConstants.SecondsInMinute)
-            {
-                AddSecondsMarker(duration, denomination, timerWidth, timerHeight, timerLeft, timerTop,
-                    lineMarkerWidth, timeMarkerWidth, timeMarkerHeight);
-            }
-            else
-            {
-                AddMinutesMarker(duration, denomination, timerWidth, timerHeight, timerLeft, timerTop,
-                    lineMarkerWidth, timeMarkerWidth, timeMarkerHeight);
-            }
-
-            // Add slider components
-            var sliderHead = this.GetCurrentSlide().Shapes.AddShape(
-                Microsoft.Office.Core.MsoAutoShapeType.msoShapeIsoscelesTriangle, 
-                timerLeft - (sliderHeadSize / 2), timerTop - (sliderHeadSize / 2), sliderHeadSize, sliderHeadSize);
-            sliderHead.Name = TimerLabConstants.TimerSliderHead;
-            sliderHead.Rotation = TimerLabConstants.Rotate180Degrees;
-            sliderHead.Fill.ForeColor.RGB = sliderColor;
-            sliderHead.Line.Transparency = TimerLabConstants.TransparencyTranparent;
-
-            var sliderBody = this.GetCurrentSlide().Shapes.AddShape(Microsoft.Office.Core.MsoAutoShapeType.msoShapeRectangle, 
-                timerLeft - (sliderBodyWidth / 2), timerTop, sliderBodyWidth, timerHeight);
-            sliderBody.Name = TimerLabConstants.TimerSliderBody;
-            sliderBody.Fill.ForeColor.RGB = sliderColor;
-            sliderBody.Line.Transparency = TimerLabConstants.TransparencyTranparent;
-
-            // Add slider animations
-            AddSliderMotionEffect(sliderHead, duration, timerWidth, slideWidth, 
-                PowerPoint.MsoAnimTriggerType.msoAnimTriggerOnPageClick);
-            AddSliderMotionEffect(sliderBody, duration, timerWidth, slideWidth, 
-                PowerPoint.MsoAnimTriggerType.msoAnimTriggerWithPrevious);
-            AddSliderEndEffect(sliderHead, PowerPoint.MsoAnimTriggerType.msoAnimTriggerAfterPrevious);
-            AddSliderEndEffect(sliderBody, PowerPoint.MsoAnimTriggerType.msoAnimTriggerWithPrevious);
+            AddTimerBody(timerWidth, timerHeight, timerLeft, timerTop, timerBodyColor);
+            AddMarkers(duration, timerWidth, timerHeight, timerLeft, timerTop);
+            AddSlider(duration, timerWidth, timerHeight, timerLeft, timerTop, sliderColor, slideWidth);
         }
 
+        #region Timer Properties
         private int Duration()
         {
             int duration = TimerLabConstants.SecondsInMinute;
@@ -121,6 +73,38 @@ namespace PowerPointLabs.TimerLab
         {
             float height = (float)HeightSlider.Value;
             return height;
+        }
+        #endregion
+
+        #region Timer Creation
+        #region Body
+        private void AddTimerBody(float timerWidth, float timerHeight, float timerLeft, 
+            float timerTop, int timerBodyColor)
+        {
+            // Create timer
+            var timerBody = this.GetCurrentSlide().Shapes.AddShape(Microsoft.Office.Core.MsoAutoShapeType.msoShapeRectangle,
+                timerLeft, timerTop, timerWidth, timerHeight);
+            timerBody.Name = TimerLabConstants.TimerBody;
+            timerBody.Fill.ForeColor.RGB = timerBodyColor;
+            timerBody.Line.ForeColor.RGB = timerBodyColor;
+        }
+        #endregion
+
+        #region Markers
+        private void AddMarkers(int duration, float timerWidth, float timerHeight, float timerLeft, float timerTop)
+        {
+            if (duration <= TimerLabConstants.SecondsInMinute)
+            {
+                AddSecondsMarker(duration, TimerLabConstants.DefaultDenomination, timerWidth, timerHeight, 
+                    timerLeft, timerTop, TimerLabConstants.DefaultMinutesLineMarkerWidth, 
+                    TimerLabConstants.DefaultTimeMarkerWidth, TimerLabConstants.DefaultTimeMarkerHeight);
+            }
+            else
+            {
+                AddMinutesMarker(duration, TimerLabConstants.DefaultDenomination, timerWidth, timerHeight,
+                    timerLeft, timerTop, TimerLabConstants.DefaultMinutesLineMarkerWidth,
+                    TimerLabConstants.DefaultTimeMarkerWidth, TimerLabConstants.DefaultTimeMarkerHeight);
+            }
         }
 
         private void AddSecondsMarker(int duration, int denomination, float timerWidth, float timerHeight, float timerLeft, 
@@ -253,6 +237,34 @@ namespace PowerPointLabs.TimerLab
                 GroupShapes(TimerLabConstants.TimerTimeMarker, TimerLabConstants.TimerTimeMarkerGroup);
             }
         }
+        #endregion
+
+        #region Slider
+        private void AddSlider(int duration, float timerWidth, float timerHeight, float timerLeft, 
+            float timerTop, int sliderColor, float slideWidth)
+        {
+            var sliderHead = this.GetCurrentSlide().Shapes.AddShape(Microsoft.Office.Core.MsoAutoShapeType.msoShapeIsoscelesTriangle,
+                timerLeft - (TimerLabConstants.DefaultSliderHeadSize / 2), timerTop - (TimerLabConstants.DefaultSliderHeadSize / 2),
+                TimerLabConstants.DefaultSliderHeadSize, TimerLabConstants.DefaultSliderHeadSize);
+            sliderHead.Name = TimerLabConstants.TimerSliderHead;
+            sliderHead.Rotation = TimerLabConstants.Rotate180Degrees;
+            sliderHead.Fill.ForeColor.RGB = sliderColor;
+            sliderHead.Line.Transparency = TimerLabConstants.TransparencyTranparent;
+
+            var sliderBody = this.GetCurrentSlide().Shapes.AddShape(Microsoft.Office.Core.MsoAutoShapeType.msoShapeRectangle,
+                timerLeft - (TimerLabConstants.DefaultSliderBodyWidth / 2), timerTop, TimerLabConstants.DefaultSliderBodyWidth, timerHeight);
+            sliderBody.Name = TimerLabConstants.TimerSliderBody;
+            sliderBody.Fill.ForeColor.RGB = sliderColor;
+            sliderBody.Line.Transparency = TimerLabConstants.TransparencyTranparent;
+
+            // Add slider animations
+            AddSliderMotionEffect(sliderHead, duration, timerWidth, slideWidth,
+                PowerPoint.MsoAnimTriggerType.msoAnimTriggerOnPageClick);
+            AddSliderMotionEffect(sliderBody, duration, timerWidth, slideWidth,
+                PowerPoint.MsoAnimTriggerType.msoAnimTriggerWithPrevious);
+            AddSliderEndEffect(sliderHead, PowerPoint.MsoAnimTriggerType.msoAnimTriggerAfterPrevious);
+            AddSliderEndEffect(sliderBody, PowerPoint.MsoAnimTriggerType.msoAnimTriggerWithPrevious);
+        }
 
         private void AddSliderMotionEffect(Shape shape, int duration, float timerWidth, float slideWidth, 
             PowerPoint.MsoAnimTriggerType trigger)
@@ -274,8 +286,11 @@ namespace PowerPointLabs.TimerLab
                 PowerPoint.MsoAnimTriggerType.msoAnimTriggerAfterPrevious);
             sliderEndEffect.Timing.Duration = TimerLabConstants.ColorChangeDuration;
         }
+        #endregion
+        #endregion
 
-        # region NumericUpDown Control
+        #region Controls
+        #region NumericUpDown Control
         private void DurationTextBox_ValueDecremented(object sender, 
             MahApps.Metro.Controls.NumericUpDownChangedRoutedEventArgs args)
         {
@@ -328,7 +343,7 @@ namespace PowerPointLabs.TimerLab
                 DurationTextBox.Value = integerPart + 1;
             }
 
-            if (IsTimerExist())
+            if (IsFullTimerExist())
             {
                 // remove current marker and add with new markers
                 int duration = Duration();
@@ -390,9 +405,9 @@ namespace PowerPointLabs.TimerLab
             WidthTextBox.Text = ((int)value).ToString();
 
             // update timer dimensions
-            var timerBody = GetShapeByName(TimerLabConstants.TimerBody);
-            if (timerBody != null)
+            if (IsFullTimerExist())
             {
+                var timerBody = GetShapeByName(TimerLabConstants.TimerBody);
                 float increment = value - timerBody.Width;
 
                 var lineMarkerGroup = GetShapeByName(TimerLabConstants.TimerLineMarkerGroup);
@@ -475,9 +490,10 @@ namespace PowerPointLabs.TimerLab
             HeightTextBox.Text = ((int)value).ToString();
 
             // update timer dimensions
-            var timerBody = GetShapeByName(TimerLabConstants.TimerBody);
-            if (timerBody != null)
+            if (IsFullTimerExist())
             {
+                var timerBody = GetShapeByName(TimerLabConstants.TimerBody);
+
                 float increment = value - timerBody.Height;
                 timerBody.Top = NewPosition(timerBody.Top, increment);
                 timerBody.Height = timerBody.Height + increment;
@@ -529,6 +545,7 @@ namespace PowerPointLabs.TimerLab
             HeightSlider.Value = value;
         }
         #endregion
+        #endregion
 
         #region Shapes Helper
         private float NewPosition(float originalPosition, float objectSize)
@@ -577,7 +594,7 @@ namespace PowerPointLabs.TimerLab
         #endregion
 
         #region Validation Helper
-        private bool IsTimerExist()
+        private bool IsFullTimerExist()
         {
             var timerBody = GetShapeByName(TimerLabConstants.TimerBody);
             var lineMarkerGroup = GetShapeByName(TimerLabConstants.TimerLineMarkerGroup);
@@ -585,11 +602,12 @@ namespace PowerPointLabs.TimerLab
             var sliderHead = GetShapeByName(TimerLabConstants.TimerSliderHead);
             var sliderBody = GetShapeByName(TimerLabConstants.TimerSliderBody);
 
-            return (timerBody != null) &&
-                (lineMarkerGroup != null) &&
-                (timerMarkerGroup != null) &&
-                (sliderHead != null) &&
-                (sliderBody != null);
+            if ((timerBody == null) || (lineMarkerGroup == null) || (timerMarkerGroup == null) ||
+                (sliderHead == null) || (sliderBody == null))
+            {
+                return false;
+            }
+            return true;
         }
 
         private bool IsNumbersOnly(string text)

--- a/PowerPointLabs/PowerPointLabs/TimerLab/TimerLabPaneWPF.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/TimerLab/TimerLabPaneWPF.xaml.cs
@@ -360,7 +360,7 @@ namespace PowerPointLabs.TimerLab
             }
         }
 
-        private void DurationTextBox_MouseLeave(object sender, System.Windows.Input.MouseEventArgs e)
+        private void DurationTextBox_LostFocus(object sender, RoutedEventArgs e)
         {
             if (DurationTextBox.Value == null)
             {
@@ -394,6 +394,15 @@ namespace PowerPointLabs.TimerLab
             WidthSlider.Maximum = SlideWidth();        
         }
 
+        private void WidthSlider_PreviewMouseDown(object sender, System.Windows.Input.MouseButtonEventArgs e)
+        {
+            // update timer dimensions
+            if (HasTimer())
+            {
+                ReformMissingComponents();
+            }
+        }
+
         private void WidthSlider_ValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
         {
             // update text box value
@@ -403,8 +412,6 @@ namespace PowerPointLabs.TimerLab
             // update timer dimensions
             if (HasTimer())
             {
-                ReformMissingComponents();
-
                 var timerBody = GetShapeByName(TimerLabConstants.TimerBody);
                 float increment = value - timerBody.Width;
 
@@ -438,7 +445,7 @@ namespace PowerPointLabs.TimerLab
                 {
                     if (effect.EffectType == PowerPoint.MsoAnimEffect.msoAnimEffectPathRight)
                     {
-                        if (effect.Shape.Name.Equals(TimerLabConstants.TimerSliderBody) || 
+                        if (effect.Shape.Name.Equals(TimerLabConstants.TimerSliderBody) ||
                             effect.Shape.Name.Equals(TimerLabConstants.TimerSliderHead))
                         {
                             float end = timerBody.Width / SlideWidth();
@@ -446,7 +453,6 @@ namespace PowerPointLabs.TimerLab
                         }
                     }
                 }
-
                 AdjustZOrder();
             }
         }
@@ -480,6 +486,12 @@ namespace PowerPointLabs.TimerLab
             }
             WidthTextBox.Text = value.ToString();
             WidthSlider.Value = value;
+
+            // update timer dimensions
+            if (HasTimer())
+            {
+                ReformMissingComponents();
+            }
         }
         #endregion
 
@@ -491,6 +503,15 @@ namespace PowerPointLabs.TimerLab
             HeightSlider.Value = TimerLabConstants.DefaultTimerHeight;
         }
 
+        private void HeightSlider_PreviewMouseDown(object sender, System.Windows.Input.MouseButtonEventArgs e)
+        {
+            // update timer dimensions
+            if (HasTimer())
+            {
+                ReformMissingComponents();
+            }
+        }
+
         private void HeightSlider_ValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
         {
             // update text box value
@@ -500,8 +521,6 @@ namespace PowerPointLabs.TimerLab
             // update timer dimensions
             if (HasTimer())
             {
-                ReformMissingComponents();
-
                 var timerBody = GetShapeByName(TimerLabConstants.TimerBody);
 
                 float increment = value - timerBody.Height;
@@ -555,6 +574,12 @@ namespace PowerPointLabs.TimerLab
             }
             HeightTextBox.Text = value.ToString();
             HeightSlider.Value = value;
+
+            // update timer dimensions
+            if (HasTimer())
+            {
+                ReformMissingComponents();
+            }
         }
         #endregion
         #endregion
@@ -572,6 +597,21 @@ namespace PowerPointLabs.TimerLab
 
             // add new markers
             AddMarkers(Duration(), timerBody.Width, timerBody.Height, timerBody.Left, timerBody.Top);
+        }
+
+        private void UpdateSlider()
+        {
+            // remove current Slider
+            Shape sliderHead = GetShapeByName(TimerLabConstants.TimerSliderHead);
+            sliderHead.Delete();
+            Shape sliderBody = GetShapeByName(TimerLabConstants.TimerSliderBody);
+            sliderBody.Delete();
+
+            var timerBody = GetShapeByName(TimerLabConstants.TimerBody);
+
+            // add new slider
+            AddSlider(Duration(), timerBody.Width, timerBody.Height, timerBody.Left, timerBody.Top, 
+                SliderColor(), SlideWidth());
         }
 
         private void UpdateSliderDuration()
@@ -607,7 +647,8 @@ namespace PowerPointLabs.TimerLab
             ReformTimerBodyIfMissing();
             ReformMarkersIfMissing();
             ReformSliderIfMissing();
-
+            UpdateMarkers();
+            UpdateSlider();
             AdjustZOrder();
         }
 
@@ -748,6 +789,7 @@ namespace PowerPointLabs.TimerLab
         {
             MessageBox.Show(content, "Error");
         }
+
         #endregion
     }
 }


### PR DESCRIPTION
Fixes #1242 

If any components of the timer still exist, clicking the create button will trigger the error message that only one timer is allowed. Any components of the timer that is missing will also be generated based on the values on the pane.