### PR TITLE
PowerPoint still open in background after exiting #1309

### DIFF
--- a/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/FillFormat.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/FillFormat.cs
@@ -35,7 +35,7 @@ namespace PowerPointLabs.SyncLab.ObjectFormats
                     SyncFormatConstants.DisplayImageSize.Height);
             shape.Line.Visible = Microsoft.Office.Core.MsoTriState.msoFalse;
             SyncFormat(formatShape, shape);
-            Bitmap image = new Bitmap(Graphics.ShapeToImage(shape));
+            Bitmap image = new Bitmap(Graphics.ShapeToBitmap(shape));
             shape.Delete();
             return image;
         }

--- a/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/FontColorFormat.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/FontColorFormat.cs
@@ -34,7 +34,7 @@ namespace PowerPointLabs.SyncLab.ObjectFormats
             shape.Fill.ForeColor.RGB = formatShape.TextFrame.TextRange.Font.Color.RGB;
             shape.Fill.BackColor.RGB = formatShape.TextFrame.TextRange.Font.Color.RGB;
             shape.Fill.Solid();
-            Bitmap image = Graphics.ShapeToImage(shape);
+            Bitmap image = Graphics.ShapeToBitmap(shape);
             shape.Delete();
             return image;
         }

--- a/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/FontColorFormat.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/FontColorFormat.cs
@@ -34,7 +34,7 @@ namespace PowerPointLabs.SyncLab.ObjectFormats
             shape.Fill.ForeColor.RGB = formatShape.TextFrame.TextRange.Font.Color.RGB;
             shape.Fill.BackColor.RGB = formatShape.TextFrame.TextRange.Font.Color.RGB;
             shape.Fill.Solid();
-            Bitmap image = new Bitmap(Graphics.ShapeToImage(shape));
+            Bitmap image = Graphics.ShapeToImage(shape);
             shape.Delete();
             return image;
         }

--- a/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/LineArrowFormat.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/LineArrowFormat.cs
@@ -30,7 +30,7 @@ namespace PowerPointLabs.SyncLab.ObjectFormats
                 0, SyncFormatConstants.DisplayImageSize.Height,
                 SyncFormatConstants.DisplayImageSize.Width, 0);
             SyncFormat(formatShape, shape);
-            Bitmap image = new Bitmap(Graphics.ShapeToImage(shape));
+            Bitmap image = Graphics.ShapeToImage(shape);
             shape.Delete();
             return image;
         }

--- a/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/LineArrowFormat.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/LineArrowFormat.cs
@@ -30,7 +30,7 @@ namespace PowerPointLabs.SyncLab.ObjectFormats
                 0, SyncFormatConstants.DisplayImageSize.Height,
                 SyncFormatConstants.DisplayImageSize.Width, 0);
             SyncFormat(formatShape, shape);
-            Bitmap image = Graphics.ShapeToImage(shape);
+            Bitmap image = Graphics.ShapeToBitmap(shape);
             shape.Delete();
             return image;
         }

--- a/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/LineCompoundTypeFormat.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/LineCompoundTypeFormat.cs
@@ -32,7 +32,7 @@ namespace PowerPointLabs.SyncLab.ObjectFormats
             SyncFormat(formatShape, shape);
             shape.Line.ForeColor.RGB = SyncFormatConstants.ColorBlack;
             shape.Line.Weight = SyncFormatConstants.DisplayLineWeight;
-            Bitmap image = new Bitmap(Graphics.ShapeToImage(shape));
+            Bitmap image = Graphics.ShapeToImage(shape);
             shape.Delete();
             return image;
         }

--- a/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/LineCompoundTypeFormat.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/LineCompoundTypeFormat.cs
@@ -32,7 +32,7 @@ namespace PowerPointLabs.SyncLab.ObjectFormats
             SyncFormat(formatShape, shape);
             shape.Line.ForeColor.RGB = SyncFormatConstants.ColorBlack;
             shape.Line.Weight = SyncFormatConstants.DisplayLineWeight;
-            Bitmap image = Graphics.ShapeToImage(shape);
+            Bitmap image = Graphics.ShapeToBitmap(shape);
             shape.Delete();
             return image;
         }

