### PR TITLE
Sync Lab: Deleting shape during copy causes exception #1387

### DIFF
--- a/PowerPointLabs/PowerPointLabs/SyncLab/View/SyncFormatDialog.xaml
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/View/SyncFormatDialog.xaml
@@ -11,6 +11,6 @@
         <TextBox x:Name="nameTextBox" Height="23" Margin="10,10,10,0" TextWrapping="Wrap" Text="TextBox" VerticalAlignment="Top"/>
         <TreeView x:Name="treeView" Margin="10,38,10,35" HorizontalContentAlignment="Stretch"/>
         <Button x:Name="okButton" IsDefault="True" Content="OK" Margin="0,0,90,10" HorizontalAlignment="Right" Width="75" Height="20" VerticalAlignment="Bottom" Grid.ColumnSpan="2" Click="OkButton_Click" Grid.Row="1"/>
-        <Button x:Name="cancelButton" IsCancel="True" Content="Cancel" Margin="0,0,10,10" HorizontalAlignment="Right" Width="75" Height="20" VerticalAlignment="Bottom" Grid.Column="1" Grid.Row="1" Click="CancelButton_Click"/>
+        <Button x:Name="cancelButton" IsCancel="True" Content="Cancel" Margin="0,0,10,10" HorizontalAlignment="Right" Width="75" Height="20" VerticalAlignment="Bottom" Grid.Column="1" Grid.Row="1"/>
     </Grid>
 </Window>

--- a/PowerPointLabs/PowerPointLabs/SyncLab/View/SyncFormatDialog.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/View/SyncFormatDialog.xaml.cs
@@ -15,19 +15,17 @@ namespace PowerPointLabs.SyncLab.View
     /// </summary>
     public partial class SyncFormatDialog : Window
     {
-        public delegate void OkButtonEventHandler(SyncFormatDialog dialog);
-        public event OkButtonEventHandler OkButtonClick;
         public FormatTreeNode[] Formats { get; private set; }
-        public Shape Shape { get; private set; }
 
         private string originalName;
-        private SyncPaneWPF parent;
 
-        public SyncFormatDialog(SyncPaneWPF parent, Shape shape, string formatName, FormatTreeNode[] formats)
+        public SyncFormatDialog(Shape shape) : this(shape, shape.Name, SyncFormatConstants.FormatCategories)
+        {
+        }
+
+        public SyncFormatDialog(Shape shape, string formatName, FormatTreeNode[] formats)
         {
             InitializeComponent();
-            this.parent = parent;
-            this.Shape = shape;
 
             formatName = formatName.Trim();
             if (SyncFormatUtil.IsValidFormatName(formatName))
@@ -106,15 +104,7 @@ namespace PowerPointLabs.SyncLab.View
 
         private void OkButton_Click(object sender, RoutedEventArgs e)
         {
-            OkButtonClick(this);
-            parent.Dialog = null;
-            this.Close();
-        }
-
-        private void CancelButton_Click(object sender, RoutedEventArgs e)
-        {
-            parent.Dialog = null;
-            this.Close();
+            this.DialogResult = true;
         }
 
         private void ScrollToTop()

--- a/PowerPointLabs/PowerPointLabs/SyncLab/View/SyncFormatPaneItem.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/View/SyncFormatPaneItem.xaml.cs
@@ -135,7 +135,16 @@ namespace PowerPointLabs.SyncLab.View
         private void EditButton_Click(object sender, RoutedEventArgs e)
         {
             Shape shape = shapeStorage.GetShape(shapeKey);
-            Subscribe(parent.ShowDialog(shape, this.Text, formats));
+            parent.Dialog = new SyncFormatDialog(shape, Text, formats);
+            parent.Dialog.ObjectName = this.Text;
+            bool? result = parent.Dialog.ShowDialog();
+            if (!result.HasValue || !(bool)result)
+            {
+                return;
+            }
+            this.formats = parent.Dialog.Formats;
+            this.Text = parent.Dialog.ObjectName;
+            parent.Dialog = null;
         }
 
         private void DeleteButton_Click(object sender, RoutedEventArgs e)
@@ -146,18 +155,6 @@ namespace PowerPointLabs.SyncLab.View
         private void OnMouseDoubleClick(object sender, MouseButtonEventArgs e)
         {
             ApplyFormatToSelected();
-        }
-
-        private void Subscribe(SyncFormatDialog eventDialog)
-        {
-            eventDialog.OkButtonClick += new SyncFormatDialog.OkButtonEventHandler(EditFormat);
-        }
-
-        private void EditFormat(SyncFormatDialog eventDialog)
-        {
-            this.formats = eventDialog.Formats;
-            this.Text = eventDialog.ObjectName;
-            eventDialog.OkButtonClick -= new SyncFormatDialog.OkButtonEventHandler(EditFormat);
         }
 
         private void ApplyFormatToSelected()

--- a/PowerPointLabs/PowerPointLabs/SyncLab/View/SyncPaneWPF.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/View/SyncPaneWPF.xaml.cs
@@ -144,7 +144,6 @@ namespace PowerPointLabs.SyncLab.View
             item.Image = new System.Drawing.Bitmap(Utils.Graphics.ShapeToBitmap(shape));
             formatListBox.Items.Insert(0, item);
             formatListBox.SelectedIndex = 0;
-            Dialog = null;
         }
 
         private void ApplyFormats(FormatTreeNode[] nodes, Shape formatShape, ShapeRange newShapes)
@@ -218,6 +217,7 @@ namespace PowerPointLabs.SyncLab.View
                 return;
             }
             AddFormatToList(shape, Dialog.ObjectName, Dialog.Formats);
