### PR TITLE
Blur/Recolor Remainder does not work on groups #1414 

### DIFF
--- a/PowerPointLabs/PowerPointLabs/Models/PowerPointBgEffectSlide.cs
+++ b/PowerPointLabs/PowerPointLabs/Models/PowerPointBgEffectSlide.cs
@@ -8,6 +8,7 @@ using ImageProcessor.Imaging.Filters;
 using Microsoft.Office.Interop.PowerPoint;
 
 using PowerPointLabs.CropLab;
+using PowerPointLabs.Utils;
 
 using Core = Microsoft.Office.Core;
 
@@ -150,7 +151,19 @@ namespace PowerPointLabs.Models
         {
             foreach (Shape shape in shapeRange)
             {
-                shape.SoftEdge.Radius = Math.Min(Math.Min(shape.Width, shape.Height) * 0.15f, 10f);
+                float softEdgeRadius = Math.Min(Math.Min(shape.Width, shape.Height) * 0.15f, 10f);
+                if (Graphics.IsAGroup(shape))
+                {
+                    for (int i = 1; i <= shape.GroupItems.Count; i++)
+                    {
+                        Shape child = shape.GroupItems.Range(i)[1];
+                        child.SoftEdge.Radius = softEdgeRadius;
+                    }
+                }
+                else
+                {
+                    shape.SoftEdge.Radius = softEdgeRadius;
+                }
             }
 
             var croppedShape = CropToShape.Crop(FromSlideFactory(refSlide), shapeRange, handleError: false);

--- a/PowerPointLabs/Test/FunctionalTest/EffectsLabTest.cs
+++ b/PowerPointLabs/Test/FunctionalTest/EffectsLabTest.cs
@@ -17,14 +17,16 @@ namespace Test.FunctionalTest
         public void FT_EffectsLabTest()
         {
             PplFeatures.BlurrinessOverlay("EffectsLabBlurBackground", true);
-            TestRemainderEffect(46, PplFeatures.SepiaBackgroundEffect);
-            TestRemainderEffect(43, PplFeatures.BlurBackgroundEffect);
-            TestRemainderEffect(40, PplFeatures.BlurBackgroundEffect);
+            TestRemainderEffect(52, PplFeatures.SepiaBackgroundEffect);
+            TestRemainderEffect(49, PplFeatures.BlurBackgroundEffect);
+            TestRemainderEffect(46, PplFeatures.BlurBackgroundEffect);
             PplFeatures.BlurrinessOverlay("EffectsLabBlurRemainder", true);
-            TestRemainderEffect(37, PplFeatures.BlurRemainderEffect);
-            TestRemainderEffect(34, PplFeatures.SepiaBackgroundEffect);
+            TestRemainderEffect(43, PplFeatures.BlurRemainderEffect);
+            TestRemainderEffect(40, PplFeatures.BlurRemainderEffect);
+            TestRemainderEffect(37, PplFeatures.SepiaBackgroundEffect);
             PplFeatures.BlurrinessOverlay("EffectsLabBlurBackground", false);
-            TestRemainderEffect(31, PplFeatures.BlurBackgroundEffect);
+            TestRemainderEffect(34, PplFeatures.BlurBackgroundEffect);
+            TestRemainderEffect(31, PplFeatures.SepiaRemainderEffect);
             TestRemainderEffect(28, PplFeatures.SepiaRemainderEffect);
             TestRemainderEffect(25, PplFeatures.GothamRemainderEffect);
             TestRemainderEffect(22, PplFeatures.BlackAndWhiteBackgroundEffect);


### PR DESCRIPTION
Fixes #1414 

Also added grouped shapes for Blur/Recolor Remainder into EffectsLab.pptx functional tests.