### PR TITLE
'Replace with clipboard' should be available for all objects #1269 

### DIFF
--- a/PowerPointLabs/PowerPointLabs/ActionFramework/Action/AddShapeActionHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/Action/AddShapeActionHandler.cs
@@ -6,7 +6,9 @@ using PowerPointLabs.ActionFramework.Common.Interface;
 
 namespace PowerPointLabs.ActionFramework.Action
 {
-    [ExportActionRibbonId("AddCustomShape", "addCustomShapePictureGroup")]
+    [ExportActionRibbonId("AddCustomShape", "AddCustomShapePicture", "AddCustomShapeChart",
+                        "AddCustomShapeTable", "AddCustomShapeGroup", "AddCustomShapeFreeform",
+                        "AddCustomShapeInk", "AddCustomShapeSmartArt")]
     class AddShapeActionHandler : ShapesLabActionHandler
     {
         protected override void ExecuteAction(string ribbonId)

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/Action/PasteLab/PasteLabReplaceActionHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/Action/PasteLab/PasteLabReplaceActionHandler.cs
@@ -6,7 +6,7 @@ using PowerPointLabs.ActionFramework.Common.Interface;
 
 namespace PowerPointLabs.ActionFramework.Action.PasteLab
 {
-    [ExportActionRibbonId("pasteAndReplace")]
+    [ExportActionRibbonId("PasteAndReplace", "PasteAndReplaceFreeform", "PasteAndReplacePicture")]
     class PasteLabReplaceActionHandler : ActionHandler
     {
         protected override void ExecuteAction(string ribbonId)

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/Enabled/PasteLab/PasteLabReplaceEnabledHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/Enabled/PasteLab/PasteLabReplaceEnabledHandler.cs
@@ -5,7 +5,7 @@ using PowerPointLabs.ActionFramework.Common.Interface;
 
 namespace PowerPointLabs.ActionFramework.Enabled.PasteLab
 {
-    [ExportEnabledRibbonId("pasteAndReplace")]
+    [ExportEnabledRibbonId("PasteAndReplace", "PasteAndReplaceFreeform", "PasteAndReplacePicture")]
     class PasteLabReplaceEnabledHandler : EnabledHandler
     {
         protected override bool GetEnabled(string ribbonId)

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/Image/AddShapeImageHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/Image/AddShapeImageHandler.cs
@@ -4,7 +4,9 @@ using PowerPointLabs.ActionFramework.Common.Interface;
 
 namespace PowerPointLabs.ActionFramework.Image
 {
-    [ExportImageRibbonId("AddCustomShape", "addCustomShapePictureGroup")]
+    [ExportImageRibbonId("AddCustomShape", "AddCustomShapePicture", "AddCustomShapeChart", 
+                        "AddCustomShapeTable", "AddCustomShapeGroup", "AddCustomShapeFreeform",
+                        "AddCustomShapeInk", "AddCustomShapeSmartArt")]
     class AddShapeImageHandler : ImageHandler
     {
         protected override Bitmap GetImage(string ribbonId)

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/Image/PasteLab/PasteLabReplaceImageHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/Image/PasteLab/PasteLabReplaceImageHandler.cs
@@ -4,7 +4,7 @@ using PowerPointLabs.ActionFramework.Common.Interface;
 
 namespace PowerPointLabs.ActionFramework.Image.PasteLab
 {
-    [ExportImageRibbonId("pasteAndReplace")]
+    [ExportImageRibbonId("PasteAndReplace", "PasteAndReplaceFreeform", "PasteAndReplacePicture")]
     class PasteLabReplaceImageHandler : ImageHandler
     {
         protected override Bitmap GetImage(string ribbonId)

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/Label/AddShapeLabelHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/Label/AddShapeLabelHandler.cs
@@ -3,7 +3,9 @@ using PowerPointLabs.ActionFramework.Common.Interface;
 
 namespace PowerPointLabs.ActionFramework.Label
 {
-    [ExportLabelRibbonId("AddCustomShape", "addCustomShapePictureGroup")]
+    [ExportLabelRibbonId("AddCustomShape", "AddCustomShapePicture", "AddCustomShapeChart", 
+                        "AddCustomShapeTable", "AddCustomShapeGroup", "AddCustomShapeFreeform",
+                        "AddCustomShapeInk", "AddCustomShapeSmartArt")]
     class AddShapeLabelHandler : LabelHandler
     {
         protected override string GetLabel(string ribbonId)

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/Label/PasteLab/PasteLabReplaceLabelHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/Label/PasteLab/PasteLabReplaceLabelHandler.cs
@@ -3,7 +3,7 @@ using PowerPointLabs.ActionFramework.Common.Interface;
 
 namespace PowerPointLabs.ActionFramework.Label.PasteLab
 {
-    [ExportLabelRibbonId("pasteAndReplace")]
+    [ExportLabelRibbonId("PasteAndReplace", "PasteAndReplaceFreeform", "PasteAndReplacePicture")]
     class PasteLabReplaceLabelHandler : LabelHandler
     {
         protected override string GetLabel(string ribbonId)

--- a/PowerPointLabs/PowerPointLabs/Ribbon1.xml
+++ b/PowerPointLabs/PowerPointLabs/Ribbon1.xml
@@ -495,10 +495,10 @@
                getLabel ="GetConvertToPictureShapeLabel"
                getImage="GetConvertToPicMenuImage"
                onAction="ConvertToPictureButtonClick"/>
-        <button id="addCustomShapeFreeform"
-               getLabel ="GetAddCustomShapeShapeLabel"
-               getImage="GetAddToCustomShapeContextImage"
-               onAction="AddShapeButtonClick"/>
+        <button id="AddCustomShapeFreeform"
+               getLabel ="GetLabel"
+               getImage="GetImage"
+               onAction="OnAction"/>
         <button id="cutOutShapeFreeform"
                 getLabel="GetCutOutShapeShapeLabel"
                 getImage="GetImage"
@@ -534,6 +534,10 @@
                getImage="GetZoomOutContextImage"
                getEnabled="OnGetEnabledZoomButton"
                onAction="AddZoomOutButtonClick"/>
+        <button id="AddCustomShapePicture"
+               getLabel ="GetLabel"
+               getImage="GetImage"
+               onAction="OnAction"/>
         <button id="fitToWidthPicture"
                 getLabel="GetLabel"
                 getImage="GetImage"
@@ -542,10 +546,6 @@
                 getLabel="GetLabel"
                 getImage="GetImage"
                 onAction="OnAction"/>
-        <button id="addCustomShapePicture"
-                getLabel ="GetAddCustomShapeShapeLabel"
-                getImage="GetAddToCustomShapeContextImage"
-                onAction="AddShapeButtonClick"/>
         <button id="hideShape"
                getLabel ="GetHideSelectedShapeLabel"
                getImage="GetHideShapeImage"
@@ -563,10 +563,10 @@
                getLabel ="GetConvertToPictureShapeLabel"
                getImage="GetConvertToPicMenuImage"
                onAction="ConvertToPictureButtonClick"/>
-        <button id="addCustomShapeChart"
-               getLabel ="GetAddCustomShapeShapeLabel"
-               getImage="GetAddToCustomShapeContextImage"
-               onAction="AddShapeButtonClick"/>
+        <button id="AddCustomShapeChart"
+               getLabel ="GetLabel"
+               getImage="GetImage"
+               onAction="OnAction"/>
         <button id="fitToWidthChart"
                 getLabel="GetLabel"
                 getImage="GetImage"
@@ -592,10 +592,10 @@
                 getLabel="GetLabel"
                 getImage="GetImage"
                 onAction="OnAction"/>
-        <button id="addCustomShapeTable"
-               getLabel ="GetAddCustomShapeShapeLabel"
-               getImage="GetAddToCustomShapeContextImage"
-               onAction="AddShapeButtonClick"/>
+        <button id="AddCustomShapeTable"
+               getLabel ="GetLabel"
+               getImage="GetImage"
+               onAction="OnAction"/>
       </menu>
     </contextMenu>
     <contextMenu idMso="ContextMenuObjectsGroup">
@@ -645,7 +645,7 @@
                getLabel ="GetConvertToPictureShapeLabel"
                getImage="GetConvertToPicMenuImage"
                onAction="ConvertToPictureButtonClick"/>
-        <button id="addCustomShapePictureGroup"
+        <button id="AddCustomShapeGroup"
                getLabel ="GetLabel"
                getImage="GetImage"
                onAction="OnAction"/>
@@ -670,10 +670,10 @@
                getLabel ="GetConvertToPictureShapeLabel"
                getImage="GetConvertToPicMenuImage"
                onAction="ConvertToPictureButtonClick"/>
-        <button id="addCustomShapeInk"
-               getLabel ="GetAddCustomShapeShapeLabel"
-               getImage="GetAddToCustomShapeContextImage"
-               onAction="AddShapeButtonClick"/>
+        <button id="AddCustomShapeInk"
+               getLabel ="GetLabel"
+               getImage="GetImage"
+               onAction="OnAction"/>
       </menu>
     </contextMenu>
     <contextMenu idMso="ContextMenuSmartArtBackground">
@@ -687,10 +687,10 @@
                getLabel ="GetConvertToPictureShapeLabel"
                getImage="GetConvertToPicMenuImage"
                onAction="ConvertToPictureButtonClick"/>
-        <button id="addCustomShapeSmartArt"
-               getLabel ="GetAddCustomShapeShapeLabel"
-               getImage="GetAddToCustomShapeContextImage"
-               onAction="AddShapeButtonClick"/>
+        <button id="AddCustomShapeSmartArt"
+               getLabel ="GetLabel"
+               getImage="GetImage"
+               onAction="OnAction"/>
       </menu>
     </contextMenu>
     <contextMenu idMso="ContextMenuThumbnail">

--- a/PowerPointLabs/PowerPointLabs/Ribbon1.xml
+++ b/PowerPointLabs/PowerPointLabs/Ribbon1.xml
@@ -437,11 +437,6 @@
                getImage="GetZoomToAreaContextImage"
                getEnabled="OnGetEnabledZoomButton"
                onAction="ZoomBtnClick"/>
-        <button id="pasteAndReplace"
-                getEnabled="GetEnabled"
-                getImage="GetImage"
-                getLabel="GetLabel"
-                onAction="OnAction"/>
         <menu id="HighlightBulletsMenuShape"
               getLabel="GetHighlightBulletsMenuShapeLabel"
               getImage="GetHighlightBulletsBackgroundContextImage">
@@ -478,6 +473,11 @@
               getLabel ="GetHideSelectedShapeLabel"
               getImage="GetHideShapeImage"
               onAction="HideShapeButtonClick"/>
+        <button id="PasteAndReplace"
+                getEnabled="GetEnabled"
+                getImage="GetImage"
+                getLabel="GetLabel"
+                onAction="OnAction"/>
       </menu>
     </contextMenu>
     <contextMenu idMso="ContextMenuShapeFreeform">
@@ -515,6 +515,11 @@
               getLabel ="GetHideSelectedShapeLabel"
               getImage="GetHideShapeImage"
               onAction="HideShapeButtonClick"/>
+        <button id="PasteAndReplaceFreeform"
+                getEnabled="GetEnabled"
+                getImage="GetImage"
+                getLabel="GetLabel"
+                onAction="OnAction"/>
       </menu>
     </contextMenu>
     <contextMenu idMso="ContextMenuPicture">
@@ -550,6 +555,11 @@
                getLabel ="GetHideSelectedShapeLabel"
                getImage="GetHideShapeImage"
                onAction="HideShapeButtonClick"/>
+        <button id="PasteAndReplacePicture"
+                getEnabled="GetEnabled"
+                getImage="GetImage"
+                getLabel="GetLabel"
+                onAction="OnAction"/>
       </menu>
     </contextMenu>
     <contextMenu idMso="ContextMenuChartArea">


### PR DESCRIPTION
Fixes #1269 , #1178 

Enabled "Replace With Clipboard" for pictures and freeform shapes.
Fixed some missing context menu items.