### PR TITLE
SyncLab revision

### DIFF
--- a/PowerPointLabs/PowerPointLabs/ActionFramework/Action/SyncLabActionHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/Action/SyncLabActionHandler.cs
@@ -1,0 +1,19 @@
+﻿using PowerPointLabs.ActionFramework.Common.Attribute;
+using PowerPointLabs.ActionFramework.Common.Extension;
+using PowerPointLabs.ActionFramework.Common.Interface;
+using PowerPointLabs.SyncLab.View;
+
+namespace PowerPointLabs.ActionFramework.Action
+{
+    [ExportActionRibbonId("SyncLabButton")]
+    class SyncLabActionHandler : ActionHandler
+    {
+        protected override void ExecuteAction(string ribbonId)
+        {
+            this.RegisterTaskPane(typeof(SyncPane), TextCollection.SyncLabTaskPanelTitle);
+            var syncPane = this.GetTaskPane(typeof(SyncPane));
+            // toggle pane visibility
+            syncPane.Visible = !syncPane.Visible;
+        }
+    }
+}

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/Image/SyncLabImageHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/Image/SyncLabImageHandler.cs
@@ -1,0 +1,15 @@
+﻿using System.Drawing;
+using PowerPointLabs.ActionFramework.Common.Attribute;
+using PowerPointLabs.ActionFramework.Common.Interface;
+
+namespace PowerPointLabs.ActionFramework.Image
+{
+    [ExportImageRibbonId("SyncLabButton")]
+    class SyncLabImageHandler : ImageHandler
+    {
+        protected override Bitmap GetImage(string ribbonId)
+        {
+            return new Bitmap(Properties.Resources.SyncLab);
+        }
+    }
+}

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/Label/SyncLabLabelHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/Label/SyncLabLabelHandler.cs
@@ -1,0 +1,14 @@
+﻿using PowerPointLabs.ActionFramework.Common.Attribute;
+using PowerPointLabs.ActionFramework.Common.Interface;
+
+namespace PowerPointLabs.ActionFramework.Label
+{
+    [ExportLabelRibbonId("SyncLabButton")]
+    class SyncLabLabelHandler : LabelHandler
+    {
+        protected override string GetLabel(string ribbonId)
+        {
+            return TextCollection.SyncLabButtonLabel;
+        }
+    }
+}

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/Supertip/SyncLabSupertipHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/Supertip/SyncLabSupertipHandler.cs
@@ -1,0 +1,14 @@
+﻿using PowerPointLabs.ActionFramework.Common.Attribute;
+using PowerPointLabs.ActionFramework.Common.Interface;
+
+namespace PowerPointLabs.ActionFramework.Supertip
+{
+    [ExportSupertipRibbonId("SyncLabButton")]
+    class SyncLabSupertipHandler : SupertipHandler
+    {
+        protected override string GetSupertip(string ribbonId)
+        {
+            return TextCollection.SyncLabButtonSupertip;
+        }
+    }
+}

--- a/PowerPointLabs/PowerPointLabs/PowerPointLabs.csproj
+++ b/PowerPointLabs/PowerPointLabs/PowerPointLabs.csproj
@@ -259,6 +259,7 @@
     <Compile Include="ActionFramework\Action\CropLabSettingsActionHandler.cs" />
     <Compile Include="ActionFramework\Action\CropToSameActionHandler.cs" />
     <Compile Include="ActionFramework\Action\CropToSlideActionHandler.cs" />
+    <Compile Include="ActionFramework\Action\SyncLabActionHandler.cs" />
     <Compile Include="ActionFramework\Action\MoveCropShapeButtonActionHandler.cs" />
     <Compile Include="ActionFramework\Action\CropToAspectRatioActionHandler.cs" />
     <Compile Include="ActionFramework\Action\CropOutPaddingActionHandler.cs" />
@@ -330,6 +331,7 @@
     <Compile Include="ActionFramework\Image\PasteLab\PasteLabMergeImageHandler.cs" />
     <Compile Include="ActionFramework\Image\PasteLab\PasteLabGroupImageHandler.cs" />
     <Compile Include="ActionFramework\Image\PasteLab\PasteLabReplaceImageHandler.cs" />
