### PR TITLE
Positions Lab rotate causes PowerPoint to crash #1371

### DIFF
--- a/PowerPointLabs/PowerPointLabs/PositionsLab/PositionsPaneWPF.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/PositionsLab/PositionsPaneWPF.xaml.cs
@@ -358,8 +358,17 @@ namespace PowerPointLabs.PositionsLab
 
         void _leftMouseUpListener_Rotation(object sender, SysMouseEventInfo e)
         {
-            _dispatcherTimer.Stop();
-            _selectedRange.Select();
+            try
+            {
+                _dispatcherTimer.Stop();
+                _selectedRange.Select();
+            }
+            catch (Exception ex)
+            {
+                rotationButton.IsChecked = false;
+                duplicateRotationButton.IsChecked = false;
+                Logger.LogException(ex, "Rotation");
+            }
         }
 
         void _leftMouseDownListener_Rotation(object sender, SysMouseEventInfo e)


### PR DESCRIPTION
Fixes #1371 

Catch the exception that causes the crash and toggle both buttons to false.
We can treat it as the user stops the rotate operation as the shapes are deleted