### PR TITLE
Color picker magnifier stuck after alt-tab #1399 

### DIFF
--- a/PowerPointLabs/PowerPointLabs/ColorPicker/Magnifier.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/ColorPicker/Magnifier.xaml.cs
@@ -67,9 +67,10 @@ namespace PowerPointLabs.ColorPicker
                 // Make window click-through
                 int extendedStyle = Native.GetWindowLong(hwndParent.Handle, (int)Native.WindowLong.GWL_EXSTYLE);
                 Native.SetWindowLong(hwndParent.Handle, (int)Native.WindowLong.GWL_EXSTYLE,
-                                                extendedStyle |
-                                                (int)Native.ExtendedWindowStyles.WS_EX_TRANSPARENT |
-                                                (int)Native.ExtendedWindowStyles.WS_EX_LAYERED);
+                                    extendedStyle |
+                                    (int)Native.ExtendedWindowStyles.WS_EX_TRANSPARENT |
+                                    (int)Native.ExtendedWindowStyles.WS_EX_LAYERED |
+                                    (int)Native.ExtendedWindowStyles.WS_EX_TOOLWINDOW);
                 Native.SetWindowLong(hwndParent.Handle, (int)Native.WindowLong.GWL_STYLE, (int)Native.WindowStyles.WS_POPUP);
 
                 // Must be transparent for Magnification to work

--- a/PowerPointLabs/PowerPointLabs/ColorPicker/MagnifierOverlay.xaml
+++ b/PowerPointLabs/PowerPointLabs/ColorPicker/MagnifierOverlay.xaml
@@ -11,7 +11,9 @@
              WindowStartupLocation="Manual"
              WindowStyle="None"
              Width="200" 
-             Height="200">
+             Height="200" 
+             Loaded="MagnifierOverlay_Loaded" 
+             Deactivated="MagnifierMainWindow_Deactivated">
     <Window.Background>
         <SolidColorBrush Color="White" Opacity="0"/>
     </Window.Background>

--- a/PowerPointLabs/PowerPointLabs/ColorPicker/MagnifierOverlay.xaml
+++ b/PowerPointLabs/PowerPointLabs/ColorPicker/MagnifierOverlay.xaml
@@ -13,7 +13,7 @@
              Width="200" 
              Height="200" 
              Loaded="MagnifierOverlay_Loaded" 
-             Deactivated="MagnifierMainWindow_Deactivated">
+             Deactivated="MagnifierOverlay_Deactivated">
     <Window.Background>
         <SolidColorBrush Color="White" Opacity="0"/>
     </Window.Background>

--- a/PowerPointLabs/PowerPointLabs/ColorPicker/MagnifierOverlay.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/ColorPicker/MagnifierOverlay.xaml.cs
@@ -1,4 +1,7 @@
 ﻿using System.Windows;
+using System.Windows.Interop;
+
+using PPExtraEventHelper;
 
 namespace PowerPointLabs.ColorPicker
 {
@@ -11,5 +14,21 @@ namespace PowerPointLabs.ColorPicker
         {
             InitializeComponent();
         }
+
+        private void MagnifierOverlay_Loaded(object sender, RoutedEventArgs e)
+        {
+            WindowInteropHelper wndHelper = new WindowInteropHelper(this);
+            int extendedStyle = Native.GetWindowLong(wndHelper.Handle, (int)Native.WindowLong.GWL_EXSTYLE);
+
+            Native.SetWindowLong(wndHelper.Handle, (int)Native.WindowLong.GWL_EXSTYLE,
+                                extendedStyle | (int)Native.ExtendedWindowStyles.WS_EX_TOOLWINDOW);
+        }
+
+        private void MagnifierMainWindow_Deactivated(object sender, System.EventArgs e)
+        {
+            PPMouse.StopAllActions();
+        }
     }
+
+
 }

--- a/PowerPointLabs/PowerPointLabs/ColorPicker/MagnifierOverlay.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/ColorPicker/MagnifierOverlay.xaml.cs
@@ -24,7 +24,7 @@ namespace PowerPointLabs.ColorPicker
                                 extendedStyle | (int)Native.ExtendedWindowStyles.WS_EX_TOOLWINDOW);
         }
 
-        private void MagnifierMainWindow_Deactivated(object sender, System.EventArgs e)
+        private void MagnifierOverlay_Deactivated(object sender, System.EventArgs e)
         {
             PPMouse.StopAllActions();
         }

--- a/PowerPointLabs/PowerPointLabs/PPMouse.cs
+++ b/PowerPointLabs/PowerPointLabs/PPMouse.cs
@@ -75,6 +75,11 @@ namespace PPExtraEventHelper
             }
         }
 
+        public static void StopAllActions()
+        {
+            LeftButtonUp?.Invoke();
+        }
+
         private static bool IsHookSuccessful()
         {
             return hook != 0;

--- a/PowerPointLabs/PowerPointLabs/ThisAddIn.cs
+++ b/PowerPointLabs/PowerPointLabs/ThisAddIn.cs
@@ -834,8 +834,8 @@ namespace PowerPointLabs
 
             _deactivatedPresFullName = pres.FullName;
 
-            // in this case, we are closing the last client presentation, therefore we
-            // we can close the shape gallery
+            // in this case, we are closing the last client presentation,
+            // therefore we can close the shape gallery
             if (_isClosing &&
                 Application.Presentations.Count == 2 &&
                 ShapePresentation != null &&


### PR DESCRIPTION
Fixes #1399 

Color picker magnifier should be dismissed once alt-tab is pressed, or when PPT is deactivated.