+    <Compile Include="ActionFramework\Image\SyncLabImageHandler.cs" />
     <Compile Include="ActionFramework\Image\ShapesLabImageHandler.cs" />
     <Compile Include="ActionFramework\Enabled\PasteLab\PasteLabFillEnabledHandler.cs" />
     <Compile Include="ActionFramework\Image\PasteLab\PasteLabFillImageHandler.cs" />
@@ -358,6 +360,7 @@
     <Compile Include="ActionFramework\Label\PasteLab\PasteLabPositionLabelHandler.cs" />
     <Compile Include="ActionFramework\Label\PasteLab\PasteLabOriginalPositionLabelHandler.cs" />
     <Compile Include="ActionFramework\Label\PasteLab\PasteLabReplaceLabelHandler.cs" />
+    <Compile Include="ActionFramework\Label\SyncLabLabelHandler.cs" />
     <Compile Include="ActionFramework\Label\ShapesLabLabelHandler.cs" />
     <Compile Include="ActionFramework\Label\PasteLab\PasteLabFillLabelHandler.cs" />
     <Compile Include="ActionFramework\Label\RemoveHighlightingLabelHandler.cs" />
@@ -382,6 +385,7 @@
     <Compile Include="ActionFramework\Supertip\CropLabMenuSupertipHandler.cs" />
     <Compile Include="ActionFramework\Supertip\CropToAspectRatioSupertipHandler.cs" />
     <Compile Include="ActionFramework\Supertip\CropOutPaddingSupertipHandler.cs" />
+    <Compile Include="ActionFramework\Supertip\SyncLabSupertipHandler.cs" />
     <Compile Include="ActionFramework\Supertip\ShapesLabSupertipHandler.cs" />
     <Compile Include="ActionFramework\Supertip\RemoveHighlightingSupertipHandler.cs" />
     <Compile Include="ActionFramework\Supertip\EffectsLabBlurSelectedSupertipHandler.cs" />

--- a/PowerPointLabs/PowerPointLabs/Ribbon1.cs
+++ b/PowerPointLabs/PowerPointLabs/Ribbon1.cs
@@ -17,7 +17,6 @@ using PowerPointLabs.DrawingsLab;
 using PowerPointLabs.HighlightLab;
 using PowerPointLabs.Models;
 using PowerPointLabs.PictureSlidesLab.View;
-using PowerPointLabs.SyncLab.View;
 using PowerPointLabs.Views;
 
 using Office = Microsoft.Office.Core;
@@ -376,11 +375,6 @@ namespace PowerPointLabs
             return TextCollection.HighlightTextFragmentsButtonSupertip;
         }
 
-        public string GetSyncLabButtonSupertip(Office.IRibbonControl control)
-        {
-            return TextCollection.SyncLabButtonSupertip;
-        }
-
         public string GetEffectsLabSupertip(Office.IRibbonControl control)
         {
             return TextCollection.EffectsLabMenuSupertip;
@@ -586,10 +580,6 @@ namespace PowerPointLabs
         public string GetEffectsLabButtonLabel(Office.IRibbonControl control)
         {
             return TextCollection.EffectsLabButtonLabel;
-        }
-        public string GetSyncButtonLabel(Office.IRibbonControl control)
-        {
-            return TextCollection.SyncLabButtonLabel;
         }
         public string GetEffectsLabMakeTransparentButtonLabel(Office.IRibbonControl control)
         {
@@ -1335,19 +1325,6 @@ namespace PowerPointLabs
             catch (Exception e)
             {
                 Logger.LogException(e, "GetHideShapeImage");
-                throw;
-            }
-        }
-
-        public Bitmap GetSyncLabImage(Office.IRibbonControl control)
-        {
-            try
-            {
-                return new Bitmap(Properties.Resources.SyncLab);
-            }
-            catch (Exception e)
-            {
-                Logger.LogException(e, "GetSyncLabImage");
                 throw;
             }
         }
@@ -2343,45 +2320,6 @@ namespace PowerPointLabs
                 Logger.LogException(e, "DrawingsLabButtonClicked");
                 throw;
             }
