### PR TITLE
Paste Into Group has exception after undo #1370 

### DIFF
--- a/PowerPointLabs/PowerPointLabs/ActionFramework/Action/PasteLab/PasteAtCursorPositionActionHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/Action/PasteLab/PasteAtCursorPositionActionHandler.cs
@@ -18,7 +18,7 @@ namespace PowerPointLabs.ActionFramework.Action.PasteLab
     class PasteAtCursorPositionActionHandler : PasteLabActionHandler
     {
         protected override ShapeRange ExecutePasteAction(string ribbonId, PowerPointPresentation presentation, PowerPointSlide slide,
-                                                        Selection selection, ShapeRange pastingShapes)
+                                                        ShapeRange selectedShapes, ShapeRange selectedChildShapes)
         {
             PPMouse.Coordinates coordinates = PPMouse.RightClickCoordinates;
             DocumentWindow activeWindow = this.GetCurrentWindow();
@@ -34,7 +34,8 @@ namespace PowerPointLabs.ActionFramework.Action.PasteLab
                 positionY = ((coordinates.Y - activeWindow.PointsToScreenPixelsY(0)) / yref) * 100;
             }
 
-            return PasteAtPosition.Execute(presentation, slide, pastingShapes, positionX, positionY);
+            ShapeRange pastingShapes = slide.Shapes.Paste();
+            return PasteAtCursorPosition.Execute(presentation, slide, pastingShapes, positionX, positionY);
         }
     }
 }

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/Action/PasteLab/PasteAtOriginalPositionActionHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/Action/PasteLab/PasteAtOriginalPositionActionHandler.cs
@@ -2,6 +2,7 @@
 
 using PowerPointLabs.ActionFramework.Common.Attribute;
 using PowerPointLabs.Models;
+using PowerPointLabs.PasteLab;
 
 namespace PowerPointLabs.ActionFramework.Action.PasteLab
 {
@@ -14,8 +15,12 @@ namespace PowerPointLabs.ActionFramework.Action.PasteLab
     class PasteAtOriginalPositionActionHandler : PasteLabActionHandler
     {
         protected override ShapeRange ExecutePasteAction(string ribbonId, PowerPointPresentation presentation, PowerPointSlide slide,
-                                                        Selection selection, ShapeRange pastingShapes)
+                                                        ShapeRange selectedShapes, ShapeRange selectedChildShapes)
         {
+            PowerPointSlide tempSlide = presentation.AddSlide(index: slide.Index);
+            ShapeRange tempPastingShapes = tempSlide.Shapes.Paste();
+            ShapeRange pastingShapes = slide.CopyShapesToSlide(tempPastingShapes);
+            tempSlide.Delete();
             return pastingShapes;
         }
     }

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/Action/PasteLab/PasteIntoGroupActionHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/Action/PasteLab/PasteIntoGroupActionHandler.cs
@@ -12,23 +12,22 @@ namespace PowerPointLabs.ActionFramework.Action.PasteLab
     class PasteIntoGroupActionHandler : PasteLabActionHandler
     {
         protected override ShapeRange ExecutePasteAction(string ribbonId, PowerPointPresentation presentation, PowerPointSlide slide,
-                                                        Selection selection, ShapeRange pastingShapes)
+                                                        ShapeRange selectedShapes, ShapeRange selectedChildShapes)
         {
-            if (!IsSelectionShapes(selection))
+            if (selectedShapes.Count <= 0)
             {
                 Logger.Log("PasteIntoGroup failed. No valid shape is selected.");
-                pastingShapes.Delete();
                 return null;
             }
 
-            if (selection.ShapeRange.Count == 1 && !Graphics.IsAGroup(selection.ShapeRange[1]))
+            if (selectedShapes.Count == 1 && !Graphics.IsAGroup(selectedShapes[1]))
             {
                 Logger.Log("PasteIntoGroup failed. Selection is only a single shape.");
-                pastingShapes.Delete();
                 return null;
             }
 
-            return PasteIntoGroup.Execute(presentation, slide, selection.ShapeRange, pastingShapes);
+            ShapeRange pastingShapes = slide.Shapes.Paste();
+            return PasteIntoGroup.Execute(presentation, slide, selectedShapes, pastingShapes);
         }
     }
 }

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/Action/PasteLab/PasteLabActionHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/Action/PasteLab/PasteLabActionHandler.cs
@@ -12,8 +12,8 @@ namespace PowerPointLabs.ActionFramework.Action.PasteLab
 {
     abstract class PasteLabActionHandler : BaseUtilActionHandler
     {
-        private static readonly string SelectOrderTagName = "SelectOrderTagName";
-        private static readonly string SelectChildOrderTagName = "SelectChildOrderTagName";
+        private static readonly string SelectOrder = "PasteLabSelectOrder";
+        private static readonly string SelectChildOrder = "PasteLabSelectChildOrder";
 
         // Sealed method: Subclasses should override ExecutePasteAction instead
         protected sealed override void ExecuteAction(string ribbonId)
@@ -43,7 +43,7 @@ namespace PowerPointLabs.ActionFramework.Action.PasteLab
                 ShapeRange selectedShapes = selection.ShapeRange;
                 for (int i = 1; i <= selectedShapes.Count; i++)
                 {
-                    selectedShapes[i].Tags.Add(SelectOrderTagName, i.ToString());
+                    selectedShapes[i].Tags.Add(SelectOrder, i.ToString());
                 }
 
                 ShapeRange selectedChildShapes = null;
@@ -52,7 +52,7 @@ namespace PowerPointLabs.ActionFramework.Action.PasteLab
                     selectedChildShapes = selection.ChildShapeRange;
                     for (int i = 1; i <= selectedChildShapes.Count; i++)
                     {
-                        selectedChildShapes[i].Tags.Add(SelectChildOrderTagName, i.ToString());
+                        selectedChildShapes[i].Tags.Add(SelectChildOrder, i.ToString());
                     }
                 }
 
@@ -70,26 +70,26 @@ namespace PowerPointLabs.ActionFramework.Action.PasteLab
                         for (int i = 1; i <= shape.GroupItems.Count; i++)
                         {
                             Shape child = shape.GroupItems.Range(i)[1];
-                            if (!child.Tags[SelectChildOrderTagName].Equals(""))
+                            if (!child.Tags[SelectChildOrder].Equals(""))
                             {
                                 correctedChildShapeList.Add(child);
                             }
                         }
                     }
                 }