--- a/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/LineDashTypeFormat.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/LineDashTypeFormat.cs
@@ -32,7 +32,7 @@ namespace PowerPointLabs.SyncLab.ObjectFormats
             SyncFormat(formatShape, shape);
             shape.Line.ForeColor.RGB = SyncFormatConstants.ColorBlack;
             shape.Line.Weight = SyncFormatConstants.DisplayLineWeight;
-            Bitmap image = new Bitmap(Graphics.ShapeToImage(shape));
+            Bitmap image = Graphics.ShapeToImage(shape);
             shape.Delete();
             return image;
         }

--- a/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/LineDashTypeFormat.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/LineDashTypeFormat.cs
@@ -32,7 +32,7 @@ namespace PowerPointLabs.SyncLab.ObjectFormats
             SyncFormat(formatShape, shape);
             shape.Line.ForeColor.RGB = SyncFormatConstants.ColorBlack;
             shape.Line.Weight = SyncFormatConstants.DisplayLineWeight;
-            Bitmap image = Graphics.ShapeToImage(shape);
+            Bitmap image = Graphics.ShapeToBitmap(shape);
             shape.Delete();
             return image;
         }

--- a/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/LineFillFormat.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/LineFillFormat.cs
@@ -32,7 +32,7 @@ namespace PowerPointLabs.SyncLab.ObjectFormats
                     SyncFormatConstants.DisplayImageSize.Height);
             shape.Line.Visible = Microsoft.Office.Core.MsoTriState.msoFalse;
             shape.Fill.ForeColor = formatShape.Line.ForeColor;
-            Bitmap image = Graphics.ShapeToImage(shape);
+            Bitmap image = Graphics.ShapeToBitmap(shape);
             shape.Delete();
             return image;
         }

--- a/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/LineFillFormat.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/LineFillFormat.cs
@@ -32,7 +32,7 @@ namespace PowerPointLabs.SyncLab.ObjectFormats
                     SyncFormatConstants.DisplayImageSize.Height);
             shape.Line.Visible = Microsoft.Office.Core.MsoTriState.msoFalse;
             shape.Fill.ForeColor = formatShape.Line.ForeColor;
-            Bitmap image = new Bitmap(Graphics.ShapeToImage(shape));
+            Bitmap image = Graphics.ShapeToImage(shape);
             shape.Delete();
             return image;
         }

--- a/PowerPointLabs/PowerPointLabs/SyncLab/SyncFormatUtil.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/SyncFormatUtil.cs
@@ -15,7 +15,7 @@ namespace PowerPointLabs.SyncLab
 
         public static Shapes GetTemplateShapes()
         {
-            var shapeStorage = SyncLabShapeStorage.GetInstance();
+            var shapeStorage = SyncLabShapeStorage.Instance;
             return shapeStorage.Slides[SyncLabShapeStorage.FormatStorageSlide].Shapes;
         }
 

--- a/PowerPointLabs/PowerPointLabs/SyncLab/SyncFormatUtil.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/SyncFormatUtil.cs
@@ -13,20 +13,10 @@ namespace PowerPointLabs.SyncLab
     {
         #region Display Image Utils
 
-        private static PowerPointPresentation templateShapeStorage = null;
-
         public static Shapes GetTemplateShapes()
         {
-            if (templateShapeStorage == null)
-            {
-                string path = Path.GetTempPath();
-                string name = string.Format(TextCollection.SyncLabStorageFileName,
-                                 DateTime.Now.ToString("yyyyMMddHHmmssffff"));
-                templateShapeStorage = new PowerPointPresentation(path, name);
-                templateShapeStorage.OpenInBackground();
-                templateShapeStorage.AddSlide();
-            }
-            return templateShapeStorage.Slides[0].Shapes;
+            var shapeStorage = SyncLabShapeStorage.GetInstance();
+            return shapeStorage.Slides[SyncLabShapeStorage.FormatStorageSlide].Shapes;
         }
 
         public static Bitmap GetTextDisplay(string text, System.Drawing.Font font, Size imageSize)

--- a/PowerPointLabs/PowerPointLabs/SyncLab/SyncLabShapeStorage.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/SyncLabShapeStorage.cs
@@ -9,13 +9,25 @@ namespace PowerPointLabs.SyncLab
     public class SyncLabShapeStorage : PowerPointPresentation
     {
 
+        public const int FormatStorageSlide = 0;
+
         private int nextKey = 0;
 
-        public SyncLabShapeStorage() : base()
+        private static SyncLabShapeStorage storage;
+
+        public static SyncLabShapeStorage GetInstance()
+        {
+            if (storage == null)
+            {
+                storage = new SyncLabShapeStorage();
+            }
+            return storage;
+        }
+
+        private SyncLabShapeStorage() : base()
         {
             Path = System.IO.Path.GetTempPath();
-            Name = string.Format(TextCollection.SyncLabStorageFileName,
-                                 DateTime.Now.ToString("yyyyMMddHHmmssffff"));
+            Name = TextCollection.SyncLabStorageFileName;
             OpenInBackground();
             ClearShapes();
         }
@@ -87,7 +99,7 @@ namespace PowerPointLabs.SyncLab
                 GetSlide(1).Delete();
             }
             AddSlide();
-            Slides[0].DeleteAllShapes();
+            Slides[FormatStorageSlide].DeleteAllShapes();
         }
     }
 }