-        }
-        #endregion
-
-        #region Feature: Sync Lab
-        public void SyncLabButtonClick(Office.IRibbonControl control)
-        {
-            InitSyncLabPane();
-        }
-
-        private static SyncPane InitSyncLabPane()
-        {
-            var prensentation = PowerPointPresentation.Current.Presentation;
-
-            Globals.ThisAddIn.RegisterSyncLabPane(prensentation);
-
-            var syncLabPane = Globals.ThisAddIn.GetActivePane(typeof(SyncPane));
-
-            if (syncLabPane == null || !(syncLabPane.Control is SyncPane))
-            {
-                return null;
-            }
-
-            var syncLab = syncLabPane.Control as SyncPane;
-
-            Trace.TraceInformation(
-                "Before Visible: " +
-                string.Format("Pane Width = {0}, Pane Height = {1}, Control Width = {2}, Control Height {3}",
-                              syncLabPane.Width, syncLabPane.Height, syncLab.Width, syncLab.Height));
-
-            // if currently the pane is hidden, show the pane
-            if (!syncLabPane.Visible)
-            {
-                syncLabPane.Visible = true;
-
-                syncLab.Width = syncLabPane.Width - 16;
-                syncLab.PaneReload();
-            }
-
-            return syncLab;
         }
         #endregion
 

--- a/PowerPointLabs/PowerPointLabs/Ribbon1.xml
+++ b/PowerPointLabs/PowerPointLabs/Ribbon1.xml
@@ -335,11 +335,11 @@
                   getSupertip="GetSupertip"
                   onAction="OnAction"/>
           <button id="SyncLabButton"
-                  getLabel="GetSyncButtonLabel"
+                  getLabel="GetLabel"
                   size="large"
-                  getImage="GetSyncLabImage"
-                  getSupertip="GetSyncLabButtonSupertip"
-                  onAction="SyncLabButtonClick"/>
+                  getImage="GetImage"
+                  getSupertip="GetSupertip"
+                  onAction="OnAction"/>
           <menu id="CropLabMenu"
                   getLabel="GetLabel"
                   getImage="GetImage"

--- a/PowerPointLabs/PowerPointLabs/SyncLab/SyncFormatConstants.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/SyncFormatConstants.cs
@@ -39,11 +39,6 @@ namespace PowerPointLabs.SyncLab.ObjectFormats
                             new FormatTreeNode("Font Size", new Format(typeof(FontSizeFormat))),
                             new FormatTreeNode("Font Color", new Format(typeof(FontColorFormat))),
                             new FormatTreeNode("Style", new Format(typeof(FontStyleFormat)))
-                            /*new FormatTreeNode("Shadow", new Format(typeof(FillFormat))),
-                            new FormatTreeNode("Strikethrough", new Format(typeof(FillFormat))),
-                            new FormatTreeNode("Character Spacing", new Format(typeof(FillFormat))),
-                            new FormatTreeNode("Line Spacing", new Format(typeof(FillFormat))),
-                            new FormatTreeNode("Alignment", new Format(typeof(FillFormat)))*/
                         ),
                     new FormatTreeNode(
                             "Fill",
@@ -59,16 +54,6 @@ namespace PowerPointLabs.SyncLab.ObjectFormats
                             new FormatTreeNode("Dash Type", new Format(typeof(LineDashTypeFormat))),
                             new FormatTreeNode("Arrow", new Format(typeof(LineArrowFormat)))
                         ),
