### PR TITLE
Improve FT for sync labs #1341

### DIFF
--- a/PowerPointLabs/PowerPointLabs/FunctionalTestInterface.Impl/Controller/SyncLabController.cs
+++ b/PowerPointLabs/PowerPointLabs/FunctionalTestInterface.Impl/Controller/SyncLabController.cs
@@ -57,11 +57,11 @@ namespace PowerPointLabs.FunctionalTestInterface.Impl.Controller
 
         public void DialogSelectItem(int categoryIndex, int itemIndex)
         {
-            if (_pane != null && _pane.SyncPaneWPF1.dialog != null)
+            if (_pane != null && _pane.SyncPaneWPF1.Dialog != null)
             {
                 UIThreadExecutor.Execute(() =>
                 {
-                    ((_pane.SyncPaneWPF1.dialog.treeView.Items[categoryIndex] as TreeViewItem)
+                    ((_pane.SyncPaneWPF1.Dialog.treeView.Items[categoryIndex] as TreeViewItem)
                         .Items[itemIndex] as SyncFormatDialogItem).IsChecked = true;
                 });
             }
@@ -69,11 +69,11 @@ namespace PowerPointLabs.FunctionalTestInterface.Impl.Controller
 
         public void DialogClickOk()
         {
-            if (_pane != null && _pane.SyncPaneWPF1.dialog != null)
+            if (_pane != null && _pane.SyncPaneWPF1.Dialog != null)
             {
                 UIThreadExecutor.Execute(() =>
                 {
-                    _pane.SyncPaneWPF1.dialog.okButton.RaiseEvent(new RoutedEventArgs(ButtonBase.ClickEvent));
+                    _pane.SyncPaneWPF1.Dialog.okButton.RaiseEvent(new RoutedEventArgs(ButtonBase.ClickEvent));
                 });
             }
             

--- a/PowerPointLabs/PowerPointLabs/FunctionalTestInterface.Impl/Controller/SyncLabController.cs
+++ b/PowerPointLabs/PowerPointLabs/FunctionalTestInterface.Impl/Controller/SyncLabController.cs
@@ -1,9 +1,10 @@
 ﻿using System;
 using System.Windows;
+using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
 
-using Microsoft.Office.Interop.PowerPoint;
 using PowerPointLabs.ActionFramework.Common.Extension;
+using PowerPointLabs.SyncLab;
 using PowerPointLabs.SyncLab.View;
 using TestInterface;
 
@@ -52,6 +53,30 @@ namespace PowerPointLabs.FunctionalTestInterface.Impl.Controller
                             .pasteButton.RaiseEvent(new RoutedEventArgs(ButtonBase.ClickEvent));
                 });
             }
+        }
+
+        public void DialogSelectItem(int categoryIndex, int itemIndex)
+        {
+            if (_pane != null && _pane.SyncPaneWPF1.dialog != null)
+            {
+                UIThreadExecutor.Execute(() =>
+                {
+                    ((_pane.SyncPaneWPF1.dialog.treeView.Items[categoryIndex] as TreeViewItem)
+                        .Items[itemIndex] as SyncFormatDialogItem).IsChecked = true;
+                });
+            }
+        }
+
+        public void DialogClickOk()
+        {
+            if (_pane != null && _pane.SyncPaneWPF1.dialog != null)
+            {
+                UIThreadExecutor.Execute(() =>
+                {
+                    _pane.SyncPaneWPF1.dialog.okButton.RaiseEvent(new RoutedEventArgs(ButtonBase.ClickEvent));
+                });
+            }
+            
         }
 
     }

--- a/PowerPointLabs/PowerPointLabs/SyncLab/View/SyncFormatDialog.xaml
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/View/SyncFormatDialog.xaml
@@ -11,6 +11,6 @@
         <TextBox x:Name="nameTextBox" Height="23" Margin="10,10,10,0" TextWrapping="Wrap" Text="TextBox" VerticalAlignment="Top"/>
         <TreeView x:Name="treeView" Margin="10,38,10,35" HorizontalContentAlignment="Stretch"/>
         <Button x:Name="okButton" IsDefault="True" Content="OK" Margin="0,0,90,10" HorizontalAlignment="Right" Width="75" Height="20" VerticalAlignment="Bottom" Grid.ColumnSpan="2" Click="OkButton_Click" Grid.Row="1"/>