-                correctedShapeList.Sort((sh1, sh2) => int.Parse(sh2.Tags[SelectOrderTagName]) - int.Parse(sh1.Tags[SelectOrderTagName]));
-                correctedChildShapeList.Sort((sh1, sh2) => int.Parse(sh2.Tags[SelectChildOrderTagName]) - int.Parse(sh1.Tags[SelectChildOrderTagName]));
+                correctedShapeList.Sort((sh1, sh2) => int.Parse(sh1.Tags[SelectOrder]) - int.Parse(sh2.Tags[SelectOrder]));
+                correctedChildShapeList.Sort((sh1, sh2) => int.Parse(sh1.Tags[SelectChildOrder]) - int.Parse(sh2.Tags[SelectChildOrder]));
                 passedSelectedShapes = slide.ToShapeRange(correctedShapeList);
                 passedSelectedChildShapes = slide.ToShapeRange(correctedChildShapeList);
 
                 // Remove the tags after they have been used
                 foreach (Shape shape in passedSelectedShapes)
                 {
-                    shape.Tags.Delete(SelectOrderTagName);
+                    shape.Tags.Delete(SelectOrder);
                 }
                 foreach (Shape shape in passedSelectedChildShapes)
                 {
-                    shape.Tags.Delete(SelectChildOrderTagName);
+                    shape.Tags.Delete(SelectChildOrder);
                 }
 
                 // Revert clipboard

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/Action/PasteLab/PasteLabActionHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/Action/PasteLab/PasteLabActionHandler.cs
@@ -12,8 +12,8 @@ namespace PowerPointLabs.ActionFramework.Action.PasteLab
 {
     abstract class PasteLabActionHandler : BaseUtilActionHandler
     {
-        private static readonly string SelectOrder = "PasteLabSelectOrder";
-        private static readonly string SelectChildOrder = "PasteLabSelectChildOrder";
+        private static readonly string SelectOrderTagName = "PasteLabSelectOrder";
+        private static readonly string SelectChildOrderTagName = "PasteLabSelectChildOrder";
 
         // Sealed method: Subclasses should override ExecutePasteAction instead
         protected sealed override void ExecuteAction(string ribbonId)
@@ -43,7 +43,7 @@ namespace PowerPointLabs.ActionFramework.Action.PasteLab
                 ShapeRange selectedShapes = selection.ShapeRange;
                 for (int i = 1; i <= selectedShapes.Count; i++)
                 {
-                    selectedShapes[i].Tags.Add(SelectOrder, i.ToString());
+                    selectedShapes[i].Tags.Add(SelectOrderTagName, i.ToString());
                 }
 
                 ShapeRange selectedChildShapes = null;
@@ -52,7 +52,7 @@ namespace PowerPointLabs.ActionFramework.Action.PasteLab
                     selectedChildShapes = selection.ChildShapeRange;
                     for (int i = 1; i <= selectedChildShapes.Count; i++)
                     {
-                        selectedChildShapes[i].Tags.Add(SelectChildOrder, i.ToString());
+                        selectedChildShapes[i].Tags.Add(SelectChildOrderTagName, i.ToString());
                     }
                 }
 
@@ -65,31 +65,21 @@ namespace PowerPointLabs.ActionFramework.Action.PasteLab
                 foreach (Shape shape in correctedShapes)
                 {
                     correctedShapeList.Add(shape);
-                    if (Graphics.IsAGroup(shape))
-                    {
-                        for (int i = 1; i <= shape.GroupItems.Count; i++)
-                        {
-                            Shape child = shape.GroupItems.Range(i)[1];
-                            if (!child.Tags[SelectChildOrder].Equals(""))
-                            {
-                                correctedChildShapeList.Add(child);
-                            }
-                        }
-                    }
+                    correctedChildShapeList.AddRange(Graphics.GetChildrenWithNonEmptyTag(shape, SelectChildOrderTagName));
                 }
-                correctedShapeList.Sort((sh1, sh2) => int.Parse(sh1.Tags[SelectOrder]) - int.Parse(sh2.Tags[SelectOrder]));
-                correctedChildShapeList.Sort((sh1, sh2) => int.Parse(sh1.Tags[SelectChildOrder]) - int.Parse(sh2.Tags[SelectChildOrder]));
+                correctedShapeList.Sort((sh1, sh2) => int.Parse(sh1.Tags[SelectOrderTagName]) - int.Parse(sh2.Tags[SelectOrderTagName]));
+                correctedChildShapeList.Sort((sh1, sh2) => int.Parse(sh1.Tags[SelectChildOrderTagName]) - int.Parse(sh2.Tags[SelectChildOrderTagName]));
                 passedSelectedShapes = slide.ToShapeRange(correctedShapeList);
                 passedSelectedChildShapes = slide.ToShapeRange(correctedChildShapeList);
 
                 // Remove the tags after they have been used
                 foreach (Shape shape in passedSelectedShapes)
                 {
-                    shape.Tags.Delete(SelectOrder);
+                    shape.Tags.Delete(SelectOrderTagName);
                 }
                 foreach (Shape shape in passedSelectedChildShapes)
                 {
-                    shape.Tags.Delete(SelectChildOrder);
+                    shape.Tags.Delete(SelectChildOrderTagName);
                 }
 
                 // Revert clipboard

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/Action/PasteLab/PasteLabActionHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/Action/PasteLab/PasteLabActionHandler.cs
@@ -73,14 +73,8 @@ namespace PowerPointLabs.ActionFramework.Action.PasteLab
                 passedSelectedChildShapes = slide.ToShapeRange(correctedChildShapeList);
 
                 // Remove the tags after they have been used
-                foreach (Shape shape in passedSelectedShapes)
-                {
-                    shape.Tags.Delete(SelectOrderTagName);
-                }
-                foreach (Shape shape in passedSelectedChildShapes)
-                {
-                    shape.Tags.Delete(SelectChildOrderTagName);
-                }
+                Graphics.DeleteTagFromShapes(passedSelectedShapes, SelectOrderTagName);
+                Graphics.DeleteTagFromShapes(passedSelectedChildShapes, SelectChildOrderTagName);
 
                 // Revert clipboard
                 tempClipboardShapes.Copy();

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/Action/PasteLab/PasteToFillSlideActionHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/Action/PasteLab/PasteToFillSlideActionHandler.cs
@@ -15,8 +15,9 @@ namespace PowerPointLabs.ActionFramework.Action.PasteLab
     class PasteToFillSlideActionHandler : PasteLabActionHandler
     {
         protected override ShapeRange ExecutePasteAction(string ribbonId, PowerPointPresentation presentation, PowerPointSlide slide,
-                                                        Selection selection, ShapeRange pastingShapes)
+                                                        ShapeRange selectedShapes, ShapeRange selectedChildShapes)
         {
+            ShapeRange pastingShapes = slide.Shapes.Paste();
             PasteToFillSlide.Execute(slide, pastingShapes, presentation.SlideWidth, presentation.SlideHeight);
             return null;
         }

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/Action/PasteLab/ReplaceWithClipboardActionHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/Action/PasteLab/ReplaceWithClipboardActionHandler.cs
@@ -12,16 +12,16 @@ namespace PowerPointLabs.ActionFramework.Action.PasteLab
     class ReplaceWithClipboardActionHandler : PasteLabActionHandler
     {
         protected override ShapeRange ExecutePasteAction(string ribbonId, PowerPointPresentation presentation, PowerPointSlide slide,
-                                                        Selection selection, ShapeRange pastingShapes)
+                                                        ShapeRange selectedShapes, ShapeRange selectedChildShapes)
         {
-            if (!IsSelectionShapes(selection))
+            if (selectedShapes.Count <= 0)
             {
                 MessageBox.Show("Please select at least one shape.", "Error");
-                pastingShapes.Delete();
                 return null;
             }
-
-            return ReplaceWithClipboard.Execute(presentation, slide, selection, pastingShapes);
+            
+            ShapeRange pastingShapes = slide.Shapes.Paste();
+            return ReplaceWithClipboard.Execute(presentation, slide, selectedShapes, selectedChildShapes, pastingShapes);
         }
     }
 }

