### PR TITLE
Paste To Fill Slide does not maintain aspect ratio and crop to slide #1325 

### DIFF
--- a/PowerPointLabs/PowerPointLabs/ActionFramework/Action/CropToSlideActionHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/Action/CropToSlideActionHandler.cs
@@ -34,7 +34,7 @@ namespace PowerPointLabs.ActionFramework.Action
             }
             float slideWidth = this.GetCurrentPresentation().SlideWidth;
             float slideHeight = this.GetCurrentPresentation().SlideHeight;
-            bool hasChange = CropToSlide.CropSelection(shapeRange, this.GetCurrentSlide(), slideWidth, slideHeight);
+            bool hasChange = CropToSlide.Crop(shapeRange, this.GetCurrentSlide(), slideWidth, slideHeight);
             if (!hasChange)
             {
                 HandleErrorCode(CropLabErrorHandler.ErrorCodeNoShapeOverBoundary, FeatureName, errorHandler);

--- a/PowerPointLabs/PowerPointLabs/PasteLab/PasteLabMain.cs
+++ b/PowerPointLabs/PowerPointLabs/PasteLab/PasteLabMain.cs
@@ -177,22 +177,22 @@ namespace PowerPointLabs.PasteLab
                 return;
             }
 
-            var newShapeRange = slide.Shapes.Paste();
-            newShapeRange = RemovePlaceholders(slide, newShapeRange);
+            var pastedShapeRange = slide.Shapes.Paste();
+            pastedShapeRange = RemovePlaceholders(slide, pastedShapeRange);
 
-            if (newShapeRange.Count > 1)
+            if (pastedShapeRange.Count > 1)
             {
-                Shape pastedShape = newShapeRange.Group();
-                pastedShape.Left = xPosition;
-                pastedShape.Top = yPosition;
-                Logger.Log(string.Format("PasteToPosition: Pasted {0} at ({1}, {2})", pastedShape.Name, pastedShape.Left, pastedShape.Top));
-                pastedShape.Ungroup();
+                Shape pastedShapeGroup = pastedShapeRange.Group();
+                pastedShapeGroup.Left = xPosition;
+                pastedShapeGroup.Top = yPosition;
+                Logger.Log(string.Format("PasteToPosition: Pasted {0} at ({1}, {2})", pastedShapeGroup.Name, pastedShapeGroup.Left, pastedShapeGroup.Top));
+                pastedShapeGroup.Ungroup();
             }
-            else
+            else if (pastedShapeRange.Count == 1)
             {
-                newShapeRange.Left = xPosition;
-                newShapeRange.Top = yPosition;
-                Logger.Log(string.Format("PasteToPosition: Pasted {0} at ({1}, {2})", newShapeRange.Name, newShapeRange.Left, newShapeRange.Top));
+                pastedShapeRange.Left = xPosition;
+                pastedShapeRange.Top = yPosition;
+                Logger.Log(string.Format("PasteToPosition: Pasted {0} at ({1}, {2})", pastedShapeRange.Name, pastedShapeRange.Left, pastedShapeRange.Top));
             }
         }
 

--- a/PowerPointLabs/PowerPointLabs/PasteLab/PasteLabMain.cs
+++ b/PowerPointLabs/PowerPointLabs/PasteLab/PasteLabMain.cs
@@ -185,6 +185,7 @@ namespace PowerPointLabs.PasteLab
                 Shape pastedShape = newShapeRange.Group();
                 pastedShape.Left = xPosition;
                 pastedShape.Top = yPosition;
+                Logger.Log(string.Format("PasteToPosition: Pasted {0} at ({1}, {2})", pastedShape.Name, pastedShape.Left, pastedShape.Top));
                 pastedShape.Ungroup();
             }
             else
@@ -193,6 +194,7 @@ namespace PowerPointLabs.PasteLab
                 {
                     shape.Left = xPosition;
                     shape.Top = yPosition;
+                    Logger.Log(string.Format("PasteToPosition: Pasted {0} at ({1}, {2})", shape.Name, shape.Left, shape.Top));
                 }
             }
         }

