### PR TITLE
Sync Line Color gives wrong color #1421

### DIFF
--- a/PowerPointLabs/PowerPointLabs/SyncLab/SyncFormatConstants.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/SyncFormatConstants.cs
@@ -44,13 +44,13 @@ namespace PowerPointLabs.SyncLab.ObjectFormats
                             new FormatTreeNode("Color", new Format(typeof(FillFormat))),
                             new FormatTreeNode("Transparency", new Format(typeof(FillTransparencyFormat)))),
                     new FormatTreeNode(
-                            "Line",                        
-                            new FormatTreeNode("Color", new Format(typeof(LineFillFormat))),
-                            new FormatTreeNode("Transparency", new Format(typeof(LineTransparencyFormat))),
+                            "Line",
                             new FormatTreeNode("Width", new Format(typeof(LineWeightFormat))),
                             new FormatTreeNode("Compound Type", new Format(typeof(LineCompoundTypeFormat))),
                             new FormatTreeNode("Dash Type", new Format(typeof(LineDashTypeFormat))),
-                            new FormatTreeNode("Arrow", new Format(typeof(LineArrowFormat)))),
+                            new FormatTreeNode("Arrow", new Format(typeof(LineArrowFormat))),
+                            new FormatTreeNode("Color", new Format(typeof(LineFillFormat))),
+                            new FormatTreeNode("Transparency", new Format(typeof(LineTransparencyFormat)))),
                     new FormatTreeNode(
                             "Size/Position",
                             new FormatTreeNode("Width", new Format(typeof(PositionWidthFormat))),


### PR DESCRIPTION
The problem was in the order of the sync format constants.
Weight, Compound Type and Dash Type will create a line for the picture if it does not exist, but color and transparency will not. By changing the order, if the user selects weight/compound type/dash type with fill, the former will be applied first, creating the line, then the fill will be applied properly.