### PR TITLE
Improve icons for sync text #1285

### DIFF
--- a/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/FontFormat.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/FontFormat.cs
@@ -24,7 +24,7 @@ namespace PowerPointLabs.SyncLab.ObjectFormats
         public static Bitmap DisplayImage(Shape formatShape)
         {
             return SyncFormatUtil.GetTextDisplay(
-                "T",
+                SyncFormatConstants.DisplayFontString,
                 new System.Drawing.Font(formatShape.TextEffect.FontName,
                                         SyncFormatConstants.DisplayImageFontSize),
                 SyncFormatConstants.DisplayImageSize);

--- a/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/FontStyleFormat.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/FontStyleFormat.cs
@@ -39,7 +39,8 @@ namespace PowerPointLabs.SyncLab.ObjectFormats
                 style |= FontStyle.Italic;
             }
             font = new System.Drawing.Font(font.FontFamily, font.Size, style);
-            return SyncFormatUtil.GetTextDisplay( "T", font, SyncFormatConstants.DisplayImageSize);
+            return SyncFormatUtil.GetTextDisplay(SyncFormatConstants.DisplayFontString, font,
+                                                SyncFormatConstants.DisplayImageSize);
         }
 
         private static bool Sync(Shape formatShape, Shape newShape)

--- a/PowerPointLabs/PowerPointLabs/SyncLab/SyncFormatConstants.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/SyncFormatConstants.cs
@@ -7,6 +7,7 @@ namespace PowerPointLabs.SyncLab.ObjectFormats
 
         public static readonly Size DisplayImageSize = new Size(30, 30);
 
+        public static readonly string DisplayFontString = "Text";
         public static readonly int DisplayImageFontSize = 12;
         public static readonly Font DisplayImageFont = new Font("Arial", DisplayImageFontSize);
 


### PR DESCRIPTION
Changed the text from "T" to "Text". With a longer word, the user should have an easier time recognizing the font family/style