+            Dialog = null;
         }
         #endregion
 

--- a/PowerPointLabs/PowerPointLabs/SyncLab/View/SyncPaneWPF.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/View/SyncPaneWPF.xaml.cs
@@ -75,23 +75,6 @@ namespace PowerPointLabs.SyncLab.View
         {
             (formatListBox.Items[index] as SyncFormatPaneItem).Text = text;
         }
-
-        public SyncFormatDialog ShowDialog(Shape shape)
-        {
-            return ShowDialog(shape, shape.Name, SyncFormatConstants.FormatCategories);
-        }
-
-        public SyncFormatDialog ShowDialog(Shape shape, String formatName, FormatTreeNode[] formats)
-        {
-            if (Dialog != null)
-            {
-                Dialog.Close();
-            }
-
-            Dialog = new SyncFormatDialog(this, shape, formatName, formats);
-            Dialog.Show();
-            return Dialog;
-        }
         #endregion
 
         #region Sync API
@@ -148,17 +131,8 @@ namespace PowerPointLabs.SyncLab.View
             ApplyFormats(nodes, formatShape, shapes);
         }
 
-        private void Subscribe(SyncFormatDialog eventDialog)
+        private void AddFormatToList(Shape shape, string name, FormatTreeNode[] formats)
         {
-            eventDialog.OkButtonClick += new SyncFormatDialog.OkButtonEventHandler(AddFormatToList);
-        }
-
-        private void AddFormatToList(SyncFormatDialog eventDialog)
-        {
-            Shape shape = eventDialog.Shape;
-            string name = eventDialog.ObjectName;
-            FormatTreeNode[] formats = eventDialog.Formats;
-
             string shapeKey = CopyShape(shape);
             if (shapeKey == null)
             {
@@ -170,7 +144,6 @@ namespace PowerPointLabs.SyncLab.View
             item.Image = new System.Drawing.Bitmap(Utils.Graphics.ShapeToBitmap(shape));
             formatListBox.Items.Insert(0, item);
             formatListBox.SelectedIndex = 0;
-            eventDialog.OkButtonClick -= new SyncFormatDialog.OkButtonEventHandler(AddFormatToList);
             Dialog = null;
         }
 
@@ -237,7 +210,14 @@ namespace PowerPointLabs.SyncLab.View
                 MessageBox.Show(TextCollection.SyncLabCopySelectError, TextCollection.SyncLabErrorDialogTitle);
                 return;
             }
