### PR TITLE
Paste Lab: Grouped shapes with same name disappear when "Replace With Clipboard" #1358 

### DIFF
--- a/PowerPointLabs/PowerPointLabs/PasteLab/ReplaceWithClipboard.cs
+++ b/PowerPointLabs/PowerPointLabs/PasteLab/ReplaceWithClipboard.cs
@@ -28,7 +28,7 @@ namespace PowerPointLabs.PasteLab
                 for (int i = 1; i <= selectedGroupCount; i++)
                 {
                     Shape shape = selectedGroup.GroupItems.Range(i)[1];
-                    if (shape.Name.Equals(selectedShape.Name))
+                    if (shape == selectedShape)
                     {
                         continue;
                     }


### PR DESCRIPTION
Fixes #1358 