### PR TITLE
Sync Lab: Darkness of colors not copied #1256

### DIFF
--- a/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/FillFormat.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/FillFormat.cs
@@ -44,8 +44,8 @@ namespace PowerPointLabs.SyncLab.ObjectFormats
                 if (formatShape.Fill.Type == Microsoft.Office.Core.MsoFillType.msoFillPatterned)
                 {
                     newShape.Fill.Patterned(formatShape.Fill.Pattern);
-                    newShape.Fill.ForeColor = formatShape.Fill.ForeColor;
-                    newShape.Fill.BackColor = formatShape.Fill.BackColor;
+                    newShape.Fill.ForeColor.RGB = formatShape.Fill.ForeColor.RGB;
+                    newShape.Fill.BackColor.RGB = formatShape.Fill.BackColor.RGB;
                 }
                 else if (formatShape.Fill.Type == Microsoft.Office.Core.MsoFillType.msoFillBackground)
                 {
@@ -54,7 +54,7 @@ namespace PowerPointLabs.SyncLab.ObjectFormats
                 else if (formatShape.Fill.Type == Microsoft.Office.Core.MsoFillType.msoFillSolid)
                 {
                     newShape.Fill.Solid();
-                    newShape.Fill.ForeColor = formatShape.Fill.ForeColor;
+                    newShape.Fill.ForeColor.RGB = formatShape.Fill.ForeColor.RGB;
                 }
             }
             catch (Exception)

--- a/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/LineFillFormat.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/LineFillFormat.cs
@@ -41,8 +41,8 @@ namespace PowerPointLabs.SyncLab.ObjectFormats
         {
             try
             {
-                newShape.Line.ForeColor = formatShape.Line.ForeColor;
-                newShape.Line.BackColor = formatShape.Line.BackColor;
+                newShape.Line.ForeColor.RGB = formatShape.Line.ForeColor.RGB;
+                newShape.Line.BackColor.RGB = formatShape.Line.BackColor.RGB;
             }
             catch (Exception)
             {


### PR DESCRIPTION
The change to using the RGB values to sync should fix the issue
Fixes: #1256