--- a/PowerPointLabs/PowerPointLabs/PasteLab/PasteLabMain.cs
+++ b/PowerPointLabs/PowerPointLabs/PasteLab/PasteLabMain.cs
@@ -190,12 +190,9 @@ namespace PowerPointLabs.PasteLab
             }
             else
             {
-                foreach (Shape shape in newShapeRange)
-                {
-                    shape.Left = xPosition;
-                    shape.Top = yPosition;
-                    Logger.Log(string.Format("PasteToPosition: Pasted {0} at ({1}, {2})", shape.Name, shape.Left, shape.Top));
-                }
+                newShapeRange.Left = xPosition;
+                newShapeRange.Top = yPosition;
+                Logger.Log(string.Format("PasteToPosition: Pasted {0} at ({1}, {2})", newShapeRange.Name, newShapeRange.Left, newShapeRange.Top));
             }
         }
 

--- a/PowerPointLabs/PowerPointLabs/PasteLab/PasteLabMain.cs
+++ b/PowerPointLabs/PowerPointLabs/PasteLab/PasteLabMain.cs
@@ -24,7 +24,7 @@ namespace PowerPointLabs.PasteLab
 
             ShapeRange pastedShapeRange = slide.Shapes.Paste();
             Logger.Log(string.Format("PasteToFillSlide: {0} objects pasted", pastedShapeRange.Count));
-            pastedShapeRange = RemovePlaceholders(slide, pastedShapeRange);
+            pastedShapeRange = Graphics.GetShapesWhenTypeNotMatches(slide, pastedShapeRange, Microsoft.Office.Core.MsoShapeType.msoPlaceholder);
 
             if (pastedShapeRange.Count <= 0)
             {
@@ -186,7 +186,7 @@ namespace PowerPointLabs.PasteLab
             }
 
             var pastedShapeRange = slide.Shapes.Paste();
-            pastedShapeRange = RemovePlaceholders(slide, pastedShapeRange);
+            pastedShapeRange = Graphics.GetShapesWhenTypeNotMatches(slide, pastedShapeRange, Microsoft.Office.Core.MsoShapeType.msoPlaceholder);
 
             if (pastedShapeRange.Count > 1)
             {
@@ -259,19 +259,6 @@ namespace PowerPointLabs.PasteLab
                     eff.MoveAfter(curSlide.TimeLine.MainSequence[curo - 1]);
                 }
             }
-        }
-
-        private static ShapeRange RemovePlaceholders(PowerPointSlide slide, ShapeRange shapes)
-        {
-            List<Shape> newShapeList = new List<Shape>();
-            foreach (Shape shape in shapes)
-            {
-                if (shape.Type != Microsoft.Office.Core.MsoShapeType.msoPlaceholder)
-                {
-                    newShapeList.Add(shape);
-                }
-            }
-            return slide.ToShapeRange(newShapeList);
         }
     }
 }

--- a/PowerPointLabs/PowerPointLabs/Utils/Graphics.cs
+++ b/PowerPointLabs/PowerPointLabs/Utils/Graphics.cs
@@ -13,7 +13,9 @@ using System.Windows.Media.Imaging;
 
 using Microsoft.Office.Core;
 using Microsoft.Office.Interop.PowerPoint;
+
 using PowerPointLabs.Models;
+
 using PPExtraEventHelper;
 
 using Drawing = System.Drawing;
@@ -161,6 +163,32 @@ namespace PowerPointLabs.Utils
                    refShape.Type == candidateShape.Type &&
                    (refShape.Type != MsoShapeType.msoAutoShape ||
                    refShape.AutoShapeType == candidateShape.AutoShapeType);
+        }
+
+        public static ShapeRange GetShapesWhenTypeMatches(PowerPointSlide slide, ShapeRange shapes, MsoShapeType type)
+        {
+            List<Shape> newShapeList = new List<Shape>();
+            foreach (Shape shape in shapes)
+            {
+                if (shape.Type == type)
+                {
+                    newShapeList.Add(shape);
+                }
+            }
+            return slide.ToShapeRange(newShapeList);
+        }
+
+        public static ShapeRange GetShapesWhenTypeNotMatches(PowerPointSlide slide, ShapeRange shapes, MsoShapeType type)
+        {
+            List<Shape> newShapeList = new List<Shape>();
+            foreach (Shape shape in shapes)
+            {
+                if (shape.Type != type)
+                {
+                    newShapeList.Add(shape);
+                }
+            }
+            return slide.ToShapeRange(newShapeList);
         }
 
         public static void MakeShapeViewTimeInvisible(Shape shape, Slide curSlide)


### PR DESCRIPTION
Fixes #1325 , #1306 (similar issues and fixes, dependent helper methods)

The crop can be reverted using PowerPoint's crop