### PR TITLE
Improve icons for line dash and compound #1283

### DIFF
--- a/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/LineCompoundTypeFormat.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/LineCompoundTypeFormat.cs
@@ -30,6 +30,8 @@ namespace PowerPointLabs.SyncLab.ObjectFormats
                 0, SyncFormatConstants.DisplayImageSize.Height,
                 SyncFormatConstants.DisplayImageSize.Width, 0);
             SyncFormat(formatShape, shape);
+            shape.Line.ForeColor.RGB = SyncFormatConstants.ColorBlack;
+            shape.Line.Weight = SyncFormatConstants.DisplayLineWeight;
             Bitmap image = new Bitmap(Graphics.ShapeToImage(shape));
             shape.Delete();
             return image;

--- a/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/LineDashTypeFormat.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/LineDashTypeFormat.cs
@@ -30,6 +30,8 @@ namespace PowerPointLabs.SyncLab.ObjectFormats
                 0, SyncFormatConstants.DisplayImageSize.Height,
                 SyncFormatConstants.DisplayImageSize.Width, 0);
             SyncFormat(formatShape, shape);
+            shape.Line.ForeColor.RGB = SyncFormatConstants.ColorBlack;
+            shape.Line.Weight = SyncFormatConstants.DisplayLineWeight;
             Bitmap image = new Bitmap(Graphics.ShapeToImage(shape));
             shape.Delete();
             return image;

--- a/PowerPointLabs/PowerPointLabs/SyncLab/SyncFormatConstants.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/SyncFormatConstants.cs
@@ -10,6 +10,9 @@ namespace PowerPointLabs.SyncLab.ObjectFormats
         public static readonly int DisplayImageFontSize = 12;
         public static readonly Font DisplayImageFont = new Font("Arial", DisplayImageFontSize);
 
+        public static readonly int ColorBlack = 0;
+        public static readonly int DisplayLineWeight = 5;
+
         private static FormatTreeNode[] formatCategories = InitFormatCategories();
 
         public static FormatTreeNode[] FormatCategories


### PR DESCRIPTION
Now the icons use thicker lines, so that the user can see the formatting that they are about to copy.
I used black to display instead of the original color because I do not want the users to think that they are copying the color too.
![image](https://cloud.githubusercontent.com/assets/12381148/24708315/13934f36-1a49-11e7-91d7-99ba65273458.png)

Fixes: #1283 