-            Subscribe(ShowDialog(shape));
+            Dialog = new SyncFormatDialog(shape);
+            Dialog.ObjectName = shape.Name;
+            bool? result = Dialog.ShowDialog();
+            if (!result.HasValue || !(bool)result)
+            {
+                return;
+            }
+            AddFormatToList(shape, Dialog.ObjectName, Dialog.Formats);
         }
         #endregion
 

--- a/PowerPointLabs/Test/FunctionalTest/SyncLabTest.cs
+++ b/PowerPointLabs/Test/FunctionalTest/SyncLabTest.cs
@@ -15,6 +15,10 @@ namespace Test.FunctionalTest
     [TestClass]
     public class SyncLabTest : BaseFunctionalTest
     {
+        private const int MaxRetry = 5;
+        private const int CategoryIndexPosition = 0;
+        private const int FormatItemIndexPosition = 1;
+
         private const int OriginalSyncGroupToShapeSlideNo = 36;
         private const int ExpectedSyncGroupToShapeSlideNo = 37;
         private const int OriginalSyncShapeToGroupSlideNo = 38;
@@ -64,8 +68,7 @@ namespace Test.FunctionalTest
 
             // copy blank item for the paste error dialog test
             PpOperations.SelectShape(Line);    
-            syncLab.Copy();
-            syncLab.DialogClickOk();
+            CopyStyle(syncLab);
 
             // no selection sync
             PpOperations.SelectSlide(ExpectedSyncShapeToGroupSlideNo);
@@ -84,9 +87,7 @@ namespace Test.FunctionalTest
             PpOperations.SelectSlide(originalSlide);
             PpOperations.SelectShape(fromShape);
 
-            syncLab.Copy();
-            syncLab.DialogSelectItem(1, 0);
-            syncLab.DialogClickOk();
+            CopyStyle(syncLab, 1, 0);
 
             PpOperations.SelectShape(toShape);
             syncLab.Sync(0);
@@ -102,6 +103,36 @@ namespace Test.FunctionalTest
             var expectedShape = PpOperations.SelectShape(shapeToCheck)[1];
             SlideUtil.IsSameLooking(expectedSlide, actualSlide);
             SlideUtil.IsSameShape(expectedShape, actualShape);
+        }
+
+        private void CopyStyle(ISyncLabController syncLab)
+        {
+            new Task(() =>
+            {
+                ThreadUtil.WaitFor(1000);
+                syncLab.DialogClickOk();
+            }).Start();
+            syncLab.Copy();
+        }
+
+        private void CopyStyle(ISyncLabController syncLab, int categoryPosition, int itemPosition)
+        {
+            int[,] dialogItems = new int[,] { { categoryPosition, itemPosition } };
+            CopyStyle(syncLab, dialogItems);
+        }
+
+        private void CopyStyle(ISyncLabController syncLab, int[,] dialogItems)
+        {
+            new Task(() =>
+            {
+                ThreadUtil.WaitFor(1000);
+                for (int i = 0; i < dialogItems.GetLength(0); i++)
+                {
+                    syncLab.DialogSelectItem(dialogItems[i, CategoryIndexPosition], dialogItems[i, FormatItemIndexPosition]);
+                }
+                syncLab.DialogClickOk();
+            }).Start();
+            syncLab.Copy();
         }
     }
 }


### PR DESCRIPTION
Fixes #1387 

To fix the problem, I switched the dialog back to a modal dialog (as it makes more sense, the user should not edit the slide before finishing his selection to copy). This also prevents other problems such as the user editing the style of the shape while the copy dialog is open.

But this means that the tests are blocked by the dialog when it opens. To solve this problem, we run the method in a separate thread similar to how MessageBoxUtil's ExpectMessageBoxWillPopUp() handles it.