### PR TITLE
BaseCropLabTest in UnitTests should be an abstract class #1496

### DIFF
--- a/PowerPointLabs/Test/UnitTest/CropLab/BaseCropLabTest.cs
+++ b/PowerPointLabs/Test/UnitTest/CropLab/BaseCropLabTest.cs
@@ -10,14 +10,9 @@ using PowerPoint = Microsoft.Office.Interop.PowerPoint;
 namespace Test.UnitTest.CropLab
 {
     [TestClass]
-    public class BaseCropLabTest : BaseUnitTest
+    public abstract class BaseCropLabTest : BaseUnitTest
     {
         private readonly Dictionary<string, string> _originalShapeName = new Dictionary<string, string>();
-
-        protected override string GetTestingSlideName()
-        {
-            return "CropLab.pptx";
-        }
 
         protected PowerPoint.ShapeRange GetShapes(int slideNumber, IEnumerable<string> shapeNames)
         {


### PR DESCRIPTION
Fixes #1496 

Remove GetTestingSlideName() and made BaseCropLabTest into an abstract class.
This is because we do not want to call a placeholder ppt file