### PR TITLE
Pasting placeholder objects causes exceptions #1449 

### DIFF
--- a/PowerPointLabs/PowerPointLabs/ActionFramework/Action/PasteLab/PasteAtCursorPositionActionHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/Action/PasteLab/PasteAtCursorPositionActionHandler.cs
@@ -35,7 +35,12 @@ namespace PowerPointLabs.ActionFramework.Action.PasteLab
                 positionY = ((coordinates.Y - activeWindow.PointsToScreenPixelsY(0)) / yref) * 100;
             }
 
-            ShapeRange pastingShapes = slide.Shapes.Paste();
+            ShapeRange pastingShapes = PasteShapesFromClipboard(slide);
+            if (pastingShapes == null)
+            {
+                return null;
+            }
+
             return PasteAtCursorPosition.Execute(presentation, slide, pastingShapes, positionX, positionY);
         }
     }

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/Action/PasteLab/PasteAtOriginalPositionActionHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/Action/PasteLab/PasteAtOriginalPositionActionHandler.cs
@@ -19,9 +19,16 @@ namespace PowerPointLabs.ActionFramework.Action.PasteLab
                                                         ShapeRange selectedShapes, ShapeRange selectedChildShapes)
         {
             PowerPointSlide tempSlide = presentation.AddSlide(index: slide.Index);
-            ShapeRange tempPastingShapes = tempSlide.Shapes.Paste();
+            ShapeRange tempPastingShapes = PasteShapesFromClipboard(tempSlide);
+            if (tempPastingShapes == null)
+            {
+                tempSlide.Delete();
+                return null;
+            }
+
             ShapeRange pastingShapes = slide.CopyShapesToSlide(tempPastingShapes);
             tempSlide.Delete();
+
             return pastingShapes;
         }
     }

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/Action/PasteLab/PasteAtOriginalPositionActionHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/Action/PasteLab/PasteAtOriginalPositionActionHandler.cs
@@ -2,7 +2,6 @@
 
 using PowerPointLabs.ActionFramework.Common.Attribute;
 using PowerPointLabs.Models;
-using PowerPointLabs.PasteLab;
 
 namespace PowerPointLabs.ActionFramework.Action.PasteLab
 {
@@ -23,7 +22,7 @@ namespace PowerPointLabs.ActionFramework.Action.PasteLab
             if (tempPastingShapes == null)
             {
                 tempSlide.Delete();
-                return null;
+                return PasteShapesFromClipboard(slide);
             }
 
             ShapeRange pastingShapes = slide.CopyShapesToSlide(tempPastingShapes);

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/Action/PasteLab/PasteIntoGroupActionHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/Action/PasteLab/PasteIntoGroupActionHandler.cs
@@ -26,7 +26,12 @@ namespace PowerPointLabs.ActionFramework.Action.PasteLab
                 return null;
             }
 
-            ShapeRange pastingShapes = slide.Shapes.Paste();
+            ShapeRange pastingShapes = PasteShapesFromClipboard(slide);
+            if (pastingShapes == null)
+            {
+                return null;
+            }
+
             return PasteIntoGroup.Execute(presentation, slide, selectedShapes, pastingShapes);
         }
     }

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/Action/PasteLab/PasteToFillSlideActionHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/Action/PasteLab/PasteToFillSlideActionHandler.cs
@@ -18,7 +18,12 @@ namespace PowerPointLabs.ActionFramework.Action.PasteLab
         protected override ShapeRange ExecutePasteAction(string ribbonId, PowerPointPresentation presentation, PowerPointSlide slide,
                                                         ShapeRange selectedShapes, ShapeRange selectedChildShapes)
         {
-            ShapeRange pastingShapes = slide.Shapes.Paste();
+            ShapeRange pastingShapes = PasteShapesFromClipboard(slide);
+            if (pastingShapes == null)
+            {
+                return null;
+            }
+
             PasteToFillSlide.Execute(slide, pastingShapes, presentation.SlideWidth, presentation.SlideHeight);
             return null;
         }

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/Action/PasteLab/ReplaceWithClipboardActionHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/Action/PasteLab/ReplaceWithClipboardActionHandler.cs
@@ -24,8 +24,13 @@ namespace PowerPointLabs.ActionFramework.Action.PasteLab
                 MessageBox.Show("Please select at least one shape.", "Error");
                 return null;
             }
-            
-            ShapeRange pastingShapes = slide.Shapes.Paste();
+
+            ShapeRange pastingShapes = PasteShapesFromClipboard(slide);
+            if (pastingShapes == null)
+            {
+                return null;
+            }
+
             return ReplaceWithClipboard.Execute(presentation, slide, selectedShapes, selectedChildShapes, pastingShapes);
         }
     }

--- a/PowerPointLabs/PowerPointLabs/PasteLab/PasteToFillSlide.cs
+++ b/PowerPointLabs/PowerPointLabs/PasteLab/PasteToFillSlide.cs
@@ -10,6 +10,10 @@ namespace PowerPointLabs.PasteLab
         public static void Execute(PowerPointSlide slide, ShapeRange pastingShapes, float slideWidth, float slideHeight)
         {
             pastingShapes = Graphics.GetShapesWhenTypeNotMatches(slide, pastingShapes, Microsoft.Office.Core.MsoShapeType.msoPlaceholder);
+            if (pastingShapes.Count == 0)
+            {
+                return;
+            }
 
             Shape shapeToFillSlide = pastingShapes[1];
             if (pastingShapes.Count > 1)


### PR DESCRIPTION
Fixes #1449

Since we are unable to detect whether a placeholder is in the clipboard, the solution is to catch and handle the COMExceptions that occur when pasting placeholders. 

This behavior (of doing nothing when pasting placeholders) is the same as PowerPoint's.