### PR TITLE
Double-clicking hidden shape crashes PowerPoint #1378 

### DIFF
--- a/PowerPointLabs/PowerPointLabs/ThisAddIn.cs
+++ b/PowerPointLabs/PowerPointLabs/ThisAddIn.cs
@@ -1486,7 +1486,8 @@ namespace PowerPointLabs
                     overlappingShapeZIndex = shape.ZOrderPosition;
                 }
             }
-            if (overlappingShape != null)
+            if (overlappingShape != null &&
+                overlappingShape.Visible == Office.MsoTriState.msoTrue)
             {
                 overlappingShape.Select();
             }


### PR DESCRIPTION
Fixes #1378 