--- a/PowerPointLabs/PowerPointLabs/MiscFeatures/MergeIntoGroup.cs
+++ b/PowerPointLabs/PowerPointLabs/MiscFeatures/MergeIntoGroup.cs
@@ -17,17 +17,16 @@ namespace PowerPointLabs.MiscFeatures
             // Temporarily save the animation
             Shape tempShapeForAnimation = slide.Shapes.AddShape(Microsoft.Office.Core.MsoAutoShapeType.msoShapeRectangle, 0, 0, 1, 1);
             slide.TransferAnimation(firstSelectedShape, tempShapeForAnimation);
-
-            // Merge into one group
-            if (Graphics.IsCorrupted(firstSelectedShape))
-            {
-                firstSelectedShape = Graphics.CorruptionCorrection(firstSelectedShape, slide);
-            }
-
+            
+            // Ungroup first selection and add into list
             string groupName = firstSelectedShape.Name;
             bool isFirstSelectionGroup = false;
             List<Shape> newShapesList = new List<Shape>();
 
+            if (Graphics.IsCorrupted(firstSelectedShape))
+            {
+                firstSelectedShape = Graphics.CorruptionCorrection(firstSelectedShape, slide);
+            }
             if (Graphics.IsAGroup(firstSelectedShape))
             {
                 isFirstSelectionGroup = true;
@@ -42,6 +41,7 @@ namespace PowerPointLabs.MiscFeatures
                 newShapesList.Add(firstSelectedShape);
             }
             
