### PR TITLE
Replace with clipboard: not working if the target object is an image in a group #1528

### DIFF
--- a/PowerPointLabs/PowerPointLabs/ActionFramework/PasteLab/ReplaceWithClipboard/ReplaceWithClipboardEnabledHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/PasteLab/ReplaceWithClipboard/ReplaceWithClipboardEnabledHandler.cs
@@ -14,7 +14,9 @@ namespace PowerPointLabs.ActionFramework.PasteLab
         protected override bool GetEnabled(string ribbonId)
         {
             Selection currentSelection = this.GetCurrentSelection();
-            return !GraphicsUtil.IsClipboardEmpty() && ShapeUtil.IsSelectionSingleShape(currentSelection);
+            return !GraphicsUtil.IsClipboardEmpty() &&
+                ShapeUtil.IsSelectionSingleShape(currentSelection) &&
+                !ShapeUtil.HasPlaceholderInSelection(currentSelection);
         }
     }
 }

--- a/PowerPointLabs/PowerPointLabs/Utils/ShapeUtil.cs
+++ b/PowerPointLabs/PowerPointLabs/Utils/ShapeUtil.cs
@@ -191,14 +191,17 @@ namespace PowerPointLabs.Utils
 
         public static bool IsSelectionSingleShape(Selection selection)
         {
-            if (selection.HasChildShapeRange)
+            if (selection.Type != PpSelectionType.ppSelectionShapes)
             {
-                return selection.ChildShapeRange.Count == 1 &&
-                    selection.ChildShapeRange.Type == Microsoft.Office.Core.MsoShapeType.msoAutoShape;
+                return false;
             }
 
-            return selection.Type == PpSelectionType.ppSelectionShapes &&
-                selection.ShapeRange.Count == 1;
+            if (selection.HasChildShapeRange)
+            {
+                return selection.ChildShapeRange.Count == 1;
+            }
+
+            return selection.ShapeRange.Count == 1;
         }
 
         public static bool IsSelectionMultipleOrGroup(Selection selection)


### PR DESCRIPTION
Fixes #1528 