-        <Button x:Name="cancelButton" IsCancel="True" Content="Cancel" Margin="0,0,10,10" HorizontalAlignment="Right" Width="75" Height="20" VerticalAlignment="Bottom" Grid.Column="1" Grid.Row="1"/>
+        <Button x:Name="cancelButton" IsCancel="True" Content="Cancel" Margin="0,0,10,10" HorizontalAlignment="Right" Width="75" Height="20" VerticalAlignment="Bottom" Grid.Column="1" Grid.Row="1" Click="CancelButton_Click"/>
     </Grid>
 </Window>

--- a/PowerPointLabs/PowerPointLabs/SyncLab/View/SyncFormatDialog.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/View/SyncFormatDialog.xaml.cs
@@ -15,28 +15,32 @@ namespace PowerPointLabs.SyncLab.View
     /// </summary>
     public partial class SyncFormatDialog : Window
     {
+        public delegate void OkButtonEventHandler(SyncFormatDialog dialog);
+        public event OkButtonEventHandler OkButtonClick;
+        public string OriginalName { get; private set; }
+        public FormatTreeNode[] Formats { get; private set; }
+        public Shape Shape { get; private set; }
 
-        string originalName;
-        FormatTreeNode[] formats = null;
+        private SyncPaneWPF parent;
 
-        public SyncFormatDialog(Shape shape) : this(shape, shape.Name, SyncFormatConstants.FormatCategories)
-        {
-        }
-
-        public SyncFormatDialog(Shape shape, string formatName, FormatTreeNode[] formats)
+        public SyncFormatDialog(SyncPaneWPF parent, Shape shape, string formatName, FormatTreeNode[] formats)
         {
             InitializeComponent();
+            this.parent = parent;
+            this.Shape = shape;
+
             formatName = formatName.Trim();
             if (SyncFormatUtil.IsValidFormatName(formatName))
             {
-                this.originalName = formatName;
+                OriginalName = formatName;
             }
             else
             {
-                this.originalName = TextCollection.SyncLabDefaultFormatName;
+                OriginalName = TextCollection.SyncLabDefaultFormatName;
             }
-            this.originalName = formatName;
-            this.formats = formats;
+            OriginalName = formatName;
+            ObjectName = OriginalName;
+            this.Formats = formats;
             foreach (FormatTreeNode format in formats)
             {
                 Object treeItem = DialogItemFromFormatTree(shape, format);
@@ -102,7 +106,15 @@ namespace PowerPointLabs.SyncLab.View
 
         private void OkButton_Click(object sender, RoutedEventArgs e)
         {
-            this.DialogResult = true;
+            OkButtonClick(this);
+            parent.dialog = null;
+            this.Close();
+        }
+
+        private void CancelButton_Click(object sender, RoutedEventArgs e)
+        {
+            parent.dialog = null;
+            this.Close();
         }
 
         private void ScrollToTop()
@@ -110,14 +122,6 @@ namespace PowerPointLabs.SyncLab.View
             if (!treeView.Items.IsEmpty)
             {
                 (treeView.Items[0] as TreeViewItem).BringIntoView();
-            }
-        }
-
-        public FormatTreeNode[] Formats
-        {
-            get
-            {
-                return formats;
             }
         }
 
@@ -131,7 +135,7 @@ namespace PowerPointLabs.SyncLab.View
                 }
                 else
                 {
-                    return this.originalName;
+                    return this.OriginalName;
                 }
             }
             set

--- a/PowerPointLabs/PowerPointLabs/SyncLab/View/SyncFormatDialog.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/View/SyncFormatDialog.xaml.cs
@@ -107,13 +107,13 @@ namespace PowerPointLabs.SyncLab.View
         private void OkButton_Click(object sender, RoutedEventArgs e)
         {
             OkButtonClick(this);
-            parent.dialog = null;
+            parent.Dialog = null;
             this.Close();
         }
 
         private void CancelButton_Click(object sender, RoutedEventArgs e)
         {
-            parent.dialog = null;
+            parent.Dialog = null;
             this.Close();
         }
 