+            // Add all other selections into list
             for (int i = 2; i <= selectedShapes.Count; i++)
             {
                 Shape shape = selectedShapes[i];
@@ -52,6 +52,7 @@ namespace PowerPointLabs.MiscFeatures
                 newShapesList.Add(shape);
             }
 
+            // Create the new group from the list
             selectedShapes = slide.ToShapeRange(newShapesList);
             Shape selectedGroup = selectedShapes.Group();
             selectedGroup.Name = isFirstSelectionGroup ? groupName : selectedGroup.Name;

--- a/PowerPointLabs/PowerPointLabs/Models/PowerPointSlide.cs
+++ b/PowerPointLabs/PowerPointLabs/Models/PowerPointSlide.cs
@@ -556,9 +556,14 @@ namespace PowerPointLabs.Models
             {
                 shape.Copy();
                 var newShape = _slide.Shapes.Paste()[1];
+
                 newShape.Left = shape.Left;
                 newShape.Top = shape.Top;
                 Graphics.MoveZToJustInFront(newShape, shape);
+
+                DeleteShapeAnimations(newShape);
+                TransferAnimation(shape, newShape);
+
                 return newShape;
             }
             catch (COMException)

--- a/PowerPointLabs/PowerPointLabs/Models/PowerPointSlide.cs
+++ b/PowerPointLabs/PowerPointLabs/Models/PowerPointSlide.cs
@@ -557,6 +557,7 @@ namespace PowerPointLabs.Models
                 shape.Copy();
                 var newShape = _slide.Shapes.Paste()[1];
 
