### PR TITLE
Paste To Fill Slide fails with Ink in clipboard #1442

### DIFF
--- a/PowerPointLabs/PowerPointLabs/CropLab/CropToSlide.cs
+++ b/PowerPointLabs/PowerPointLabs/CropLab/CropToSlide.cs
@@ -36,7 +36,7 @@ namespace PowerPointLabs.CropLab
             {
                 return false;
             }
-            if (Utils.Graphics.IsShape(shape) || shape.Rotation != 0)
+            if (!Utils.Graphics.IsPicture(shape) || shape.Rotation != 0)
             {
                 Utils.Graphics.ExportShape(shape, ShapePicture);
                 var newShape = currentSlide.Shapes.AddPicture(ShapePicture,

--- a/PowerPointLabs/PowerPointLabs/Utils/Graphics.cs
+++ b/PowerPointLabs/PowerPointLabs/Utils/Graphics.cs
@@ -160,6 +160,12 @@ namespace PowerPointLabs.Utils
                 || shape.Type == MsoShapeType.msoGroup;
         }
 
+        public static bool IsPicture(Shape shape)
+        {
+            return shape.Type == MsoShapeType.msoPicture ||
+                   shape.Type == MsoShapeType.msoLinkedPicture;
+        }
+
         public static bool IsSamePosition(Shape refShape, Shape candidateShape,
                                           bool exactMatch = true, float blurRadius = float.Epsilon)
         {


### PR DESCRIPTION
Fixes #1442 

This should fix all cases of such exceptions, such as having a chart or smartart copied.