### PR TITLE
Timer slider z-order behind line markers #1407 

### DIFF
--- a/PowerPointLabs/PowerPointLabs/TimerLab/TimerLabPaneWPF.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/TimerLab/TimerLabPaneWPF.xaml.cs
@@ -403,6 +403,7 @@ namespace PowerPointLabs.TimerLab
             {
                 ReformMissingComponents();
                 RecreateMarkers();
+                AdjustZOrder();
                 UpdateSliderPosition();
                 UpdateSliderAnimationDuration();
             }


### PR DESCRIPTION
Fixes #1407 

When changing duration, the slider will no longer go behind the line markers.