+                newShape.Name = shape.Name;
                 newShape.Left = shape.Left;
                 newShape.Top = shape.Top;
                 Graphics.MoveZToJustInFront(newShape, shape);

--- a/PowerPointLabs/PowerPointLabs/PasteLab/PasteAtCursorPosition.cs
+++ b/PowerPointLabs/PowerPointLabs/PasteLab/PasteAtCursorPosition.cs
@@ -4,7 +4,7 @@ using PowerPointLabs.Models;
 
 namespace PowerPointLabs.PasteLab
 {
-    static internal class PasteAtPosition
+    static internal class PasteAtCursorPosition
     {
         public static ShapeRange Execute(PowerPointPresentation presentation, PowerPointSlide slide, 
                                         ShapeRange pastingShapes, float positionX, float positionY)

--- a/PowerPointLabs/PowerPointLabs/PasteLab/PasteIntoGroup.cs
+++ b/PowerPointLabs/PowerPointLabs/PasteLab/PasteIntoGroup.cs
@@ -15,6 +15,7 @@ namespace PowerPointLabs.PasteLab
         {
             Shape firstSelectedShape = selectedShapes[1];
             Shape tempShapeForAnimation = slide.Shapes.AddShape(Microsoft.Office.Core.MsoAutoShapeType.msoShapeRectangle, 0, 0, 1, 1);
+            slide.TransferAnimation(firstSelectedShape, tempShapeForAnimation);
             Graphics.MoveZToJustInFront(tempShapeForAnimation, firstSelectedShape);
 
             string originalGroupName = null;
@@ -57,8 +58,8 @@ namespace PowerPointLabs.PasteLab
             ShapeRange shapesToGroup = slide.ToShapeRange(shapesToGroupList);
             Shape resultGroup = shapesToGroup.Group();
             resultGroup.Name = originalGroupName ?? resultGroup.Name;
-            Graphics.MoveZToJustInFront(resultGroup, tempShapeForAnimation);
             slide.TransferAnimation(tempShapeForAnimation, resultGroup);
+            Graphics.MoveZToJustInFront(resultGroup, tempShapeForAnimation);
 
             tempShapeForAnimation.Delete();
             return slide.ToShapeRange(resultGroup);

--- a/PowerPointLabs/PowerPointLabs/PasteLab/PasteIntoGroup.cs
+++ b/PowerPointLabs/PowerPointLabs/PasteLab/PasteIntoGroup.cs
@@ -14,53 +14,54 @@ namespace PowerPointLabs.PasteLab
                                     float? posLeft = null, float? posTop = null)
         {
             Shape firstSelectedShape = selectedShapes[1];
-            ShapeRange newSelectedShapes = slide.CloneShapeFromRange(selectedShapes, firstSelectedShape);
+            Shape tempShapeForAnimation = slide.Shapes.AddShape(Microsoft.Office.Core.MsoAutoShapeType.msoShapeRectangle, 0, 0, 1, 1);
+            Graphics.MoveZToJustInFront(tempShapeForAnimation, firstSelectedShape);
 
             string originalGroupName = null;
-            if (newSelectedShapes.Count == 1 && Graphics.IsAGroup(firstSelectedShape))
+            if (selectedShapes.Count == 1 && Graphics.IsAGroup(firstSelectedShape))
             {
                 originalGroupName = firstSelectedShape.Name;
-                newSelectedShapes = newSelectedShapes[1].Ungroup();
+                selectedShapes = firstSelectedShape.Ungroup();
             }
 
             // Calculate the center to paste at if not specified
-            float selectionLeft = newSelectedShapes[1].Left;
-            float selectionTop = newSelectedShapes[1].Top;
-            float selectionWidth = newSelectedShapes[1].Width;
-            float selectionHeight = newSelectedShapes[1].Height;
-            if (newSelectedShapes.Count > 1)
+            float selectionLeft = selectedShapes[1].Left;
+            float selectionTop = selectedShapes[1].Top;
+            float selectionWidth = selectedShapes[1].Width;
+            float selectionHeight = selectedShapes[1].Height;
+            if (selectedShapes.Count > 1)
             {
-                Shape selectionGroup = newSelectedShapes.Group();
+                Shape selectionGroup = selectedShapes.Group();
                 selectionLeft = selectionGroup.Left;
                 selectionTop = selectionGroup.Top;
                 selectionWidth = selectionGroup.Width;
                 selectionHeight = selectionGroup.Height;
-                newSelectedShapes.Ungroup();
+                selectionGroup.Ungroup();
             }
-
             posLeft = posLeft ?? (selectionLeft + (selectionWidth - pastingShapes[1].Width) / 2);
             posTop = posTop ?? (selectionTop + (selectionHeight - pastingShapes[1].Height) / 2);
-            ShapeRange pastedShapes = PasteAtPosition.Execute(presentation, slide, pastingShapes, posLeft.Value, posTop.Value);
+
+            ShapeRange pastedShapes = PasteAtCursorPosition.Execute(presentation, slide, pastingShapes, posLeft.Value, posTop.Value);
             pastedShapes.ZOrder(Microsoft.Office.Core.MsoZOrderCmd.msoBringToFront);
 
-            List<Shape> newGroupShapeList = new List<Shape>();
-            for (int i = 1; i <= newSelectedShapes.Count; i++)
+            List<Shape> shapesToGroupList = new List<Shape>();
+            for (int i = 1; i <= selectedShapes.Count; i++)
             {
-                newGroupShapeList.Add(newSelectedShapes[i]);
+                shapesToGroupList.Add(selectedShapes[i]);
             }
             for (int i = 1; i <= pastingShapes.Count; i++)
             {
-                newGroupShapeList.Add(pastingShapes[i]);
+                shapesToGroupList.Add(pastingShapes[i]);
             }
 
-            ShapeRange newShapeRange = slide.ToShapeRange(newGroupShapeList);
-            Shape newGroup = newShapeRange.Group();
-            newGroup.Name = originalGroupName ?? newGroup.Name;
-            Graphics.MoveZToJustInFront(newGroup, firstSelectedShape);
-            slide.TransferAnimation(firstSelectedShape, newGroup);
+            ShapeRange shapesToGroup = slide.ToShapeRange(shapesToGroupList);
+            Shape resultGroup = shapesToGroup.Group();
+            resultGroup.Name = originalGroupName ?? resultGroup.Name;
+            Graphics.MoveZToJustInFront(resultGroup, tempShapeForAnimation);
+            slide.TransferAnimation(tempShapeForAnimation, resultGroup);
 
-            firstSelectedShape.Delete();
-            return slide.ToShapeRange(newGroup);
+            tempShapeForAnimation.Delete();
+            return slide.ToShapeRange(resultGroup);
         }
     }
 }