-                    //not easy
-                    /*new FormatTreeNode(
-                            "Effect",
-                            new FormatTreeNode("Shadow", new Format(typeof(FillFormat))),
-                            new FormatTreeNode("Reflection", new Format(typeof(FillFormat))),
-                            new FormatTreeNode("Glow", new Format(typeof(FillFormat))),
-                            new FormatTreeNode("Soft Edge", new Format(typeof(FillFormat))),
-                            new FormatTreeNode("Bevel", new Format(typeof(FillFormat))),
-                            new FormatTreeNode("3D Rotation", new Format(typeof(FillFormat)))
-                        ),*/
                     new FormatTreeNode(
                             "Size/Position",
                             new FormatTreeNode("Width", new Format(typeof(PositionWidthFormat))),

--- a/PowerPointLabs/PowerPointLabs/SyncLab/SyncLabShapeStorage.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/SyncLabShapeStorage.cs
@@ -8,14 +8,12 @@ namespace PowerPointLabs.SyncLab
 {
     public class SyncLabShapeStorage : PowerPointPresentation
     {
-#pragma warning disable 0618
 
         private int nextKey = 0;
 
         public SyncLabShapeStorage() : base()
         {
-            Path = Globals.ThisAddIn.PrepareTempFolder(
-                                         PowerPointPresentation.Current.Presentation);
+            Path = System.IO.Path.GetTempPath();
             Name = string.Format(TextCollection.SyncLabStorageFileName,
                                  DateTime.Now.ToString("yyyyMMddHHmmssffff"));
             OpenInBackground();

--- a/PowerPointLabs/PowerPointLabs/SyncLab/View/SyncPane.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/View/SyncPane.cs
@@ -5,24 +5,9 @@ namespace PowerPointLabs.SyncLab.View
     public partial class SyncPane : UserControl
     {
 
-        private bool _firstTimeLoading = true;
-
         public SyncPane()
         {
             InitializeComponent();
         }
-
-        #region API
-        public void PaneReload(bool forceReload = false)
-        {
-            if (!_firstTimeLoading && !forceReload)
-            {
-                return;
-            }
-
-            _firstTimeLoading = false;
-        }
-        #endregion
-
     }
 }

--- a/PowerPointLabs/PowerPointLabs/SyncLab/View/SyncPaneWPF.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/View/SyncPaneWPF.xaml.cs
@@ -5,7 +5,7 @@ using System.Windows.Media.Imaging;
 
 using Microsoft.Office.Interop.PowerPoint;
 
-using PowerPointLabs.Models;
+using static PowerPointLabs.ActionFramework.Common.Extension.ContentControlExtensions;
 
 namespace PowerPointLabs.SyncLab.View
 {
@@ -14,7 +14,6 @@ namespace PowerPointLabs.SyncLab.View
     /// </summary>
     public partial class SyncPaneWPF : UserControl
     {
-#pragma warning disable 0618
 
         private readonly SyncLabShapeStorage shapeStorage;
 
@@ -32,7 +31,7 @@ namespace PowerPointLabs.SyncLab.View
 
         public void SyncPaneWPF_Loaded(object sender, RoutedEventArgs e)
         {
-            var syncLabPane = Globals.ThisAddIn.GetActivePane(typeof(SyncPane));
+            var syncLabPane = this.GetAddIn().GetActivePane(typeof(SyncPane));
             if (syncLabPane == null || !(syncLabPane.Control is SyncPane))
             {
                 MessageBox.Show("Error: SyncPane not opened.");
@@ -47,14 +46,6 @@ namespace PowerPointLabs.SyncLab.View
         {
             shapeStorage.Close();
         }
-
-        /*
-        public void SyncPane_Closing(object sender, System.ComponentModel.CancelEventArgs e)
-        {
-            MessageBox.Show("Closing");
-            shapeStorage.Close();
-        }
-        */
 
         #region GUI API
         public int FormatCount
@@ -99,7 +90,7 @@ namespace PowerPointLabs.SyncLab.View
 
         public void ApplyFormats(FormatTreeNode[] nodes, Shape formatShape)
         {
-            var selection = Globals.ThisAddIn.Application.ActiveWindow.Selection;
+            var selection = this.GetCurrentSelection();
             if (selection.Type != PpSelectionType.ppSelectionShapes ||
                 selection.ShapeRange.Count == 0)
             {
@@ -178,7 +169,7 @@ namespace PowerPointLabs.SyncLab.View
         #region GUI Handles
         private void CopyButton_Click(object sender, RoutedEventArgs e)
         {
-            var selection = Globals.ThisAddIn.Application.ActiveWindow.Selection;
+            var selection = this.GetCurrentSelection();
             if (selection.Type != PpSelectionType.ppSelectionShapes ||
                 selection.ShapeRange.Count != 1)
             {


### PR DESCRIPTION
Addresses SyncLab problems in #1289

- `warning disable 0618` has been removed, and replaced with action framework's extension methods.
- `Globals.ThisAddIn.PrepareTempFolder...` in SyncLabShapeStorage replaced with `System.IO.Path.GetTempPath()`.
- Migrated SyncLab's code into actions.
- Unused code removed.