--- a/PowerPointLabs/PowerPointLabs/SyncLab/View/SyncFormatPaneItem.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/View/SyncFormatPaneItem.xaml.cs
@@ -135,15 +135,7 @@ namespace PowerPointLabs.SyncLab.View
         private void EditButton_Click(object sender, RoutedEventArgs e)
         {
             Shape shape = shapeStorage.GetShape(shapeKey);
-            SyncFormatDialog dialog = new SyncFormatDialog(shape, Text, formats);
-            dialog.ObjectName = this.Text;
-            bool? result = dialog.ShowDialog();
-            if (!result.HasValue || !(bool)result)
-            {
-                return;
-            }
-            this.formats = dialog.Formats;
-            this.Text = dialog.ObjectName;
+            Subscribe(parent.ShowDialog(shape, this.Text, formats));
         }
 
         private void DeleteButton_Click(object sender, RoutedEventArgs e)
@@ -154,6 +146,18 @@ namespace PowerPointLabs.SyncLab.View
         private void OnMouseDoubleClick(object sender, MouseButtonEventArgs e)
         {
             ApplyFormatToSelected();
+        }
+
+        private void Subscribe(SyncFormatDialog eventDialog)
+        {
+            eventDialog.OkButtonClick += new SyncFormatDialog.OkButtonEventHandler(EditFormat);
+        }
+
+        private void EditFormat(SyncFormatDialog eventDialog)
+        {
+            this.formats = eventDialog.Formats;
+            this.Text = eventDialog.ObjectName;
+            eventDialog.OkButtonClick += new SyncFormatDialog.OkButtonEventHandler(EditFormat);
         }
 
         private void ApplyFormatToSelected()

--- a/PowerPointLabs/PowerPointLabs/SyncLab/View/SyncFormatPaneItem.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/View/SyncFormatPaneItem.xaml.cs
@@ -157,7 +157,7 @@ namespace PowerPointLabs.SyncLab.View
         {
             this.formats = eventDialog.Formats;
             this.Text = eventDialog.ObjectName;
-            eventDialog.OkButtonClick += new SyncFormatDialog.OkButtonEventHandler(EditFormat);
+            eventDialog.OkButtonClick -= new SyncFormatDialog.OkButtonEventHandler(EditFormat);
         }
 
         private void ApplyFormatToSelected()

--- a/PowerPointLabs/PowerPointLabs/SyncLab/View/SyncPaneWPF.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/View/SyncPaneWPF.xaml.cs
@@ -15,7 +15,7 @@ namespace PowerPointLabs.SyncLab.View
     /// </summary>
     public partial class SyncPaneWPF : UserControl
     {
-        public SyncFormatDialog dialog;
+        public SyncFormatDialog Dialog { get; set; }
         private readonly SyncLabShapeStorage shapeStorage;
 
         public SyncPaneWPF()
@@ -46,9 +46,9 @@ namespace PowerPointLabs.SyncLab.View
         public void SyncPane_Closing(Object sender, EventArgs e)
         {
             shapeStorage.Close();
-            if (dialog != null)
+            if (Dialog != null)
             {
-                dialog.Close();
+                Dialog.Close();
             }
         }
 
@@ -83,14 +83,14 @@ namespace PowerPointLabs.SyncLab.View
 
         public SyncFormatDialog ShowDialog(Shape shape, String formatName, FormatTreeNode[] formats)
         {
-            if (dialog != null)
+            if (Dialog != null)
             {
-                dialog.Close();
+                Dialog.Close();
             }
 
-            dialog = new SyncFormatDialog(this, shape, formatName, formats);
-            dialog.Show();
-            return dialog;
+            Dialog = new SyncFormatDialog(this, shape, formatName, formats);
+            Dialog.Show();
+            return Dialog;
         }
         #endregion
 
@@ -163,7 +163,7 @@ namespace PowerPointLabs.SyncLab.View
             formatListBox.Items.Insert(0, item);
             formatListBox.SelectedIndex = 0;
             eventDialog.OkButtonClick -= new SyncFormatDialog.OkButtonEventHandler(AddFormatToList);
-            dialog = null;
+            Dialog = null;
         }
 
         private void ApplyFormats(FormatTreeNode[] nodes, Shape formatShape, ShapeRange newShapes)

