### PR TITLE
Closing PowerPoint stops sync lab from working #1430

### DIFF
--- a/PowerPointLabs/PowerPointLabs/SyncLab/SyncLabShapeStorage.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/SyncLabShapeStorage.cs
@@ -13,12 +13,12 @@ namespace PowerPointLabs.SyncLab
 
         private int nextKey = 0;
 
-        private static Lazy<SyncLabShapeStorage> storageInstance =
+        private static readonly Lazy<SyncLabShapeStorage> StorageInstance =
             new Lazy<SyncLabShapeStorage>(() => new SyncLabShapeStorage());
 
         public static SyncLabShapeStorage Instance
         {
-            get { return storageInstance.Value; }
+            get { return StorageInstance.Value; }
         }
 
         private SyncLabShapeStorage() : base()

--- a/PowerPointLabs/PowerPointLabs/SyncLab/SyncLabShapeStorage.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/SyncLabShapeStorage.cs
@@ -13,12 +13,12 @@ namespace PowerPointLabs.SyncLab
 
         private int nextKey = 0;
 
-        private static readonly Lazy<SyncLabShapeStorage> StorageInstance =
+        private static Lazy<SyncLabShapeStorage> storageInstance =
             new Lazy<SyncLabShapeStorage>(() => new SyncLabShapeStorage());
 
         public static SyncLabShapeStorage Instance
         {
-            get { return StorageInstance.Value; }
+            get { return storageInstance.Value; }
         }
 
         private SyncLabShapeStorage() : base()
@@ -27,6 +27,12 @@ namespace PowerPointLabs.SyncLab
             Name = TextCollection.SyncLabStorageFileName;
             OpenInBackground();
             ClearShapes();
+        }
+
+        public override void Close()
+        {
+            storageInstance = new Lazy<SyncLabShapeStorage>(() => new SyncLabShapeStorage());
+            base.Close();
         }
 
         // Saves shape in storage

--- a/PowerPointLabs/PowerPointLabs/SyncLab/SyncLabShapeStorage.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/SyncLabShapeStorage.cs
@@ -29,12 +29,6 @@ namespace PowerPointLabs.SyncLab
             ClearShapes();
         }
 
-        public override void Close()
-        {
-            storageInstance = new Lazy<SyncLabShapeStorage>(() => new SyncLabShapeStorage());
-            base.Close();
-        }
-
         // Saves shape in storage
         // Returns a key to find the shape by,
         // or null if the shape cannot be copied

--- a/PowerPointLabs/PowerPointLabs/SyncLab/View/SyncPaneWPF.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/View/SyncPaneWPF.xaml.cs
@@ -45,7 +45,11 @@ namespace PowerPointLabs.SyncLab.View
 
         public void SyncPane_Closing(Object sender, EventArgs e)
         {
-            shapeStorage.Close();
+            if (this.GetAddIn().Application.Presentations.Count == 1)
+            {
+                shapeStorage.Close();
+            }
+
             if (Dialog != null)
             {
                 Dialog.Close();

--- a/PowerPointLabs/PowerPointLabs/SyncLab/View/SyncPaneWPF.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/View/SyncPaneWPF.xaml.cs
@@ -45,7 +45,7 @@ namespace PowerPointLabs.SyncLab.View
 
         public void SyncPane_Closing(Object sender, EventArgs e)
         {
-            if (this.GetAddIn().Application.Presentations.Count == 1)
+            if (this.GetAddIn().Application.Presentations.Count == 2)
             {
                 shapeStorage.Close();
             }


### PR DESCRIPTION
Fixes #1430 

- Override Close() method for PowerPointPresentation
- Reinitialize the Lazy Type upon Close()