--- a/PowerPointLabs/PowerPointLabs/SyncLab/SyncLabShapeStorage.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/SyncLabShapeStorage.cs
@@ -6,22 +6,19 @@ using PowerPointLabs.Models;
 
 namespace PowerPointLabs.SyncLab
 {
-    public class SyncLabShapeStorage : PowerPointPresentation
+    public sealed class SyncLabShapeStorage : PowerPointPresentation
     {
 
         public const int FormatStorageSlide = 0;
 
         private int nextKey = 0;
 
-        private static SyncLabShapeStorage storage;
+        private static readonly Lazy<SyncLabShapeStorage> StorageInstance =
+            new Lazy<SyncLabShapeStorage>(() => new SyncLabShapeStorage());
 
-        public static SyncLabShapeStorage GetInstance()
+        public static SyncLabShapeStorage Instance
         {
-            if (storage == null)
-            {
-                storage = new SyncLabShapeStorage();
-            }
-            return storage;
+            get { return StorageInstance.Value; }
         }
 
         private SyncLabShapeStorage() : base()

--- a/PowerPointLabs/PowerPointLabs/SyncLab/View/SyncPaneWPF.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/View/SyncPaneWPF.xaml.cs
@@ -20,7 +20,7 @@ namespace PowerPointLabs.SyncLab.View
         public SyncPaneWPF()
         {
             InitializeComponent();
-            shapeStorage = new SyncLabShapeStorage();
+            shapeStorage = SyncLabShapeStorage.GetInstance();
             copyImage.Source = System.Windows.Interop.Imaging.CreateBitmapSourceFromHBitmap(
                     Properties.Resources.SyncLabCopyButton.GetHbitmap(),
                     IntPtr.Zero,

--- a/PowerPointLabs/PowerPointLabs/SyncLab/View/SyncPaneWPF.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/View/SyncPaneWPF.xaml.cs
@@ -83,7 +83,7 @@ namespace PowerPointLabs.SyncLab.View
             }
             SyncFormatPaneItem item = new SyncFormatPaneItem(this, shapeKey, shapeStorage, formats);
             item.Text = name;
-            item.Image = new System.Drawing.Bitmap(Utils.Graphics.ShapeToImage(shape));
+            item.Image = new System.Drawing.Bitmap(Utils.Graphics.ShapeToBitmap(shape));
             formatListBox.Items.Insert(0, item);
             formatListBox.SelectedIndex = 0;
         }

--- a/PowerPointLabs/PowerPointLabs/SyncLab/View/SyncPaneWPF.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/View/SyncPaneWPF.xaml.cs
@@ -20,7 +20,7 @@ namespace PowerPointLabs.SyncLab.View
         public SyncPaneWPF()
         {
             InitializeComponent();
-            shapeStorage = SyncLabShapeStorage.GetInstance();
+            shapeStorage = SyncLabShapeStorage.Instance;
             copyImage.Source = System.Windows.Interop.Imaging.CreateBitmapSourceFromHBitmap(
                     Properties.Resources.SyncLabCopyButton.GetHbitmap(),
                     IntPtr.Zero,

--- a/PowerPointLabs/PowerPointLabs/TextCollection.cs
+++ b/PowerPointLabs/PowerPointLabs/TextCollection.cs
@@ -381,9 +381,13 @@
         public const string ResizeLabsTaskPaneTitle = "Resize Lab";
         public const string TimerLabTaskPaneTitle = "Timer Lab";
         public const string SyncLabTaskPanelTitle = "Sync Lab";
-        # endregion
+        #endregion
 
-        # region ShapeGalleryPresentation
+        #region Graphics
+        public const string TemporaryImageStorageFileName = "temp.png";
+        #endregion
+
+        #region ShapeGalleryPresentation
         public const string ShapeCorruptedError =
             "Some shapes in the Shapes Lab were corrupted, but some of the them are recovered.";
         # endregion

--- a/PowerPointLabs/PowerPointLabs/TextCollection.cs
+++ b/PowerPointLabs/PowerPointLabs/TextCollection.cs
@@ -162,7 +162,7 @@
         public const string SyncLabPasteSelectError = "Please select at least one item to apply.";
         public const string SyncLabShapeDeletedError = "Error in loading shape formats. Removing invalid formats from the list.";
         public const string SyncLabCopyError = "Error: Unable to copy selected item.";
-        public const string SyncLabStorageFileName = "Sync Lab - Do not edit - {0}";
+        public const string SyncLabStorageFileName = "Sync Lab - Do not edit";
         public const string SyncLabDefaultFormatName = "Format";
         #endregion
 

--- a/PowerPointLabs/PowerPointLabs/Utils/Graphics.cs
+++ b/PowerPointLabs/PowerPointLabs/Utils/Graphics.cs
@@ -79,15 +79,22 @@ namespace PowerPointLabs.Utils
                               slideHeight, PpExportMode.ppScaleToFit);
         }
 
-        public static Image ShapeToImage(Shape shape)
+        public static Bitmap ShapeToImage(Shape shape)
         {
-            string fileName = "temp_" + DateTime.Now.ToString("yyyyMMddHHmmssffff") + ".png";
+            string fileName = "synclabtemp.png";
             string tempPicPath = Path.Combine(Path.GetTempPath(), fileName);
             ExportShape(shape, tempPicPath);
-            Image tempImage = Image.FromFile(tempPicPath);
-            Image image = (Image)tempImage.Clone(); // free up the original file to be deleted
-            tempImage.Dispose();
-            return image;
+
+            Image image = Image.FromFile(tempPicPath);
+            Bitmap bitmap = new Bitmap(image);
+            image.Dispose(); // free up the original file to be deleted
+
+            FileInfo file = new FileInfo(Path.GetTempPath() + fileName);
+            if (file.Exists)
+            {
+                file.Delete();
+            }
+            return bitmap;
         }
 
         public static void FitShapeToSlide(ref Shape shapeToMove)

--- a/PowerPointLabs/PowerPointLabs/Utils/Graphics.cs
+++ b/PowerPointLabs/PowerPointLabs/Utils/Graphics.cs
@@ -81,13 +81,14 @@ namespace PowerPointLabs.Utils
 
         public static Bitmap ShapeToImage(Shape shape)
         {
-            string fileName = "synclabtemp.png";
+            string fileName = TextCollection.TemporaryImageStorageFileName;
             string tempPicPath = Path.Combine(Path.GetTempPath(), fileName);
             ExportShape(shape, tempPicPath);
 
             Image image = Image.FromFile(tempPicPath);
             Bitmap bitmap = new Bitmap(image);
-            image.Dispose(); // free up the original file to be deleted
+            // free up the original file to be deleted
+            image.Dispose();
 
             FileInfo file = new FileInfo(Path.GetTempPath() + fileName);
             if (file.Exists)

--- a/PowerPointLabs/PowerPointLabs/Utils/Graphics.cs
+++ b/PowerPointLabs/PowerPointLabs/Utils/Graphics.cs
@@ -81,7 +81,7 @@ namespace PowerPointLabs.Utils
                               slideHeight, PpExportMode.ppScaleToFit);
         }
 
-        public static Bitmap ShapeToImage(Shape shape)
+        public static Bitmap ShapeToBitmap(Shape shape)
         {
             // we need a lock here to prevent race conditions on the temporary file
             lock (fileLock)


### PR DESCRIPTION
Fixes #1309 and #1310 (This fix solves both problems)

- Changed SyncLabShapeStorage to become a singleton class. This is to allow other classes to access the same ppt file instead of creating many "temp" copies
- Deletes temp images when done with them, to avoid clogging up user's hard disk