--- a/PowerPointLabs/Test/FunctionalTest/SyncLabTest.cs
+++ b/PowerPointLabs/Test/FunctionalTest/SyncLabTest.cs
@@ -33,13 +33,13 @@ namespace Test.FunctionalTest
             var syncLab = PplFeatures.SyncLab;
             syncLab.OpenPane();
 
-            TestCopyDialog(syncLab);
-            TestPasteDialog(syncLab);
+            TestSync(syncLab);
+            TestErrorDialogs(syncLab);
         }
 
-        private void TestCopyDialog(ISyncLabController syncLab)
+        private void TestErrorDialogs(ISyncLabController syncLab)
         {
-            var actualSlide = PpOperations.SelectSlide(4);
+            PpOperations.SelectSlide(4);
 
             // no selection
             MessageBoxUtil.ExpectMessageBoxWillPopUp(TextCollection.SyncLabErrorDialogTitle,
@@ -51,29 +51,30 @@ namespace Test.FunctionalTest
             MessageBoxUtil.ExpectMessageBoxWillPopUp(TextCollection.SyncLabErrorDialogTitle,
                 "Please select one item to copy.", syncLab.Copy, "Ok");
 
-            // copy successful
-            PpOperations.SelectShape(CopyFromShape);
-            new Task(() =>
-            {
-                ThreadUtil.WaitFor(1000);
-                SendKeys.SendWait("{ENTER}");
-            }).Start();
+            // copy blank item for the paste error dialog test
+            PpOperations.SelectShape(CopyFromShape);    
             syncLab.Copy();
-        }
+            syncLab.DialogClickOk();
 
-        private void TestPasteDialog(ISyncLabController syncLab)
-        {
             PpOperations.SelectSlide(5);
             MessageBoxUtil.ExpectMessageBoxWillPopUp(TextCollection.SyncLabErrorDialogTitle,
                 "Please select at least one item to apply.", () => syncLab.Sync(0), "Ok");
         }
 
-        # region Helper methods
-        // mouse drag & drop from Control to Shape to apply color
-        private void FindDialog()
+        private void TestSync(ISyncLabController syncLab)
         {
-            
+            PpOperations.SelectSlide(4);
+            PpOperations.SelectShape(CopyFromShape);
+
+            syncLab.Copy();
+            syncLab.DialogSelectItem(3, 2);
+            syncLab.DialogClickOk();
+
+            syncLab.Sync(0);
+
+            var actualSlide = PpOperations.SelectSlide(4);
+            var expectedSlide = PpOperations.SelectSlide(5);
+            SlideUtil.IsSameLooking(expectedSlide, actualSlide);
         }
-        # endregion
     }
 }

--- a/PowerPointLabs/Test/UnitTest/SyncLab/BaseSyncLabTest.cs
+++ b/PowerPointLabs/Test/UnitTest/SyncLab/BaseSyncLabTest.cs
@@ -7,7 +7,7 @@ using PowerPoint = Microsoft.Office.Interop.PowerPoint;
 namespace Test.UnitTest.SyncLab
 {
     [TestClass]
-    public class BaseSyncLabTest :BaseUnitTest
+    public class BaseSyncLabTest : BaseUnitTest
     {
         private readonly Dictionary<string, string> _originalShapeName = new Dictionary<string, string>();
 

--- a/PowerPointLabs/TestInterface/ISyncLabController.cs
+++ b/PowerPointLabs/TestInterface/ISyncLabController.cs
@@ -9,5 +9,9 @@ namespace TestInterface
         void Copy();
 
         void Sync(int index);
+
+        void DialogSelectItem(int categoryIndex, int itemIndex);
+
+        void DialogClickOk();
     }
 }


### PR DESCRIPTION
Improved tests for Sync Lab FT.

- Get the controller for Dialog by saving the current open dialog in SyncPaneWPF and exposing it to the FT Controller
- Change SyncFormatDialog to use EventListeners so that it does not block execution. If user attempts to open multiple dialogs, the dialogs will replace each other. This way, only 1 dialog maximum can be open at any time
- FT tests for the error messages and tests sync once. This is because we want to test if users can use all the buttons. Each individual sync test is done in UT