### PR TITLE
Crop Lab: Fix flaky unit test

### DIFF
--- a/PowerPointLabs/Test/UnitTest/CropLab/CropToSameDimTest.cs
+++ b/PowerPointLabs/Test/UnitTest/CropLab/CropToSameDimTest.cs
@@ -65,6 +65,7 @@ namespace Test.UnitTest.CropLab
         {
             CropLabSettings.AnchorPosition = AnchorPosition.BottomRight;
             CropAndCompare(22, 23);
+            CropLabSettings.AnchorPosition = AnchorPosition.Reference;
         }
 
         public void CropAndCompare(int testSlideNo, int expectedSlideNo)


### PR DESCRIPTION
Fix anchor position settings being changed but not restored in Crop Lab unit tests, causing them to sometimes fail.