--- a/PowerPointLabs/PowerPointLabs/PasteLab/ReplaceWithClipboard.cs
+++ b/PowerPointLabs/PowerPointLabs/PasteLab/ReplaceWithClipboard.cs
@@ -37,6 +37,7 @@ namespace PowerPointLabs.PasteLab
             {
                 Shape selectedGroup = selectedShapes[1];
                 Shape selectedChildShape = selectedChildShapes[1];
+                string originalGroupName = selectedGroup.Name;
 
                 float posLeft = selectedChildShape.Left;
                 float posTop = selectedChildShape.Top;
@@ -62,6 +63,7 @@ namespace PowerPointLabs.PasteLab
                 selectedChildShape.Delete();
 
                 ShapeRange result = PasteIntoGroup.Execute(presentation, slide, shapesToGroup, pastingShapes, posLeft, posTop);
+                result[1].Name = originalGroupName;
                 slide.TransferAnimation(tempShapeForAnimation, result[1]);
 
                 tempShapeForAnimation.Delete();

--- a/PowerPointLabs/PowerPointLabs/PasteLab/ReplaceWithClipboard.cs
+++ b/PowerPointLabs/PowerPointLabs/PasteLab/ReplaceWithClipboard.cs
@@ -10,50 +10,13 @@ namespace PowerPointLabs.PasteLab
 {
     static internal class ReplaceWithClipboard
     {
-        public static ShapeRange Execute(PowerPointPresentation presentation, PowerPointSlide slide, Selection selection, ShapeRange pastingShapes)
+        public static ShapeRange Execute(PowerPointPresentation presentation, PowerPointSlide slide, 
+                                        ShapeRange selectedShapes, ShapeRange selectedChildShapes, ShapeRange pastingShapes)
         {
-            // Replacing shape within a group
-            if (selection.HasChildShapeRange)
+            // Replacing individual shape
+            if (selectedChildShapes.Count == 0)
             {
-                string uid = DateTime.Now.ToString("ddMMyyyyHHmmssfff");
-
-                Shape selectedGroup = selection.ShapeRange[1];
-                Shape selectedChildShape = selection.ChildShapeRange[1];
-                selectedChildShape.Tags.Add(PasteLabConstants.ReplaceWithClipboardShapeId, uid);
-
-                float posLeft = selectedChildShape.Left;
-                float posTop = selectedChildShape.Top;
-
-                Shape tempShapeForAnimation = slide.Shapes.AddShape(Microsoft.Office.Core.MsoAutoShapeType.msoShapeRectangle, 0, 0, 1, 1);
-                slide.TransferAnimation(selectedGroup, tempShapeForAnimation);
-
-                selectedGroup = Graphics.CorruptionCorrection(selectedGroup, slide);
-
-                List<Shape> selectedGroupShapeList = new List<Shape>();
-                int selectedGroupCount = selectedGroup.GroupItems.Count;
-                for (int i = 1; i <= selectedGroupCount; i++)
-                {
-                    Shape shape = selectedGroup.GroupItems.Range(i)[1];
-                    if (shape.Tags[PasteLabConstants.ReplaceWithClipboardShapeId].Equals(uid))
-                    {
-                        continue;
-                    }
-                    selectedGroupShapeList.Add(shape);
-                }
-
-                ShapeRange shapesToGroup = slide.ToShapeRange(selectedGroupShapeList);
-                shapesToGroup = slide.CopyShapesToSlide(shapesToGroup);
-                selectedGroup.Delete();
-
-                ShapeRange result = PasteIntoGroup.Execute(presentation, slide, shapesToGroup, pastingShapes, posLeft, posTop);
-                slide.TransferAnimation(tempShapeForAnimation, result[1]);
-
-                tempShapeForAnimation.Delete();
-                return result;
-            }
-            else // replacing individual shape
-            {
-                Shape selectedShape = selection.ShapeRange[1];
+                Shape selectedShape = selectedShapes[1];
 
                 Shape pastingShape = pastingShapes[1];
                 if (pastingShapes.Count > 1)
@@ -68,6 +31,41 @@ namespace PowerPointLabs.PasteLab
                 selectedShape.Delete();
 
                 return slide.ToShapeRange(pastingShape);
+            }
+            // Replacing shape within a group
+            else
+            {
+                Shape selectedGroup = selectedShapes[1];
+                Shape selectedChildShape = selectedChildShapes[1];
+
+                float posLeft = selectedChildShape.Left;
+                float posTop = selectedChildShape.Top;
+
+                Shape tempShapeForAnimation = slide.Shapes.AddShape(Microsoft.Office.Core.MsoAutoShapeType.msoShapeRectangle, 0, 0, 1, 1);
+                slide.TransferAnimation(selectedGroup, tempShapeForAnimation);
+
+                // Get all siblings of selected child
+                List<Shape> selectedGroupShapeList = new List<Shape>();
+                for (int i = 1; i <= selectedGroup.GroupItems.Count; i++)
+                {
+                    Shape shape = selectedGroup.GroupItems.Range(i)[1];
+                    if (shape == selectedChildShape)
+                    {
+                        continue;
+                    }
+                    selectedGroupShapeList.Add(shape);
+                }
+
+                // Remove selected child since it is being replaced
+                ShapeRange shapesToGroup = slide.ToShapeRange(selectedGroupShapeList);
+                selectedGroup.Ungroup();
+                selectedChildShape.Delete();
+
+                ShapeRange result = PasteIntoGroup.Execute(presentation, slide, shapesToGroup, pastingShapes, posLeft, posTop);
+                slide.TransferAnimation(tempShapeForAnimation, result[1]);
+
+                tempShapeForAnimation.Delete();
+                return result;
             }
         }
     }

--- a/PowerPointLabs/PowerPointLabs/PowerPointLabs.csproj
+++ b/PowerPointLabs/PowerPointLabs/PowerPointLabs.csproj
@@ -548,7 +548,7 @@
     <Compile Include="FunctionalTestInterface.Impl\PowerPointOperations.cs" />
     <Compile Include="FunctionalTestInterface.Impl\SlideData.cs" />
     <Compile Include="MiscFeatures\MergeIntoGroup.cs" />
-    <Compile Include="PasteLab\PasteAtPosition.cs" />
+    <Compile Include="PasteLab\PasteAtCursorPosition.cs" />
     <Compile Include="PasteLab\PasteIntoGroup.cs" />
     <Compile Include="PasteLab\PasteLabConstants.cs" />
     <Compile Include="PasteLab\PasteToFillSlide.cs" />

--- a/PowerPointLabs/PowerPointLabs/Utils/Graphics.cs
+++ b/PowerPointLabs/PowerPointLabs/Utils/Graphics.cs
@@ -223,6 +223,26 @@ namespace PowerPointLabs.Utils
             return slide.ToShapeRange(newShapeList);
         }
 
+        public static List<Shape> GetChildrenWithNonEmptyTag(Shape shape, string tagName)
+        {
+            List<Shape> result = new List<Shape>();
+
+            if (!IsAGroup(shape))
+            {
+                return result;
+            }
+            
+            for (int i = 1; i <= shape.GroupItems.Count; i++)
+            {
+                Shape child = shape.GroupItems.Range(i)[1];
+                if (!child.Tags[tagName].Equals(""))
+                {
+                    result.Add(child);
+                }
+            }
+            return result;
+        }
+
         public static void MakeShapeViewTimeInvisible(Shape shape, Slide curSlide)
         {
             var sequence = curSlide.TimeLine.MainSequence;

--- a/PowerPointLabs/PowerPointLabs/Utils/Graphics.cs
+++ b/PowerPointLabs/PowerPointLabs/Utils/Graphics.cs
@@ -51,8 +51,20 @@ namespace PowerPointLabs.Utils
         public static Shape CorruptionCorrection(Shape shape, PowerPointSlide ownerSlide)
         {
             // in case of random corruption of shape, cut-paste a shape before using its property
-            shape.Cut();
-            return ownerSlide.Shapes.Paste()[1];
+            Shape correctedShape = ownerSlide.CopyShapeToSlide(shape);
+            shape.Delete();
+            return correctedShape;
+        }
+
+        public static ShapeRange CorruptionCorrection(ShapeRange shapes, PowerPointSlide ownerSlide)
+        {
+            List<Shape> correctedShapeList = new List<Shape>();
+            foreach (Shape shape in shapes)
+            {
+                Shape correctedShape = CorruptionCorrection(shape, ownerSlide);
+                correctedShapeList.Add(correctedShape);
+            }
+            return ownerSlide.ToShapeRange(correctedShapeList);
         }
 
         public static void ExportShape(Shape shape, string exportPath)

--- a/PowerPointLabs/PowerPointLabs/Utils/Graphics.cs
+++ b/PowerPointLabs/PowerPointLabs/Utils/Graphics.cs
@@ -620,6 +620,14 @@ namespace PowerPointLabs.Utils
             shape.Rotation += angle;
         }
 
+        public static void DeleteTagFromShapes(ShapeRange shapes, string tagName)
+        {
+            foreach (Shape shape in shapes)
+            {
+                shape.Tags.Delete(tagName);
+            }
+        }
+
         // TODO: This could be an extension method of shape.
         public static string GetText(Shape shape)
         {


### PR DESCRIPTION
Fixes #1370 

Paste Lab exceptions that are caused by corrupted shapes after undo action is now fixed.
Needs to be tested on PPT 2010/2013. PPT 2016 has less exception occurrences. 

Special thanks to @IanTeo for the solution!