### PR TITLE
Change non-dynamic variable types from "var" to static-typed #1470

### DIFF
--- a/PowerPointLabs/PowerPointLabs/ActionFramework/CaptionsLab/RemoveNotes/RemoveNotesActionHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/CaptionsLab/RemoveNotes/RemoveNotesActionHandler.cs
@@ -1,6 +1,7 @@
 ﻿using PowerPointLabs.ActionFramework.Common.Attribute;
 using PowerPointLabs.ActionFramework.Common.Extension;
 using PowerPointLabs.ActionFramework.Common.Interface;
+using PowerPointLabs.Models;
 using PowerPointLabs.TextCollection;
 
 namespace PowerPointLabs.ActionFramework.CaptionsLab
@@ -13,7 +14,7 @@ namespace PowerPointLabs.ActionFramework.CaptionsLab
             //TODO: This needs to improved to stop using global variables
             this.StartNewUndoEntry();
 
-            foreach (var slide in this.GetCurrentPresentation().SelectedSlides)
+            foreach (PowerPointSlide slide in this.GetCurrentPresentation().SelectedSlides)
             {
                 slide.NotesPageText = string.Empty;
             }

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/ColorsLab/ColorsLabActionHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/ColorsLab/ColorsLabActionHandler.cs
@@ -1,4 +1,6 @@
-﻿using PowerPointLabs.ActionFramework.Common.Attribute;
+﻿using Microsoft.Office.Tools;
+
+using PowerPointLabs.ActionFramework.Common.Attribute;
 using PowerPointLabs.ActionFramework.Common.Extension;
 using PowerPointLabs.ActionFramework.Common.Interface;
 using PowerPointLabs.TextCollection;
@@ -10,7 +12,7 @@ namespace PowerPointLabs.ActionFramework.ColorsLab
     {
         protected override void ExecuteAction(string ribbonId)
         {
-            var colorPane = 
+            CustomTaskPane colorPane = 
                 this.RegisterTaskPane(typeof(ColorPane), ColorsLabText.TaskPanelTitle);
             if (colorPane != null)
             {

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/Common/Extension/ActionFrameworkExtensions.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/Common/Extension/ActionFrameworkExtensions.cs
@@ -65,7 +65,7 @@ namespace PowerPointLabs.ActionFramework.Common.Extension
 
         public static void ExecuteOfficeCommand(string commandMso)
         {
-            var commandBars = Globals.ThisAddIn.Application.CommandBars;
+            Microsoft.Office.Core.CommandBars commandBars = Globals.ThisAddIn.Application.CommandBars;
             commandBars.ExecuteMso(commandMso);
         }
 
@@ -84,19 +84,19 @@ namespace PowerPointLabs.ActionFramework.Common.Extension
         {
             try
             {
-                var taskPane = Globals.ThisAddIn.GetActivePane(taskPaneType);
+                CustomTaskPane taskPane = Globals.ThisAddIn.GetActivePane(taskPaneType);
                 if (taskPane != null)
                 {
                     return taskPane;
                 }
 
-                var taskPaneControl = (UserControl) Activator.CreateInstance(taskPaneType);
+                UserControl taskPaneControl = (UserControl) Activator.CreateInstance(taskPaneType);
                 if (taskPaneControl == null)
                 {
                     throw new InvalidCastException("Failed to convert " + taskPaneType + " to UserControl.");
                 }
 
-                var activeWindow = Globals.ThisAddIn.Application.ActiveWindow;
+                DocumentWindow activeWindow = Globals.ThisAddIn.Application.ActiveWindow;
 
                 return Globals.ThisAddIn.RegisterTaskPane(taskPaneControl, taskPaneTitle, activeWindow,
                     visibleChangeEventHandler, dockPositionChangeEventHandler);

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/Common/Factory/BaseHandlerFactory.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/Common/Factory/BaseHandlerFactory.cs
@@ -19,15 +19,15 @@ namespace PowerPointLabs.ActionFramework.Common.Factory
 
         protected BaseHandlerFactory()
         {
-            var catalog = new AggregateCatalog(
+            AggregateCatalog catalog = new AggregateCatalog(
                 new AssemblyCatalog(Assembly.GetExecutingAssembly()));
-            var container = new CompositionContainer(catalog);
+            CompositionContainer container = new CompositionContainer(catalog);
             container.ComposeParts(this);
         }
 
         public THandler CreateInstance(string ribbonId, string ribbonTag)
         {
-            foreach (var handler in ImportedHandlers)
+            foreach (Lazy<THandler, IRibbonIdMetadata> handler in ImportedHandlers)
             {
                 if (handler.Metadata.RibbonIds.Contains(ribbonId)
                     || handler.Metadata.RibbonIds.Contains(ribbonTag))

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/CropLab/CropOutPadding/CropOutPaddingActionHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/CropLab/CropOutPadding/CropOutPaddingActionHandler.cs
@@ -19,7 +19,7 @@ namespace PowerPointLabs.ActionFramework.CropLab
         {
             IMessageService cropLabMessageService = MessageServiceFactory.GetCropLabMessageService();
             CropLabErrorHandler errorHandler = CropLabErrorHandler.InitializeErrorHandler(cropLabMessageService);
-            var selection = this.GetCurrentSelection();
+            Selection selection = this.GetCurrentSelection();
 
             if (!ShapeUtil.IsSelectionShape(selection))
             {

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/CropLab/CropToAspectRatio/CropToAspectRatioActionHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/CropLab/CropToAspectRatio/CropToAspectRatioActionHandler.cs
@@ -19,7 +19,7 @@ namespace PowerPointLabs.ActionFramework.CropLab
         {
             IMessageService cropLabMessageService = MessageServiceFactory.GetCropLabMessageService();
             CropLabErrorHandler errorHandler = CropLabErrorHandler.InitializeErrorHandler(cropLabMessageService);
-            var selection = this.GetCurrentSelection();
+            Selection selection = this.GetCurrentSelection();
 
             if (!ShapeUtil.IsSelectionShape(selection))
             {
@@ -57,7 +57,7 @@ namespace PowerPointLabs.ActionFramework.CropLab
         {
             IMessageService cropLabMessageService = MessageServiceFactory.GetCropLabMessageService();
             CropLabErrorHandler errorHandler = CropLabErrorHandler.InitializeErrorHandler(cropLabMessageService);
-            var selection = this.GetCurrentSelection();
+            Selection selection = this.GetCurrentSelection();
 
             float aspectRatioWidth = 0.0f;
             float aspectRatioHeight = 0.0f;

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/CropLab/CropToAspectRatioContentHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/CropLab/CropToAspectRatioContentHandler.cs
@@ -1,4 +1,6 @@
-﻿using PowerPointLabs.ActionFramework.Common.Attribute;
+﻿using System.Text;
+
+using PowerPointLabs.ActionFramework.Common.Attribute;
 using PowerPointLabs.ActionFramework.Common.Interface;
 using PowerPointLabs.TextCollection;
 
@@ -11,9 +13,9 @@ namespace PowerPointLabs.ActionFramework.CropLab
 
         protected override string GetContent(string ribbonId)
         {
-            var feature = ribbonId.Replace(CommonText.DynamicMenuId, "");
+            string feature = ribbonId.Replace(CommonText.DynamicMenuId, "");
 
-            var xmlString = new System.Text.StringBuilder();
+            StringBuilder xmlString = new System.Text.StringBuilder();
 
             for (int i = 0; i < PRESET_ASPECT_RATIOS.Length; i++)
             {

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/EffectsLab/Magnify/MagnifyActionHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/EffectsLab/Magnify/MagnifyActionHandler.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Windows;
 
+using Microsoft.Office.Interop.PowerPoint;
+
 using PowerPointLabs.ActionFramework.Common.Attribute;
 using PowerPointLabs.ActionFramework.Common.Extension;
 using PowerPointLabs.ActionFramework.Common.Interface;
@@ -19,9 +21,9 @@ namespace PowerPointLabs.ActionFramework.EffectsLab
         {
             this.StartNewUndoEntry();
 
-            var selection = this.GetCurrentSelection();
+            Selection selection = this.GetCurrentSelection();
 
-            PowerPoint.ShapeRange shapeRange;
+            ShapeRange shapeRange;
 
             try
             {
@@ -43,22 +45,22 @@ namespace PowerPointLabs.ActionFramework.EffectsLab
 
             try
             {
-                var croppedShape = CropToShape.Crop(this.GetCurrentSlide(), selection, isInPlace: true, handleError: false);
+                Shape croppedShape = CropToShape.Crop(this.GetCurrentSlide(), selection, isInPlace: true, handleError: false);
 
                 MagnifyGlassEffect(croppedShape, 1.4f);
             }
             catch (Exception e)
             {
-                var errorMessage = e.Message;
+                string errorMessage = e.Message;
                 errorMessage = errorMessage.Replace("Crop To Shape", "Magnify");
 
                 MessageBox.Show(errorMessage);
             }
         }
 
-        private void MagnifyGlassEffect(PowerPoint.Shape shape, float ratio)
+        private void MagnifyGlassEffect(Shape shape, float ratio)
         {
-            var delta = 0.5f * (ratio - 1);
+            float delta = 0.5f * (ratio - 1);
 
             shape.Left -= delta * shape.Width;
             shape.Top -= delta * shape.Height;

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/EffectsLab/MakeTransparent/MakeTransparentActionHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/EffectsLab/MakeTransparent/MakeTransparentActionHandler.cs
@@ -1,6 +1,8 @@
 ﻿using System.IO;
 using System.Windows;
 
+using Microsoft.Office.Interop.PowerPoint;
+
 using PowerPointLabs.ActionFramework.Common.Attribute;
 using PowerPointLabs.ActionFramework.Common.Extension;
 using PowerPointLabs.ActionFramework.Common.Interface;
@@ -9,6 +11,7 @@ using PowerPointLabs.Utils;
 
 using Office = Microsoft.Office.Core;
 using PowerPoint = Microsoft.Office.Interop.PowerPoint;
+
 
 namespace PowerPointLabs.ActionFramework.EffectsLab
 {
@@ -19,9 +22,9 @@ namespace PowerPointLabs.ActionFramework.EffectsLab
         {
             this.StartNewUndoEntry();
 
-            var selection = this.GetCurrentSelection();
+            Selection selection = this.GetCurrentSelection();
 
-            if (selection.Type != PowerPoint.PpSelectionType.ppSelectionShapes)
+            if (selection.Type != PpSelectionType.ppSelectionShapes)
             {
                 MessageBox.Show("Please select at least 1 shape");
                 return;
@@ -30,13 +33,13 @@ namespace PowerPointLabs.ActionFramework.EffectsLab
             TransparentEffect(selection.ShapeRange);
         }
 
-        private void TransparentEffect(PowerPoint.ShapeRange shapeRange)
+        private void TransparentEffect(ShapeRange shapeRange)
         {
-            foreach (PowerPoint.Shape shape in shapeRange)
+            foreach (Shape shape in shapeRange)
             {
                 if (shape.Type == Office.MsoShapeType.msoGroup)
                 {
-                    var subShapeRange = shape.Ungroup();
+                    ShapeRange subShapeRange = shape.Ungroup();
                     TransparentEffect(subShapeRange);
                     subShapeRange.Group();
                 }
@@ -59,23 +62,23 @@ namespace PowerPointLabs.ActionFramework.EffectsLab
             }
         }
 
-        private bool IsTransparentableShape(PowerPoint.Shape shape)
+        private bool IsTransparentableShape(Shape shape)
         {
             return shape.Type == Office.MsoShapeType.msoAutoShape ||
                    shape.Type == Office.MsoShapeType.msoFreeform;
         }
 
-        private void PictureTransparencyHandler(PowerPoint.Shape picture)
+        private void PictureTransparencyHandler(Shape picture)
         {
-            var rotation = picture.Rotation;
+            float rotation = picture.Rotation;
 
             picture.Rotation = 0;
 
-            var tempPicPath = Path.Combine(Path.GetTempPath(), "tempPic.png");
+            string tempPicPath = Path.Combine(Path.GetTempPath(), "tempPic.png");
 
             GraphicsUtil.ExportShape(picture, tempPicPath);
 
-            var shapeHolder =
+            Shape shapeHolder =
                 this.GetCurrentSlide().Shapes.AddShape(
                     Office.MsoAutoShapeType.msoShapeRectangle,
                     picture.Left,
@@ -83,7 +86,7 @@ namespace PowerPointLabs.ActionFramework.EffectsLab
                     picture.Width,
                     picture.Height);
 
-            var oriZOrder = picture.ZOrderPosition;
+            int oriZOrder = picture.ZOrderPosition;
 
             picture.Delete();
 
@@ -102,17 +105,17 @@ namespace PowerPointLabs.ActionFramework.EffectsLab
             File.Delete(tempPicPath);
         }
 
-        private void PlaceholderTransparencyHandler(PowerPoint.Shape picture)
+        private void PlaceholderTransparencyHandler(Shape picture)
         {
             PictureTransparencyHandler(picture);
         }
 
-        private void LineTransparencyHandler(PowerPoint.Shape shape)
+        private void LineTransparencyHandler(Shape shape)
         {
             shape.Line.Transparency = 0.5f;
         }
 
-        private void ShapeTransparencyHandler(PowerPoint.Shape shape)
+        private void ShapeTransparencyHandler(Shape shape)
         {
             shape.Fill.Transparency = 0.5f;
             shape.Line.Transparency = 0.5f;

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/EffectsLab/RecolorMenuContent/EffectsLabRecolorContentHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/EffectsLab/RecolorMenuContent/EffectsLabRecolorContentHandler.cs
@@ -1,4 +1,6 @@
-﻿using PowerPointLabs.ActionFramework.Common.Attribute;
+﻿using System.Text;
+
+using PowerPointLabs.ActionFramework.Common.Attribute;
 using PowerPointLabs.ActionFramework.Common.Interface;
 using PowerPointLabs.TextCollection;
 
@@ -15,7 +17,7 @@ namespace PowerPointLabs.ActionFramework.EffectsLab
 
         protected override string GetContent(string ribbonId)
         {
-            var xmlString = new System.Text.StringBuilder();
+            StringBuilder xmlString = new System.Text.StringBuilder();
 
             foreach (string feature in features)
             {

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/NarrationsLab/AddNarrations/AddNarrationsActionHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/NarrationsLab/AddNarrations/AddNarrationsActionHandler.cs
@@ -1,8 +1,12 @@
-﻿using System.Linq;
+﻿using System.Collections.Generic;
+using System.Linq;
+
+using Microsoft.Office.Tools;
 
 using PowerPointLabs.ActionFramework.Common.Attribute;
 using PowerPointLabs.ActionFramework.Common.Extension;
 using PowerPointLabs.ActionFramework.Common.Interface;
+using PowerPointLabs.Models;
 using PowerPointLabs.NarrationsLab;
 using PowerPointLabs.NarrationsLab.Views;
 using PowerPointLabs.TextCollection;
@@ -17,7 +21,7 @@ namespace PowerPointLabs.ActionFramework.NarrationsLab
             //TODO: This needs to improved to stop using global variables
             this.StartNewUndoEntry();
 
-            var currentSlide = this.GetCurrentSlide();
+            PowerPointSlide currentSlide = this.GetCurrentSlide();
 
             if (this.GetCurrentPresentation().SelectedSlides.Any(slide => slide.NotesPageText.Trim() != ""))
             {
@@ -25,16 +29,16 @@ namespace PowerPointLabs.ActionFramework.NarrationsLab
                 this.GetRibbonUi().RefreshRibbonControl("RemoveNarrationsButton");
             }
 
-            var allAudioFiles = NotesToAudio.EmbedSelectedSlideNotes();
+            List<string[]> allAudioFiles = NotesToAudio.EmbedSelectedSlideNotes();
 
-            var recorderPane = this.GetAddIn().GetActivePane(typeof(RecorderTaskPane));
+            CustomTaskPane recorderPane = this.GetAddIn().GetActivePane(typeof(RecorderTaskPane));
 
             if (recorderPane == null)
             {
                 return;
             }
 
-            var recorder = recorderPane.Control as RecorderTaskPane;
+            RecorderTaskPane recorder = recorderPane.Control as RecorderTaskPane;
 
             if (recorder == null)
             {

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/NarrationsLab/RecordNarrations/RecordNarrationsActionHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/NarrationsLab/RecordNarrations/RecordNarrationsActionHandler.cs
@@ -1,4 +1,7 @@
-﻿using PowerPointLabs.ActionFramework.Common.Attribute;
+﻿using Microsoft.Office.Interop.PowerPoint;
+using Microsoft.Office.Tools;
+
+using PowerPointLabs.ActionFramework.Common.Attribute;
 using PowerPointLabs.ActionFramework.Common.Extension;
 using PowerPointLabs.ActionFramework.Common.Interface;
 using PowerPointLabs.NarrationsLab.Views;
@@ -12,7 +15,7 @@ namespace PowerPointLabs.ActionFramework.NarrationsLab
         protected override void ExecuteAction(string ribbonId)
         {
             //TODO: This needs to improved to stop using global variables
-            var currentPresentation = this.GetCurrentPresentation().Presentation;
+            Presentation currentPresentation = this.GetCurrentPresentation().Presentation;
 
             if (!this.GetRibbonUi().IsValidPresentation(currentPresentation))
             {
@@ -20,13 +23,13 @@ namespace PowerPointLabs.ActionFramework.NarrationsLab
             }
 
             // prepare media files
-            var tempPath = this.GetAddIn().PrepareTempFolder(currentPresentation);
+            string tempPath = this.GetAddIn().PrepareTempFolder(currentPresentation);
             this.GetAddIn().PrepareMediaFiles(currentPresentation, tempPath);
 
             this.GetAddIn().RegisterRecorderPane(currentPresentation.Windows[1], tempPath);
 
-            var recorderPane = this.GetAddIn().GetActivePane(typeof(RecorderTaskPane));
-            var recorder = recorderPane.Control as RecorderTaskPane;
+            CustomTaskPane recorderPane = this.GetAddIn().GetActivePane(typeof(RecorderTaskPane));
+            RecorderTaskPane recorder = recorderPane.Control as RecorderTaskPane;
 
             // if currently the pane is hidden, show the pane
             if (recorder != null && !recorderPane.Visible)

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/NarrationsLab/RemoveNarrations/RemoveNarrationsActionHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/NarrationsLab/RemoveNarrations/RemoveNarrationsActionHandler.cs
@@ -1,4 +1,6 @@
-﻿using PowerPointLabs.ActionFramework.Common.Attribute;
+﻿using Microsoft.Office.Tools;
+
+using PowerPointLabs.ActionFramework.Common.Attribute;
 using PowerPointLabs.ActionFramework.Common.Extension;
 using PowerPointLabs.ActionFramework.Common.Interface;
 using PowerPointLabs.Models;
@@ -18,11 +20,11 @@ namespace PowerPointLabs.ActionFramework.NarrationsLab
 
             NotesToAudio.RemoveAudioFromSelectedSlides();
 
-            var recorderPane = this.GetAddIn().GetActivePane(typeof(RecorderTaskPane));
+            CustomTaskPane recorderPane = this.GetAddIn().GetActivePane(typeof(RecorderTaskPane));
 
             if (recorderPane != null)
             {
-                var recorder = recorderPane.Control as RecorderTaskPane;
+                RecorderTaskPane recorder = recorderPane.Control as RecorderTaskPane;
                 recorder.ClearRecordDataListForSelectedSlides();
 
                 // if current list is visible, update the pane immediately

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/PositionsLab/PositionsLabActionHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/PositionsLab/PositionsLabActionHandler.cs
@@ -1,4 +1,6 @@
-﻿using PowerPointLabs.ActionFramework.Common.Attribute;
+﻿using Microsoft.Office.Tools;
+
+using PowerPointLabs.ActionFramework.Common.Attribute;
 using PowerPointLabs.ActionFramework.Common.Extension;
 using PowerPointLabs.ActionFramework.Common.Interface;
 using PowerPointLabs.TextCollection;
@@ -11,7 +13,7 @@ namespace PowerPointLabs.ActionFramework.PositionsLab
         protected override void ExecuteAction(string ribbonId)
         {
             this.RegisterTaskPane(typeof(PositionsPane), PositionsLabText.TaskPanelTitle);
-            var positionsPane = this.GetTaskPane(typeof(PositionsPane));
+            CustomTaskPane positionsPane = this.GetTaskPane(typeof(PositionsPane));
             // if currently the pane is hidden, show the pane
             if (!positionsPane.Visible)
             {

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/ResizeLab/ResizeLabActionHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/ResizeLab/ResizeLabActionHandler.cs
@@ -1,4 +1,6 @@
-﻿using PowerPointLabs.ActionFramework.Common.Attribute;
+﻿using Microsoft.Office.Tools;
+
+using PowerPointLabs.ActionFramework.Common.Attribute;
 using PowerPointLabs.ActionFramework.Common.Extension;
 using PowerPointLabs.ActionFramework.Common.Interface;
 using PowerPointLabs.ResizeLab;
@@ -11,7 +13,7 @@ namespace PowerPointLabs.ActionFramework.ResizeLab
     {
         protected override void ExecuteAction(string ribbonId)
         {
-            var resizePane =
+            CustomTaskPane resizePane =
                 this.RegisterTaskPane(typeof(ResizeLabPane), ResizeLabText.TaskPaneTitle);
             if (resizePane != null)
             {

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/ShapesLab/AddShape/AddShapeActionHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/ShapesLab/AddShape/AddShapeActionHandler.cs
@@ -1,8 +1,11 @@
 ﻿using System.IO;
 using System.Windows.Forms;
 
+using Microsoft.Office.Interop.PowerPoint;
+
 using PowerPointLabs.ActionFramework.Common.Attribute;
 using PowerPointLabs.ActionFramework.Common.Extension;
+using PowerPointLabs.ShapesLab;
 using PowerPointLabs.ShortcutsLab;
 using PowerPointLabs.TextCollection;
 
@@ -13,9 +16,9 @@ namespace PowerPointLabs.ActionFramework.ShapesLab
     {
         protected override void ExecuteAction(string ribbonId)
         {
-            var customShape = InitCustomShapePane();
-            var selection = this.GetCurrentSelection();
-            var addIn = this.GetAddIn();
+            CustomShapePane customShape = InitCustomShapePane();
+            Selection selection = this.GetCurrentSelection();
+            ThisAddIn addIn = this.GetAddIn();
             // first of all we check if the shape gallery has been opened correctly
             if (!addIn.ShapePresentation.Opened)
             {
@@ -23,17 +26,17 @@ namespace PowerPointLabs.ActionFramework.ShapesLab
                 return;
             }
 
-            var selectedShapes = selection.ShapeRange;
+            ShapeRange selectedShapes = selection.ShapeRange;
             if (selection.HasChildShapeRange)
             {
                 selectedShapes = selection.ChildShapeRange;
             }
 
             // add shape into shape gallery first to reduce flicker
-            var shapeName = addIn.ShapePresentation.AddShape(selectedShapes, selectedShapes[1].Name);
+            string shapeName = addIn.ShapePresentation.AddShape(selectedShapes, selectedShapes[1].Name);
 
             // add the selection into pane and save it as .png locally
-            var shapeFullName = Path.Combine(customShape.CurrentShapeFolderPath, shapeName + ".png");
+            string shapeFullName = Path.Combine(customShape.CurrentShapeFolderPath, shapeName + ".png");
             ConvertToPicture.ConvertAndSave(selection, shapeFullName);
 
             // sync the shape among all opening panels

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/ShapesLab/ShapesLabActionHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/ShapesLab/ShapesLabActionHandler.cs
@@ -1,4 +1,6 @@
-﻿using PowerPointLabs.ActionFramework.Common.Attribute;
+﻿using Microsoft.Office.Tools;
+
+using PowerPointLabs.ActionFramework.Common.Attribute;
 using PowerPointLabs.ActionFramework.Common.Extension;
 using PowerPointLabs.ActionFramework.Common.Interface;
 using PowerPointLabs.ActionFramework.Common.Log;
@@ -17,14 +19,14 @@ namespace PowerPointLabs.ActionFramework.ShapesLab
             addIn.InitializeShapeGallery();
             addIn.RegisterShapesLabPane(this.GetCurrentPresentation().Presentation);
 
-            var customShapePane = GetShapesLabPane();
+            CustomTaskPane customShapePane = GetShapesLabPane();
 
             if (customShapePane == null)
             {
                 return null;
             }
 
-            var customShape = customShapePane.Control as CustomShapePane;
+            CustomShapePane customShape = customShapePane.Control as CustomShapePane;
 
             Logger.Log(
                 "Before Visible: " +
@@ -37,7 +39,7 @@ namespace PowerPointLabs.ActionFramework.ShapesLab
         public Microsoft.Office.Tools.CustomTaskPane GetShapesLabPane()
         {
 
-            var customShapePane = this.GetAddIn().GetActivePane(typeof(CustomShapePane));
+            CustomTaskPane customShapePane = this.GetAddIn().GetActivePane(typeof(CustomShapePane));
 
             if (customShapePane == null || !(customShapePane.Control is CustomShapePane))
             {
@@ -48,7 +50,7 @@ namespace PowerPointLabs.ActionFramework.ShapesLab
 
         public void TogglePaneVisibility()
         {
-            var customShapePane = GetShapesLabPane();
+            CustomTaskPane customShapePane = GetShapesLabPane();
 
             if (customShapePane == null)
             {
@@ -60,7 +62,7 @@ namespace PowerPointLabs.ActionFramework.ShapesLab
 
         public void SetPaneVisibility(bool visibility)
         {
-            var customShapePane = GetShapesLabPane();
+            CustomTaskPane customShapePane = GetShapesLabPane();
 
             if (customShapePane == null)
             {
@@ -71,7 +73,7 @@ namespace PowerPointLabs.ActionFramework.ShapesLab
 
             if (customShapePane.Visible)
             {
-                var customShape = customShapePane.Control as CustomShapePane;
+                CustomShapePane customShape = customShapePane.Control as CustomShapePane;
                 customShape.Width = customShapePane.Width - 16;
                 customShape.PaneReload();
             }

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/ShortcutsLab/ContextMenuContentHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/ShortcutsLab/ContextMenuContentHandler.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Text;
 
 using PowerPointLabs.ActionFramework.Common.Attribute;
 using PowerPointLabs.ActionFramework.Common.Interface;
@@ -17,8 +18,8 @@ namespace PowerPointLabs.ActionFramework.ShortcutsLab
     {
         protected override string GetContent(string ribbonId)
         {
-            var contextMenuGroups = GetContextMenuGroups(ribbonId);
-            var xmlString = new System.Text.StringBuilder();
+            List<ContextMenuGroup> contextMenuGroups = GetContextMenuGroups(ribbonId);
+            StringBuilder xmlString = new System.Text.StringBuilder();
 
             foreach (ContextMenuGroup group in contextMenuGroups)
             {

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/ShortcutsLab/ConvertToPicture/ConvertToPictureActionHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/ShortcutsLab/ConvertToPicture/ConvertToPictureActionHandler.cs
@@ -1,4 +1,6 @@
-﻿using PowerPointLabs.ActionFramework.Common.Attribute;
+﻿using Microsoft.Office.Interop.PowerPoint;
+
+using PowerPointLabs.ActionFramework.Common.Attribute;
 using PowerPointLabs.ActionFramework.Common.Extension;
 using PowerPointLabs.ActionFramework.Common.Interface;
 using PowerPointLabs.ShortcutsLab;
@@ -13,7 +15,7 @@ namespace PowerPointLabs.ActionFramework.ShortcutsLab
         {
             this.StartNewUndoEntry();
 
-            var selection = this.GetCurrentSelection();
+            Selection selection = this.GetCurrentSelection();
             ConvertToPicture.Convert(selection);
         }
     }

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/ShortcutsLab/EditName/EditNameActionHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/ShortcutsLab/EditName/EditNameActionHandler.cs
@@ -1,4 +1,6 @@
-﻿using PowerPointLabs.ActionFramework.Common.Attribute;
+﻿using Microsoft.Office.Interop.PowerPoint;
+
+using PowerPointLabs.ActionFramework.Common.Attribute;
 using PowerPointLabs.ActionFramework.Common.Extension;
 using PowerPointLabs.ActionFramework.Common.Interface;
 using PowerPointLabs.ShortcutsLab.Views;
@@ -11,14 +13,14 @@ namespace PowerPointLabs.ActionFramework.ShortcutsLab
     {
         protected override void ExecuteAction(string ribbonId)
         {
-            var selection = this.GetCurrentSelection();
-            var selectedShape = selection.ShapeRange[1];
+            Selection selection = this.GetCurrentSelection();
+            Shape selectedShape = selection.ShapeRange[1];
             if (selection.HasChildShapeRange)
             {
                 selectedShape = selection.ChildShapeRange[1];
             }
             
-            var editForm = new EditNameDialogBox(selectedShape);
+            EditNameDialogBox editForm = new EditNameDialogBox(selectedShape);
             editForm.ShowDialog();
         }
     }

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/ShortcutsLab/HideShape/HideShapeActionHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/ShortcutsLab/HideShape/HideShapeActionHandler.cs
@@ -1,4 +1,6 @@
-﻿using PowerPointLabs.ActionFramework.Common.Attribute;
+﻿using Microsoft.Office.Interop.PowerPoint;
+
+using PowerPointLabs.ActionFramework.Common.Attribute;
 using PowerPointLabs.ActionFramework.Common.Extension;
 using PowerPointLabs.ActionFramework.Common.Interface;
 using PowerPointLabs.TextCollection;
@@ -10,8 +12,8 @@ namespace PowerPointLabs.ActionFramework.ShortcutsLab
     {
         protected override void ExecuteAction(string ribbonId)
         {
-            var selection = this.GetCurrentSelection();
-            var selectedShapes = selection.ShapeRange;
+            Selection selection = this.GetCurrentSelection();
+            ShapeRange selectedShapes = selection.ShapeRange;
             if (selection.HasChildShapeRange)
             {
                 selectedShapes = selection.ChildShapeRange;

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/SyncLab/SyncLabActionHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/SyncLab/SyncLabActionHandler.cs
@@ -1,4 +1,6 @@
-﻿using PowerPointLabs.ActionFramework.Common.Attribute;
+﻿using Microsoft.Office.Tools;
+
+using PowerPointLabs.ActionFramework.Common.Attribute;
 using PowerPointLabs.ActionFramework.Common.Extension;
 using PowerPointLabs.ActionFramework.Common.Interface;
 using PowerPointLabs.SyncLab.Views;
@@ -12,7 +14,7 @@ namespace PowerPointLabs.ActionFramework.SyncLab
         protected override void ExecuteAction(string ribbonId)
         {
             this.RegisterTaskPane(typeof(SyncPane), SyncLabText.TaskPanelTitle);
-            var syncPane = this.GetTaskPane(typeof(SyncPane));
+            CustomTaskPane syncPane = this.GetTaskPane(typeof(SyncPane));
             // toggle pane visibility
             syncPane.Visible = !syncPane.Visible;
         }

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/TimerLab/TimerLabActionHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/TimerLab/TimerLabActionHandler.cs
@@ -1,4 +1,6 @@
-﻿using PowerPointLabs.ActionFramework.Common.Attribute;
+﻿using Microsoft.Office.Tools;
+
+using PowerPointLabs.ActionFramework.Common.Attribute;
 using PowerPointLabs.ActionFramework.Common.Extension;
 using PowerPointLabs.ActionFramework.Common.Interface;
 using PowerPointLabs.TextCollection;
@@ -12,7 +14,7 @@ namespace PowerPointLabs.ActionFramework.TimerLab
         protected override void ExecuteAction(string ribbonId)
         {
             this.RegisterTaskPane(typeof(TimerPane), TimerLabText.TaskPaneTitle);
-            var timerPane = this.GetTaskPane(typeof(TimerPane));
+            CustomTaskPane timerPane = this.GetTaskPane(typeof(TimerPane));
             // if currently the pane is hidden, show the pane
             if (!timerPane.Visible)
             {

--- a/PowerPointLabs/PowerPointLabs/AgendaLab/AgendaLabMain.cs
+++ b/PowerPointLabs/PowerPointLabs/AgendaLab/AgendaLabMain.cs
@@ -51,7 +51,7 @@ namespace PowerPointLabs.AgendaLab
             /// </summary>
             public static BulletFormats ExtractFormats(Shape contentShape)
             {
-                var paragraphs = contentShape.TextFrame2.TextRange.Paragraphs.Cast<TextRange2>().ToList();
+                List<TextRange2> paragraphs = contentShape.TextFrame2.TextRange.Paragraphs.Cast<TextRange2>().ToList();
                 return new BulletFormats(paragraphs[0],
                                         paragraphs[1],
                                         paragraphs[2]);
@@ -77,8 +77,8 @@ namespace PowerPointLabs.AgendaLab
             /// </summary>
             public static BeamFormats ExtractFormats(Shape beamShape)
             {
-                var beamText = GetShapeWithPurpose(beamShape, ShapePurpose.BeamShapeHighlightedText);
-                var regularText = GetShapeWithPurpose(beamShape, ShapePurpose.BeamShapeText);
+                Shape beamText = GetShapeWithPurpose(beamShape, ShapePurpose.BeamShapeHighlightedText);
+                Shape regularText = GetShapeWithPurpose(beamShape, ShapePurpose.BeamShapeText);
                 return new BeamFormats(beamText.TextFrame2.TextRange, regularText.TextFrame2.TextRange);
             }
 
@@ -98,16 +98,16 @@ namespace PowerPointLabs.AgendaLab
         public static void GenerateAgenda(Type type)
         {
             bool dialogOpen = false;
-            var currentWindow = Globals.ThisAddIn.Application.ActiveWindow;
-            var oldViewType = currentWindow.ViewType;
+            DocumentWindow currentWindow = Globals.ThisAddIn.Application.ActiveWindow;
+            PpViewType oldViewType = currentWindow.ViewType;
 
             try
             {
-                var slideTracker = new SlideSelectionTracker(SelectedSlides, CurrentSlide);
+                SlideSelectionTracker slideTracker = new SlideSelectionTracker(SelectedSlides, CurrentSlide);
 
                 if (AgendaPresent())
                 {
-                    var confirm = MessageBox.Show(AgendaLabText.ErrorAgendaExist,
+                    DialogResult confirm = MessageBox.Show(AgendaLabText.ErrorAgendaExist,
                                                   AgendaLabText.ErrorAgendaExistTitle,
                                                   MessageBoxButtons.OKCancel);
                     if (confirm != DialogResult.OK)
@@ -159,12 +159,12 @@ namespace PowerPointLabs.AgendaLab
 
         public static void RemoveAgenda()
         {
-            var currentWindow = Globals.ThisAddIn.Application.ActiveWindow;
-            var oldViewType = currentWindow.ViewType;
+            DocumentWindow currentWindow = Globals.ThisAddIn.Application.ActiveWindow;
+            PpViewType oldViewType = currentWindow.ViewType;
 
             try
             {
-                var slideTracker = new SlideSelectionTracker(SelectedSlides, CurrentSlide);
+                SlideSelectionTracker slideTracker = new SlideSelectionTracker(SelectedSlides, CurrentSlide);
 
                 if (!AgendaPresent())
                 {
@@ -189,14 +189,14 @@ namespace PowerPointLabs.AgendaLab
         public static void SynchroniseAgenda()
         {
             bool dialogOpen = false;
-            var currentWindow = Globals.ThisAddIn.Application.ActiveWindow;
-            var oldViewType = currentWindow.ViewType;
+            DocumentWindow currentWindow = Globals.ThisAddIn.Application.ActiveWindow;
+            PpViewType oldViewType = currentWindow.ViewType;
 
             try
             {
-                var slideTracker = new SlideSelectionTracker(SelectedSlides, CurrentSlide);
-                var refSlide = FindReferenceSlide();
-                var type = GetReferenceSlideType();
+                SlideSelectionTracker slideTracker = new SlideSelectionTracker(SelectedSlides, CurrentSlide);
+                PowerPointSlide refSlide = FindReferenceSlide();
+                Type type = GetReferenceSlideType();
                 bool usingNewReferenceSlide = false;
 
                 if (refSlide == null)
@@ -268,7 +268,7 @@ namespace PowerPointLabs.AgendaLab
         /// </summary>
         private static void CreateBulletAgenda(SlideSelectionTracker slideTracker)
         {
-            var refSlide = CreateBulletReferenceSlide();
+            PowerPointSlide refSlide = CreateBulletReferenceSlide();
 
             // here we invoke sync logic, since it's the same behavior as sync
             SyncBulletAgendaSlides(slideTracker, refSlide);
@@ -280,7 +280,7 @@ namespace PowerPointLabs.AgendaLab
         /// </summary>
         private static void CreateVisualAgenda(SlideSelectionTracker slideTracker)
         {
-            var refSlide = CreateVisualReferenceSlide();
+            PowerPointSlide refSlide = CreateVisualReferenceSlide();
 
             // here we invoke sync logic, since it's the same behavior as sync
             SyncVisualAgendaSlides(slideTracker, refSlide);
@@ -292,9 +292,9 @@ namespace PowerPointLabs.AgendaLab
         /// </summary>
         private static void CreateBeamAgenda(SlideSelectionTracker slideTracker)
         {
-            var refSlide = CreateBeamReferenceSlide();
+            PowerPointSlide refSlide = CreateBeamReferenceSlide();
 
-            var targetSlides = slideTracker.SelectedSlides;
+            List<PowerPointSlide> targetSlides = slideTracker.SelectedSlides;
             if (targetSlides.Count == 0)
             {
                 // If no slides selected, generate on all slides.
@@ -303,7 +303,7 @@ namespace PowerPointLabs.AgendaLab
             else if (targetSlides.Count == 1)
             {
                 // If only one slide selected, ask whether the user wants to generate on all slides.
-                var confirmResult = MessageBox.Show(new Form { TopMost = true },
+                DialogResult confirmResult = MessageBox.Show(new Form { TopMost = true },
                                                     AgendaLabText.BeamGenerateSingleSlideDialogContent,
                                                     AgendaLabText.BeamGenerateSingleSlideDialogTitle,
                                                     MessageBoxButtons.YesNo);
@@ -324,7 +324,7 @@ namespace PowerPointLabs.AgendaLab
 
         private static PowerPointSlide CreateBeamReferenceSlide()
         {
-            var refSlide = PowerPointSlide.FromSlideFactory(PowerPointPresentation.Current
+            PowerPointSlide refSlide = PowerPointSlide.FromSlideFactory(PowerPointPresentation.Current
                                                             .Presentation
                                                             .Slides
                                                             .Add(1, PpSlideLayout.ppLayoutBlank));
@@ -342,20 +342,20 @@ namespace PowerPointLabs.AgendaLab
 
         private static void CreateBeamAgendaShapes(PowerPointSlide refSlide, Direction beamDirection = Direction.Top)
         {
-            var sections = GetAllButFirstSection();
+            List<AgendaSection> sections = GetAllButFirstSection();
 
-            var background = PrepareBeamAgendaBackground(refSlide);
-            var textBoxes = CreateBeamAgendaTextBoxes(refSlide, sections);
-            var highlightedTextBox = CreateHighlightedTextBox(refSlide);
+            Shape background = PrepareBeamAgendaBackground(refSlide);
+            List<Shape> textBoxes = CreateBeamAgendaTextBoxes(refSlide, sections);
+            Shape highlightedTextBox = CreateHighlightedTextBox(refSlide);
             SetupBeamTextBoxPositions(textBoxes, highlightedTextBox, background);
             MatchColour(highlightedTextBox, background);
 
-            var beamShapeItems = new List<Shape>();
+            List<Shape> beamShapeItems = new List<Shape>();
             beamShapeItems.Add(background);
             beamShapeItems.Add(highlightedTextBox);
             beamShapeItems.AddRange(textBoxes);
 
-            var group = refSlide.GroupShapes(beamShapeItems);
+            Shape group = refSlide.GroupShapes(beamShapeItems);
             AgendaShape.SetShapeName(group, ShapePurpose.BeamShapeMainGroup, AgendaSection.None);
         }
 
@@ -366,25 +366,25 @@ namespace PowerPointLabs.AgendaLab
 
         private static void SetupBeamTextBoxPositions(List<Shape> textBoxes, Shape highlightedTextBox, Shape background = null)
         {
-            var slideWidth = PowerPointPresentation.Current.SlideWidth;
-            var slideHeight = PowerPointPresentation.Current.SlideHeight;
+            float slideWidth = PowerPointPresentation.Current.SlideWidth;
+            Single slideHeight = PowerPointPresentation.Current.SlideHeight;
             float itemWidth = textBoxes.Select(textBox => textBox.Width).Max();
             float itemHeight = textBoxes.Select(textBox => textBox.Height).Max();
 
-            var spacing = Math.Max(itemWidth, slideWidth/textBoxes.Count);
+            float spacing = Math.Max(itemWidth, slideWidth/textBoxes.Count);
             int columnCount = (int) (slideWidth/spacing + 0.01f); // +0.01f to cater to rounding errors.
             int rowCount = CommonUtil.CeilingDivide(textBoxes.Count, columnCount);
 
-            var left = 0f;
-            var leftOffset = (slideWidth - columnCount*spacing)/2;
-            var top = 0f;
+            float left = 0f;
+            float leftOffset = (slideWidth - columnCount*spacing)/2;
+            Single top = 0f;
 
             for (int i = 0; i < textBoxes.Count; ++i)
             {
                 int x = i%columnCount;
                 int y = i/columnCount;
 
-                var textBox = textBoxes[i];
+                Shape textBox = textBoxes[i];
                 textBox.Left = left + leftOffset + x*spacing + (spacing - textBox.Width)/2;
                 textBox.Top = top + y*itemHeight;
             }
@@ -413,7 +413,7 @@ namespace PowerPointLabs.AgendaLab
 
         private static Shape CreateHighlightedTextBox(PowerPointSlide slide)
         {
-            var textBox = slide.Shapes.AddTextbox(MsoTextOrientation.msoTextOrientationHorizontal,
+            Shape textBox = slide.Shapes.AddTextbox(MsoTextOrientation.msoTextOrientationHorizontal,
                                                   0, 0, 0, 0);
 
             AgendaShape.SetShapeName(textBox, ShapePurpose.BeamShapeHighlightedText, AgendaSection.None);
@@ -427,7 +427,7 @@ namespace PowerPointLabs.AgendaLab
 
         private static Shape PrepareBeamAgendaBackground(PowerPointSlide slide)
         {
-            var background = slide.Shapes.AddShape(MsoAutoShapeType.msoShapeRectangle, 0, 0, 0, 0);
+            Shape background = slide.Shapes.AddShape(MsoAutoShapeType.msoShapeRectangle, 0, 0, 0, 0);
 
             AgendaShape.SetShapeName(background, ShapePurpose.BeamShapeBackground, AgendaSection.None);
             background.Line.Visible = MsoTriState.msoFalse;
@@ -439,7 +439,7 @@ namespace PowerPointLabs.AgendaLab
 
         private static Shape PrepareBeamAgendaBeamItem(PowerPointSlide slide, AgendaSection section)
         {
-            var textBox = slide.Shapes.AddTextbox(MsoTextOrientation.msoTextOrientationHorizontal, 0, 0, 0, 0);
+            Shape textBox = slide.Shapes.AddTextbox(MsoTextOrientation.msoTextOrientationHorizontal, 0, 0, 0, 0);
 
             AgendaShape.SetShapeName(textBox, ShapePurpose.BeamShapeText, section);
             textBox.TextFrame.AutoSize = PpAutoSize.ppAutoSizeShapeToFitText;
@@ -457,7 +457,7 @@ namespace PowerPointLabs.AgendaLab
 
         private static PowerPointSlide CreateBulletReferenceSlide()
         {
-            var refSlide = PowerPointSlide.FromSlideFactory(PowerPointPresentation.Current
+            PowerPointSlide refSlide = PowerPointSlide.FromSlideFactory(PowerPointPresentation.Current
                                                             .Presentation
                                                             .Slides
                                                             .Add(1, PpSlideLayout.ppLayoutText));
@@ -465,8 +465,8 @@ namespace PowerPointLabs.AgendaLab
             refSlide.Transition.EntryEffect = PpEntryEffect.ppEffectPushUp;
             refSlide.Transition.Duration = 0.8f;
 
-            var titleShape = refSlide.Shapes.Placeholders[1];
-            var contentShape = refSlide.Shapes.Placeholders[2];
+            Shape titleShape = refSlide.Shapes.Placeholders[1];
+            Shape contentShape = refSlide.Shapes.Placeholders[2];
             AgendaShape.SetShapeName(contentShape, ShapePurpose.ContentShape, AgendaSection.None);
 
             ShapeUtil.SetText(titleShape, AgendaLabText.TitleContent);
@@ -474,7 +474,7 @@ namespace PowerPointLabs.AgendaLab
                                             AgendaLabText.BulletHighlightedContent,
                                             AgendaLabText.BulletUnvisitedContent);
 
-            var paragraphs = ShapeUtil.GetParagraphs(contentShape);
+            List<TextRange2> paragraphs = ShapeUtil.GetParagraphs(contentShape);
             paragraphs[0].Font.Fill.ForeColor.RGB = GraphicsUtil.ConvertColorToRgb(Color.Gray);
             paragraphs[1].Font.Fill.ForeColor.RGB = GraphicsUtil.ConvertColorToRgb(Color.Red);
             paragraphs[2].Font.Fill.ForeColor.RGB = GraphicsUtil.ConvertColorToRgb(Color.Black);
@@ -495,12 +495,12 @@ namespace PowerPointLabs.AgendaLab
 
         private static PowerPointSlide CreateVisualReferenceSlide()
         {
-            var refSlide = PowerPointSlide.FromSlideFactory(PowerPointPresentation.Current
+            PowerPointSlide refSlide = PowerPointSlide.FromSlideFactory(PowerPointPresentation.Current
                                                             .Presentation
                                                             .Slides
                                                             .Add(1, PpSlideLayout.ppLayoutTitleOnly));
 
-            var titleBar = refSlide.Shapes.Placeholders[1];
+            Shape titleBar = refSlide.Shapes.Placeholders[1];
             ShapeUtil.SetText(titleBar, AgendaLabText.TitleContent);
 
             InsertVisualAgendaSectionImages(refSlide);
@@ -520,7 +520,7 @@ namespace PowerPointLabs.AgendaLab
         /// </summary>
         private static void InsertVisualAgendaSectionImages(PowerPointSlide refSlide)
         {
-            var sectionImages = CreateSectionImagesForAllSections(refSlide);
+            List<Shape> sectionImages = CreateSectionImagesForAllSections(refSlide);
             ArrangeInGrid(sectionImages);
         }
 
@@ -551,7 +551,7 @@ namespace PowerPointLabs.AgendaLab
 
             for (int i = 0; i < sectionImages.Count; ++i)
             {
-                var sectionImage = sectionImages[i];
+                Shape sectionImage = sectionImages[i];
                 int xPosition = i%columnCount;
                 int yPosition = i/columnCount;
 
@@ -564,11 +564,11 @@ namespace PowerPointLabs.AgendaLab
 
         private static List<Shape> CreateSectionImagesForAllSections(PowerPointSlide refSlide)
         {
-            var sections = GetAllButFirstSection();
-            var sectionImages = new List<Shape>();
-            foreach (var section in sections)
+            List<AgendaSection> sections = GetAllButFirstSection();
+            List<Shape> sectionImages = new List<Shape>();
+            foreach (AgendaSection section in sections)
             {
-                var sectionImage = CreateSectionImage(refSlide, section);
+                Shape sectionImage = CreateSectionImage(refSlide, section);
                 sectionImages.Add(sectionImage);
             }
             return sectionImages;
@@ -577,8 +577,8 @@ namespace PowerPointLabs.AgendaLab
 
         private static Shape CreateSectionImage(PowerPointSlide refSlide, AgendaSection section)
         {
-            var sectionFirstSlide = FindSectionFirstNonAgendaSlide(section.Index);
-            var shape = refSlide.InsertEntrySnapshotOfSlide(sectionFirstSlide);
+            PowerPointSlide sectionFirstSlide = FindSectionFirstNonAgendaSlide(section.Index);
+            Shape shape = refSlide.InsertEntrySnapshotOfSlide(sectionFirstSlide);
             AgendaShape.SetShapeName(shape, ShapePurpose.VisualAgendaImage, section);
             return shape;
         }
@@ -586,7 +586,7 @@ namespace PowerPointLabs.AgendaLab
 
         private static void UpdateSectionImage(PowerPointSlide refSlide, AgendaSection section, Shape previousImageShape)
         {
-            var snapshotShape = CreateSectionImage(refSlide, section);
+            Shape snapshotShape = CreateSectionImage(refSlide, section);
             ShapeUtil.SyncShape(previousImageShape, snapshotShape, pickupShapeFormat: true, pickupTextContent: false, pickupTextFormat: false);
             previousImageShape.Delete();
         }
@@ -635,7 +635,7 @@ namespace PowerPointLabs.AgendaLab
         /// </summary>
         private static void ScrambleSlideSectionNames()
         {
-            var slides = PowerPointPresentation.Current.Slides;
+            List<PowerPointSlide> slides = PowerPointPresentation.Current.Slides;
             slides.Where(slide => AgendaSlide.IsAnyAgendaSlide(slide) && AgendaSlide.IsNotReferenceslide(slide))
                     .ToList()
                     .ForEach(AgendaSlide.AssignUniqueSectionName);
@@ -658,7 +658,7 @@ namespace PowerPointLabs.AgendaLab
         /// </summary>
         private static void SyncBulletAgendaSlides(SlideSelectionTracker slideTracker, PowerPointSlide refSlide)
         {
-            var sections = Sections;
+            List<AgendaSection> sections = Sections;
             SynchroniseSlidesUsingTemplate(slideTracker, refSlide, () => new BulletAgendaTemplate());
         }
 
@@ -667,8 +667,8 @@ namespace PowerPointLabs.AgendaLab
             int numberOfSections = NumberOfSections;
 
             // post process bullet points
-            var contentHolder = refSlide.GetShape(AgendaShape.WithPurpose(ShapePurpose.ContentShape));
-            var textRange = contentHolder.TextFrame2.TextRange;
+            Shape contentHolder = refSlide.GetShape(AgendaShape.WithPurpose(ShapePurpose.ContentShape));
+            TextRange2 textRange = contentHolder.TextFrame2.TextRange;
 
             while (textRange.Paragraphs.Count < numberOfSections)
             {
@@ -680,7 +680,7 @@ namespace PowerPointLabs.AgendaLab
                 textRange.Paragraphs[textRange.Paragraphs.Count].Delete();
             }
 
-            for (var i = 4; i <= textRange.Paragraphs.Count; i++)
+            for (int i = 4; i <= textRange.Paragraphs.Count; i++)
             {
                 textRange.Paragraphs[i].ParagraphFormat.Bullet.Type = MsoBulletType.msoBulletNone;
             }
@@ -711,17 +711,17 @@ namespace PowerPointLabs.AgendaLab
         private static void RegenerateReferenceSlideImages(PowerPointSlide refSlide)
         {
             List<Shape> markedForDeletion;
-            var shapeAssignment = GetImageShapeAssignment(refSlide, out markedForDeletion);
+            Dictionary<int, Shape> shapeAssignment = GetImageShapeAssignment(refSlide, out markedForDeletion);
 
-            var sections = GetAllButFirstSection();
-            var assignedOldIndexes = new HashSet<int>();
-            var unassignedNewSections = new List<AgendaSection>();
+            List<AgendaSection> sections = GetAllButFirstSection();
+            HashSet<int> assignedOldIndexes = new HashSet<int>();
+            List<AgendaSection> unassignedNewSections = new List<AgendaSection>();
 
 
             float existingImageWidth = -1;
             float existingImageHeight = -1;
 
-            foreach (var section in sections)
+            foreach (AgendaSection section in sections)
             {
                 int oldIndex = IdentifyOldSectionIndex(section);
                 if (oldIndex == -1 || assignedOldIndexes.Contains(oldIndex))
@@ -747,7 +747,7 @@ namespace PowerPointLabs.AgendaLab
 
             markedForDeletion.AddRange(from entry in shapeAssignment where !assignedOldIndexes.Contains(entry.Key) select entry.Value);
 
-            var newSectionImages = unassignedNewSections.Select(section => CreateSectionImage(refSlide, section))
+            List<Shape> newSectionImages = unassignedNewSections.Select(section => CreateSectionImage(refSlide, section))
                                                         .ToList();
             PositionNewImageShapes(newSectionImages, existingImageWidth, existingImageHeight);
 
@@ -756,14 +756,14 @@ namespace PowerPointLabs.AgendaLab
 
         private static Dictionary<int, Shape> GetImageShapeAssignment(PowerPointSlide inSlide, out List<Shape> unassignedShapes)
         {
-            var shapes = inSlide.Shapes.Cast<Shape>();
+            IEnumerable<Shape> shapes = inSlide.Shapes.Cast<Shape>();
 
             unassignedShapes = new List<Shape>();
-            var shapeAssignment = new Dictionary<int, Shape>();
+            Dictionary<int, Shape> shapeAssignment = new Dictionary<int, Shape>();
 
-            foreach (var shape in shapes)
+            foreach (Shape shape in shapes)
             {
-                var agendaShape = AgendaShape.Decode(shape);
+                AgendaShape agendaShape = AgendaShape.Decode(shape);
                 if (agendaShape == null || agendaShape.ShapePurpose != ShapePurpose.VisualAgendaImage)
                 {
                     continue;
@@ -802,7 +802,7 @@ namespace PowerPointLabs.AgendaLab
                 return;
             }
 
-            foreach (var shape in shapes)
+            foreach (Shape shape in shapes)
             {
                 shape.Width = existingImageWidth;
                 shape.Height = existingImageHeight;
@@ -816,10 +816,10 @@ namespace PowerPointLabs.AgendaLab
         /// </summary>
         private static int IdentifyOldSectionIndex(AgendaSection section)
         {
-            var sectionSlides = GetSectionSlides(section);
-            foreach (var slide in sectionSlides)
+            List<PowerPointSlide> sectionSlides = GetSectionSlides(section);
+            foreach (PowerPointSlide slide in sectionSlides)
             {
-                var agendaSlide = AgendaSlide.Decode(slide);
+                AgendaSlide agendaSlide = AgendaSlide.Decode(slide);
                 if (agendaSlide != null)
                 {
                     return agendaSlide.Section.Index;
@@ -851,14 +851,14 @@ namespace PowerPointLabs.AgendaLab
 
         private static void UpdateBeamReferenceSlide(PowerPointSlide refSlide)
         {
-            var beamShape = FindBeamShape(refSlide);
-            var currentSections = ExtractAgendaSectionsFromBeam(beamShape);
-            var newSections = GetAllButFirstSection();
+            Shape beamShape = FindBeamShape(refSlide);
+            List<AgendaSection> currentSections = ExtractAgendaSectionsFromBeam(beamShape);
+            List<AgendaSection> newSections = GetAllButFirstSection();
 
-            var beamFormats = BeamFormats.ExtractFormats(beamShape);
-            var oldTextBoxes = BeamFormats.GetAllShapesWithPurpose(beamShape, ShapePurpose.BeamShapeText);
-            var highlightedTextBox = BeamFormats.GetShapeWithPurpose(beamShape, ShapePurpose.BeamShapeHighlightedText);
-            var background = BeamFormats.GetShapeWithPurpose(beamShape, ShapePurpose.BeamShapeBackground);
+            BeamFormats beamFormats = BeamFormats.ExtractFormats(beamShape);
+            List<Shape> oldTextBoxes = BeamFormats.GetAllShapesWithPurpose(beamShape, ShapePurpose.BeamShapeText);
+            Shape highlightedTextBox = BeamFormats.GetShapeWithPurpose(beamShape, ShapePurpose.BeamShapeHighlightedText);
+            Shape background = BeamFormats.GetShapeWithPurpose(beamShape, ShapePurpose.BeamShapeBackground);
 
             MatchColour(highlightedTextBox, background);
 
@@ -868,7 +868,7 @@ namespace PowerPointLabs.AgendaLab
             }
 
 
-            var confirmResult = MessageBox.Show(new Form() { TopMost = true },
+            DialogResult confirmResult = MessageBox.Show(new Form() { TopMost = true },
                                                 AgendaLabText.ReorganiseSidebarContent,
                                                 AgendaLabText.ReorganiseSidebarTitle,
                                                 MessageBoxButtons.YesNo);
@@ -890,18 +890,18 @@ namespace PowerPointLabs.AgendaLab
                 Shape background, BeamFormats beamFormats, List<Shape> oldTextBoxes, Shape beamShape)
         {
             List<Shape> markedForDeletion;
-            var textboxAssignment = GetBeamTextboxAssignment(oldTextBoxes, out markedForDeletion);
+            Dictionary<int, Shape> textboxAssignment = GetBeamTextboxAssignment(oldTextBoxes, out markedForDeletion);
 
-            var reassignedTextboxIndexes = new HashSet<int>();
-            var newTextboxes = new List<Shape>();
+            HashSet<int> reassignedTextboxIndexes = new HashSet<int>();
+            List<Shape> newTextboxes = new List<Shape>();
 
-            foreach (var section in newSections)
+            foreach (AgendaSection section in newSections)
             {
                 int index = section.Index;
                 if (textboxAssignment.ContainsKey(index))
                 {
                     // Reuse old textbox
-                    var textbox = textboxAssignment[index];
+                    Shape textbox = textboxAssignment[index];
                     ShapeUtil.SetText(textbox, section.Name);
                     AgendaShape.SetShapeName(textbox, ShapePurpose.BeamShapeText, section);
                     reassignedTextboxIndexes.Add(index);
@@ -909,8 +909,8 @@ namespace PowerPointLabs.AgendaLab
                 else
                 {
                     // Create new textbox
-                    var textbox = PrepareBeamAgendaBeamItem(refSlide, section);
-                    var referenceTextFormat = beamFormats.Regular;
+                    Shape textbox = PrepareBeamAgendaBeamItem(refSlide, section);
+                    TextRange2 referenceTextFormat = beamFormats.Regular;
                     ShapeUtil.SyncTextRange(referenceTextFormat, textbox.TextFrame2.TextRange, pickupTextContent: false);
                     newTextboxes.Add(textbox);
                 }
@@ -919,7 +919,7 @@ namespace PowerPointLabs.AgendaLab
             markedForDeletion.AddRange(from entry in textboxAssignment where !reassignedTextboxIndexes.Contains(entry.Key) select entry.Value);
             markedForDeletion.ForEach(shape => shape.Delete());
 
-            var beamShapeShapes = beamShape.Ungroup().Cast<Shape>().ToList();
+            List<Shape> beamShapeShapes = beamShape.Ungroup().Cast<Shape>().ToList();
             beamShapeShapes.AddRange(newTextboxes);
             beamShape = refSlide.GroupShapes(beamShapeShapes);
             AgendaShape.SetShapeName(beamShape, ShapePurpose.BeamShapeMainGroup, AgendaSection.None);
@@ -931,11 +931,11 @@ namespace PowerPointLabs.AgendaLab
         private static Dictionary<int, Shape> GetBeamTextboxAssignment(IEnumerable<Shape> textboxes, out List<Shape> unassignedShapes)
         {
             unassignedShapes = new List<Shape>();
-            var shapeAssignment = new Dictionary<int, Shape>();
+            Dictionary<int, Shape> shapeAssignment = new Dictionary<int, Shape>();
 
-            foreach (var shape in textboxes)
+            foreach (Shape shape in textboxes)
             {
-                var agendaShape = AgendaShape.Decode(shape);
+                AgendaShape agendaShape = AgendaShape.Decode(shape);
                 
                 int index = agendaShape.Section.Index;
                 if (shapeAssignment.ContainsKey(index))
@@ -957,12 +957,12 @@ namespace PowerPointLabs.AgendaLab
         private static void ReorganiseBeam(PowerPointSlide refSlide, List<AgendaSection> newSections, Shape highlightedTextBox,
             Shape background, BeamFormats beamFormats, List<Shape> oldTextBoxes, Shape beamShape)
         {
-            var newTextBoxes = CreateBeamAgendaTextBoxes(refSlide, newSections);
+            List<Shape> newTextBoxes = CreateBeamAgendaTextBoxes(refSlide, newSections);
             SetupBeamTextBoxPositions(newTextBoxes, highlightedTextBox, background);
 
             for (int i = 0; i < newTextBoxes.Count; ++i)
             {
-                var referenceTextFormat = beamFormats.Regular;
+                TextRange2 referenceTextFormat = beamFormats.Regular;
                 if (i < oldTextBoxes.Count)
                 {
                     referenceTextFormat = oldTextBoxes[i].TextFrame2.TextRange;
@@ -973,7 +973,7 @@ namespace PowerPointLabs.AgendaLab
 
             oldTextBoxes.ForEach(shape => shape.Delete());
 
-            var beamShapeShapes = beamShape.Ungroup().Cast<Shape>().ToList();
+            List<Shape> beamShapeShapes = beamShape.Ungroup().Cast<Shape>().ToList();
             beamShapeShapes.AddRange(newTextBoxes);
             beamShape = refSlide.GroupShapes(beamShapeShapes);
             AgendaShape.SetShapeName(beamShape, ShapePurpose.BeamShapeMainGroup, AgendaSection.None);
@@ -991,8 +991,8 @@ namespace PowerPointLabs.AgendaLab
             }
             for (int i = 0; i < currentSections.Count; ++i)
             {
-                var currentSection = currentSections[i];
-                var newSection = newSections[i];
+                AgendaSection currentSection = currentSections[i];
+                AgendaSection newSection = newSections[i];
                 if (currentSection.Index != newSection.Index || currentSection.Name != newSection.Name)
                 {
                     return false;
@@ -1007,7 +1007,7 @@ namespace PowerPointLabs.AgendaLab
         /// </summary>
         private static List<AgendaSection> ExtractAgendaSectionsFromBeam(Shape beamShape)
         {
-            var agendaSections = beamShape.GroupItems.Cast<Shape>()
+            List<AgendaSection> agendaSections = beamShape.GroupItems.Cast<Shape>()
                                                     .Where(AgendaShape.WithPurpose(ShapePurpose.BeamShapeText))
                                                     .Select(shape => AgendaShape.Decode(shape).Section)
                                                     .ToList();
@@ -1027,23 +1027,23 @@ namespace PowerPointLabs.AgendaLab
 
         private static void SyncBeamOnSlides(List<PowerPointSlide> targetSlides, PowerPointSlide refSlide)
         {
-            var syncSlides = new List<PowerPointSlide>();
+            List<PowerPointSlide> syncSlides = new List<PowerPointSlide>();
 
             // Generate beam agenda for all target slides that do not currently have the beam agenda.
             if (targetSlides != null)
             {
-                var selectedSlidesWithoutBeam = targetSlides.Where(slide => !HasBeamShape(slide));
+                IEnumerable<PowerPointSlide> selectedSlidesWithoutBeam = targetSlides.Where(slide => !HasBeamShape(slide));
                 syncSlides.AddRange(selectedSlidesWithoutBeam);
             }
 
             // Synchronise agenda for all slides in the presentation that have the beam agenda.
-            var refBeamShape = FindBeamShape(refSlide);
-            var allSlidesWithBeam = PowerPointPresentation.Current.Slides
+            Shape refBeamShape = FindBeamShape(refSlide);
+            IEnumerable<PowerPointSlide> allSlidesWithBeam = PowerPointPresentation.Current.Slides
                                                                   .Where(slide => AgendaSlide.IsNotReferenceslide(slide) &&
                                                                                   FindBeamShape(slide) != null);
             syncSlides.AddRange(allSlidesWithBeam);
 
-            foreach (var slide in syncSlides)
+            foreach (PowerPointSlide slide in syncSlides)
             {
                 UpdateBeamOnSlide(slide, refBeamShape);
             }
@@ -1053,8 +1053,8 @@ namespace PowerPointLabs.AgendaLab
         {
             RemoveBeamAgendaFromSlide(slide);
             refBeamShape.Copy();
-            var beamShape = slide.Shapes.Paste();
-            var section = GetSlideSection(slide);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange beamShape = slide.Shapes.Paste();
+            AgendaSection section = GetSlideSection(slide);
 
             beamShape.GroupItems.Cast<Shape>()
                                 .Where(AgendaShape.WithPurpose(ShapePurpose.BeamShapeHighlightedText))
@@ -1066,13 +1066,13 @@ namespace PowerPointLabs.AgendaLab
                 return;
             }
 
-            var beamFormats = BeamFormats.ExtractFormats(refBeamShape);
-            var currentSectionTextBox = beamShape.GroupItems
+            BeamFormats beamFormats = BeamFormats.ExtractFormats(refBeamShape);
+            Shape currentSectionTextBox = beamShape.GroupItems
                                                 .Cast<Shape>()
                                                 .Where(AgendaShape.MeetsConditions(shape => shape.ShapePurpose == ShapePurpose.BeamShapeText &&
                                                                                             shape.Section.Index == section.Index))
                                                 .FirstOrDefault();
-            var currentSectionText = currentSectionTextBox.TextFrame2.TextRange;
+            TextRange2 currentSectionText = currentSectionTextBox.TextFrame2.TextRange;
 
             ShapeUtil.SyncTextRange(beamFormats.Highlighted, currentSectionText, pickupTextContent: false);
         }
@@ -1133,7 +1133,7 @@ namespace PowerPointLabs.AgendaLab
 
         private static bool ValidSections()
         {
-            var sections = PowerPointPresentation.Current.Sections;
+            List<string> sections = PowerPointPresentation.Current.Sections;
 
             if (sections.Count == 0)
             {
@@ -1164,7 +1164,7 @@ namespace PowerPointLabs.AgendaLab
 
         private static bool HasTooLongSectionName()
         {
-            var sections = Sections;
+            List<AgendaSection> sections = Sections;
             return sections.Any(section => section.Name.Length > SectionNameMaxLength);
         }
 
@@ -1174,10 +1174,10 @@ namespace PowerPointLabs.AgendaLab
         /// </summary>
         private static bool HasEmptySection()
         {
-            var sections = Sections;
-            foreach (var section in sections)
+            List<AgendaSection> sections = Sections;
+            foreach (AgendaSection section in sections)
             {
-                var sectionSlides = GetSectionSlides(section);
+                List<PowerPointSlide> sectionSlides = GetSectionSlides(section);
                 if (sectionSlides.All(slide => AgendaSlide.IsAnyAgendaSlide(slide) || PowerPointAckSlide.IsAckSlide(slide)))
                 {
                     return true;
@@ -1230,13 +1230,13 @@ namespace PowerPointLabs.AgendaLab
 
         private static bool InvalidBulletAgendaReferenceSlide(PowerPointSlide refSlide)
         {
-            var contentHolder = refSlide.GetShape(AgendaShape.WithPurpose(ShapePurpose.ContentShape));
+            Shape contentHolder = refSlide.GetShape(AgendaShape.WithPurpose(ShapePurpose.ContentShape));
             return (contentHolder == null || contentHolder.TextFrame2.TextRange.Paragraphs.Count < 3);
         }
 
         private static bool InvalidBeamAgendaReferenceSlide(PowerPointSlide refSlide)
         {
-            var beamShape = FindBeamShape(refSlide);
+            Shape beamShape = FindBeamShape(refSlide);
 
             if (beamShape == null)
             {

--- a/PowerPointLabs/PowerPointLabs/AgendaLab/AgendaLabUtility.cs
+++ b/PowerPointLabs/PowerPointLabs/AgendaLab/AgendaLabUtility.cs
@@ -38,7 +38,7 @@ namespace PowerPointLabs.AgendaLab
         {
             get
             {
-                var slides = PowerPointPresentation.Current.SelectedSlides;
+                List<PowerPointSlide> slides = PowerPointPresentation.Current.SelectedSlides;
                 if (slides.Count == 0)
                 {
                     return null;
@@ -49,19 +49,19 @@ namespace PowerPointLabs.AgendaLab
 
         private static PowerPointSlide FindReferenceSlide()
         {
-            var slides = PowerPointPresentation.Current.Slides;
+            List<PowerPointSlide> slides = PowerPointPresentation.Current.Slides;
             return slides.FirstOrDefault(AgendaSlide.IsReferenceslide);
         }
 
         private static List<PowerPointSlide> FindAllAgendaSlides()
         {
-            var slides = PowerPointPresentation.Current.Slides;
+            List<PowerPointSlide> slides = PowerPointPresentation.Current.Slides;
             return slides.Where(AgendaSlide.IsAnyAgendaSlide).ToList();
         }
 
         private static List<PowerPointSlide> FindSlidesWithBeam()
         {
-            var slides = PowerPointPresentation.Current.Slides;
+            List<PowerPointSlide> slides = PowerPointPresentation.Current.Slides;
             return slides.Where(HasBeamShape).ToList();
         }
 
@@ -77,7 +77,7 @@ namespace PowerPointLabs.AgendaLab
 
         private static Type GetReferenceSlideType()
         {
-            var referenceSlide = FindReferenceSlide();
+            PowerPointSlide referenceSlide = FindReferenceSlide();
             if (referenceSlide == null)
             {
                 return Type.None;
@@ -87,7 +87,7 @@ namespace PowerPointLabs.AgendaLab
 
         private static Type GetAnyAgendaSlideType()
         {
-            var agendaSlide = PowerPointPresentation.Current
+            PowerPointSlide agendaSlide = PowerPointPresentation.Current
                                                     .Slides
                                                     .FirstOrDefault(slide => AgendaSlide.IsAnyAgendaSlide(slide) ||
                                                                              HasBeamShape(slide));
@@ -110,7 +110,7 @@ namespace PowerPointLabs.AgendaLab
         /// </summary>
         private static PowerPointSlide TryFindSuitableRefSlide(Type type)
         {
-            var firstSlide = PowerPointPresentation.Current.FirstSlide;
+            PowerPointSlide firstSlide = PowerPointPresentation.Current.FirstSlide;
             if (firstSlide == null)
             {
                 return null;
@@ -131,10 +131,10 @@ namespace PowerPointLabs.AgendaLab
         {
             get
             {
-                var sectionProperty = PowerPointPresentation.Current.SectionProperties;
-                var sections = new List<AgendaSection>(sectionProperty.Count);
+                SectionProperties sectionProperty = PowerPointPresentation.Current.SectionProperties;
+                List<AgendaSection> sections = new List<AgendaSection>(sectionProperty.Count);
 
-                for (var i = 1; i <= sectionProperty.Count; i++)
+                for (int i = 1; i <= sectionProperty.Count; i++)
                 {
                     sections.Add(new AgendaSection(sectionProperty.Name(i), i));
                 }
@@ -144,7 +144,7 @@ namespace PowerPointLabs.AgendaLab
 
         private static List<AgendaSection> GetAllButFirstSection()
         {
-            var sections = Sections;
+            List<AgendaSection> sections = Sections;
             if (sections.Count > 1)
             {
                 sections.RemoveAt(0);
@@ -160,11 +160,11 @@ namespace PowerPointLabs.AgendaLab
 
         private static PowerPointSlide FindSectionFirstNonAgendaSlide(int sectionIndex)
         {
-            var presentation = PowerPointPresentation.Current;
+            PowerPointPresentation presentation = PowerPointPresentation.Current;
             int slideCount = presentation.SlideCount;
 
             int currentIndex = SectionFirstSlideIndex(sectionIndex);
-            var slide = presentation.GetSlide(currentIndex);
+            PowerPointSlide slide = presentation.GetSlide(currentIndex);
 
             while (AgendaSlide.IsAnyAgendaSlide(slide))
             {
@@ -181,10 +181,10 @@ namespace PowerPointLabs.AgendaLab
 
         private static PowerPointSlide FindSectionLastNonAgendaSlide(int sectionIndex)
         {
-            var presentation = PowerPointPresentation.Current;
+            PowerPointPresentation presentation = PowerPointPresentation.Current;
 
             int currentIndex = SectionLastSlideIndex(sectionIndex);
-            var slide = presentation.GetSlide(currentIndex);
+            PowerPointSlide slide = presentation.GetSlide(currentIndex);
 
             while (AgendaSlide.IsAnyAgendaSlide(slide))
             {
@@ -204,7 +204,7 @@ namespace PowerPointLabs.AgendaLab
         /// </summary>
         private static List<PowerPointSlide> AllSlidesAfterFirstSection()
         {
-            var slides = PowerPointPresentation.Current.Slides;
+            List<PowerPointSlide> slides = PowerPointPresentation.Current.Slides;
             int firstSlideIndex = SectionFirstSlideIndex(2);
             int lastSlideIndex = PowerPointPresentation.Current.SlideCount;
 
@@ -250,16 +250,16 @@ namespace PowerPointLabs.AgendaLab
         /// </summary>
         private static int SectionFirstSlideIndex(int sectionIndex)
         {
-            var sectionProperties = PowerPointPresentation.Current.SectionProperties;
+            SectionProperties sectionProperties = PowerPointPresentation.Current.SectionProperties;
             return sectionProperties.FirstSlide(sectionIndex);
         }
 
         private static AgendaSection GetSlideSection(PowerPointSlide slide)
         {
-            var slideIndex = slide.Index;
+            int slideIndex = slide.Index;
 
-            var sections = Sections;
-            var firstSlideIndexes = sections.Select(SectionFirstSlideIndex).ToList();
+            List<AgendaSection> sections = Sections;
+            List<int> firstSlideIndexes = sections.Select(SectionFirstSlideIndex).ToList();
 
             int i = 0;
             for (; i < sections.Count; ++i)
@@ -277,7 +277,7 @@ namespace PowerPointLabs.AgendaLab
         /// </summary>
         private static int SectionLastSlideIndex(int sectionIndex)
         {
-            var sectionProperties = PowerPointPresentation.Current.SectionProperties;
+            SectionProperties sectionProperties = PowerPointPresentation.Current.SectionProperties;
             int lastSlideIndex = PowerPointPresentation.Current.SlideCount;
 
             if (!IsLastSection(sectionIndex))
@@ -297,7 +297,7 @@ namespace PowerPointLabs.AgendaLab
         /// </summary>
         private static List<PowerPointSlide> GetSectionSlides(AgendaSection section)
         {
-            var slides = PowerPointPresentation.Current.Slides;
+            List<PowerPointSlide> slides = PowerPointPresentation.Current.Slides;
 
             int firstSlideIndex = SectionFirstSlideIndex(section);
             int lastSlideIndex = SectionLastSlideIndex(section);

--- a/PowerPointLabs/PowerPointLabs/AgendaLab/AgendaShape.cs
+++ b/PowerPointLabs/PowerPointLabs/AgendaLab/AgendaShape.cs
@@ -66,7 +66,7 @@ namespace PowerPointLabs.AgendaLab
 
         public static bool IsBeamShape(Shape shape)
         {
-            var agendaShape = Decode(shape);
+            AgendaShape agendaShape = Decode(shape);
             if (agendaShape == null)
             {
                 return false;
@@ -103,7 +103,7 @@ namespace PowerPointLabs.AgendaLab
         {
             return shape =>
             {
-                var agendaShape = Decode(shape);
+                AgendaShape agendaShape = Decode(shape);
                 if (agendaShape == null)
                 {
                     return false;
@@ -121,7 +121,7 @@ namespace PowerPointLabs.AgendaLab
         {
             return shape =>
             {
-                var agendaShape = Decode(shape);
+                AgendaShape agendaShape = Decode(shape);
                 if (agendaShape == null)
                 {
                     return false;

--- a/PowerPointLabs/PowerPointLabs/AgendaLab/AgendaSlide.cs
+++ b/PowerPointLabs/PowerPointLabs/AgendaLab/AgendaSlide.cs
@@ -124,7 +124,7 @@ namespace PowerPointLabs.AgendaLab
         /// </summary>
         public static void AssignUniqueSectionName(PowerPointSlide slide)
         {
-            var properties = Decode(slide);
+            AgendaSlide properties = Decode(slide);
             slide.Name = Encode(properties.AgendaType, properties.SlidePurpose, AgendaSection.None);
         }
 
@@ -138,7 +138,7 @@ namespace PowerPointLabs.AgendaLab
 
         public static bool IsReferenceslide(PowerPointSlide slide)
         {
-            var agendaSlide = Decode(slide);
+            AgendaSlide agendaSlide = Decode(slide);
             if (agendaSlide == null)
             {
                 return false;
@@ -149,7 +149,7 @@ namespace PowerPointLabs.AgendaLab
 
         public static bool IsReferenceslide(Slide slide)
         {
-            var agendaSlide = Decode(slide);
+            AgendaSlide agendaSlide = Decode(slide);
             if (agendaSlide == null)
             {
                 return false;
@@ -188,7 +188,7 @@ namespace PowerPointLabs.AgendaLab
         {
             return slide =>
             {
-                var agendaSlide = Decode(slide);
+                AgendaSlide agendaSlide = Decode(slide);
                 if (agendaSlide == null)
                 {
                     return false;
@@ -207,7 +207,7 @@ namespace PowerPointLabs.AgendaLab
         {
             return slide =>
             {
-                var agendaSlide = Decode(slide);
+                AgendaSlide agendaSlide = Decode(slide);
                 if (agendaSlide == null)
                 {
                     return false;
@@ -219,7 +219,7 @@ namespace PowerPointLabs.AgendaLab
 
         public static bool MatchesPurpose(PowerPointSlide slide, SlidePurpose purpose)
         {
-            var agendaSlide = Decode(slide);
+            AgendaSlide agendaSlide = Decode(slide);
             if (agendaSlide == null)
             {
                 return false;

--- a/PowerPointLabs/PowerPointLabs/AgendaLab/Templates/TemplateIndexTable.cs
+++ b/PowerPointLabs/PowerPointLabs/AgendaLab/Templates/TemplateIndexTable.cs
@@ -48,8 +48,8 @@ namespace PowerPointLabs.AgendaLab.Templates
         /// </summary>
         public void StoreSlideObjects(List<PowerPointSlide> sectionSlides)
         {
-            var frontSlideObjects = new PowerPointSlide[FrontIndexes.Length];
-            var backSlideObjects = new PowerPointSlide[BackIndexes.Length];
+            PowerPointSlide[] frontSlideObjects = new PowerPointSlide[FrontIndexes.Length];
+            PowerPointSlide[] backSlideObjects = new PowerPointSlide[BackIndexes.Length];
 
             for (int i = 0; i < FrontIndexes.Length; ++i)
             {

--- a/PowerPointLabs/PowerPointLabs/AnimationLab/AutoAnimate.cs
+++ b/PowerPointLabs/PowerPointLabs/AnimationLab/AutoAnimate.cs
@@ -49,7 +49,7 @@ namespace PowerPointLabs.AnimationLab
         
         private static void AddCompleteAnimations(PowerPointSlide currentSlide, PowerPointSlide nextSlide)
         {
-            var addedSlide = currentSlide.CreateAutoAnimateSlide() as PowerPointAutoAnimateSlide;
+            PowerPointAutoAnimateSlide addedSlide = currentSlide.CreateAutoAnimateSlide() as PowerPointAutoAnimateSlide;
             Globals.ThisAddIn.Application.ActiveWindow.View.GotoSlide(addedSlide.Index);
 
             LoadingDialogBox loadingDialog = new LoadingDialogBox(content: AnimationLabText.AutoAnimateLoadingText);

--- a/PowerPointLabs/PowerPointLabs/AnimationLab/DefaultMotionAnimation.cs
+++ b/PowerPointLabs/PowerPointLabs/AnimationLab/DefaultMotionAnimation.cs
@@ -2,6 +2,8 @@
 using System.Collections.Generic;
 using System.Globalization;
 
+using Microsoft.Office.Interop.PowerPoint;
+
 using PowerPointLabs.Models;
 
 using Office = Microsoft.Office.Core;
@@ -151,8 +153,8 @@ namespace PowerPointLabs.AnimationLab
             AddMotionAnimation(animationSlide, initialShape, initialX, initialY, finalX, finalY, duration, ref trigger);
             AddResizeAnimation(animationSlide, initialShape, initialWidth, initialHeight, finalWidth, finalHeight, duration, ref trigger);
 
-            var sequence = animationSlide.TimeLine.MainSequence;
-            var effectDisappear = sequence.AddEffect(initialShape, PowerPoint.MsoAnimEffect.msoAnimEffectFade,
+            Sequence sequence = animationSlide.TimeLine.MainSequence;
+            Effect effectDisappear = sequence.AddEffect(initialShape, PowerPoint.MsoAnimEffect.msoAnimEffectFade,
                 PowerPoint.MsoAnimateByLevel.msoAnimateLevelNone,
                 PowerPoint.MsoAnimTriggerType.msoAnimTriggerWithPrevious);
             effectDisappear.Exit = Office.MsoTriState.msoTrue;
@@ -185,15 +187,15 @@ namespace PowerPointLabs.AnimationLab
                 PowerPointPresentation.Current.SlideHeight / shape.Height);
             animationSlide.RelocateShapeWithoutPath(shape, 0, 0, shape.Width * scaleRatio, shape.Height * scaleRatio);
 
-            var trigger = PowerPoint.MsoAnimTriggerType.msoAnimTriggerWithPrevious;
-            var effectMotion = AddMotionAnimation(animationSlide, shape, shape.Left, shape.Top, originalLeft + (originalWidth - shape.Width) / 2, originalTop + (originalHeight - shape.Height) / 2, 0, ref trigger);
-            var effectResize = AddResizeAnimation(animationSlide, shape, shape.Width, shape.Height, originalWidth, originalHeight, 0, ref trigger);
+            MsoAnimTriggerType trigger = PowerPoint.MsoAnimTriggerType.msoAnimTriggerWithPrevious;
+            Effect effectMotion = AddMotionAnimation(animationSlide, shape, shape.Left, shape.Top, originalLeft + (originalWidth - shape.Width) / 2, originalTop + (originalHeight - shape.Height) / 2, 0, ref trigger);
+            Effect effectResize = AddResizeAnimation(animationSlide, shape, shape.Width, shape.Height, originalWidth, originalHeight, 0, ref trigger);
 
             // Make "cover" image disappear after preload.
             PowerPoint.Effect effectDisappear = null;
             if (addCoverImage)
             {
-                var sequence = animationSlide.TimeLine.MainSequence;
+                Sequence sequence = animationSlide.TimeLine.MainSequence;
                 effectDisappear = sequence.AddEffect(coverImage, PowerPoint.MsoAnimEffect.msoAnimEffectFade,
                     PowerPoint.MsoAnimateByLevel.msoAnimateLevelNone,
                     PowerPoint.MsoAnimTriggerType.msoAnimTriggerWithPrevious);
@@ -225,13 +227,13 @@ namespace PowerPointLabs.AnimationLab
         /// </summary>
         public static void DuplicateAsCoverImage(PowerPointSlide animationSlide, PowerPoint.Shape shape)
         {
-            var coverImage = shape.Duplicate()[1];
+            Shape coverImage = shape.Duplicate()[1];
             coverImage.Left = shape.Left;
             coverImage.Top = shape.Top;
             animationSlide.RemoveAnimationsForShape(coverImage);
 
-            var sequence = animationSlide.TimeLine.MainSequence;
-            var effectDisappear = sequence.AddEffect(coverImage, PowerPoint.MsoAnimEffect.msoAnimEffectFade,
+            Sequence sequence = animationSlide.TimeLine.MainSequence;
+            Effect effectDisappear = sequence.AddEffect(coverImage, PowerPoint.MsoAnimEffect.msoAnimEffectFade,
                 PowerPoint.MsoAnimateByLevel.msoAnimateLevelNone,
                 PowerPoint.MsoAnimTriggerType.msoAnimTriggerWithPrevious);
             effectDisappear.Exit = Office.MsoTriState.msoTrue;

--- a/PowerPointLabs/PowerPointLabs/AudioMisc/Audio.cs
+++ b/PowerPointLabs/PowerPointLabs/AudioMisc/Audio.cs
@@ -67,7 +67,7 @@ namespace PowerPointLabs.AudioMisc
             this.Type = audioType;
 
             // derive matched id from shape name
-            var temp = shape.Name.Split(new[] { ' ' });
+            string[] temp = shape.Name.Split(new[] { ' ' });
             if (temp.Length < 3)
             {
                 throw new FormatException(NarrationsLabText.RecorderUnrecognizeAudio);
@@ -109,8 +109,8 @@ namespace PowerPointLabs.AudioMisc
         // the original timeline.
         public void EmbedOnSlide(PowerPointSlide slide, int clickNumber)
         {
-            var isOnClick = clickNumber > 0;
-            var shapeName = Name;
+            bool isOnClick = clickNumber > 0;
+            string shapeName = Name;
 
             if (slide != null)
             {
@@ -120,7 +120,7 @@ namespace PowerPointLabs.AudioMisc
                 // name.
                 try
                 {
-                    var audioShape = AudioHelper.InsertAudioFileOnSlide(slide, SaveName);
+                    Shape audioShape = AudioHelper.InsertAudioFileOnSlide(slide, SaveName);
                     audioShape.Name = "#";
                     slide.RemoveAnimationsForShape(audioShape);
 

--- a/PowerPointLabs/PowerPointLabs/AudioMisc/AudioHelper.cs
+++ b/PowerPointLabs/PowerPointLabs/AudioMisc/AudioHelper.cs
@@ -133,7 +133,7 @@ namespace PowerPointLabs.AudioMisc
                 length = GetAudioLength(saveName);  
             }
 
-            var audio = new Audio
+            Audio audio = new Audio
                             {
                                 Name = name,
                                 SaveName = saveName,

--- a/PowerPointLabs/PowerPointLabs/AutoUpdate/Downloader.cs
+++ b/PowerPointLabs/PowerPointLabs/AutoUpdate/Downloader.cs
@@ -48,7 +48,7 @@ namespace PowerPointLabs.AutoUpdate
         {
             try
             {
-                var th = new Task(StartDownload);
+                Task th = new Task(StartDownload);
                 th.Start();
             }
             catch (Exception e)
@@ -59,7 +59,7 @@ namespace PowerPointLabs.AutoUpdate
 
         private void CallAfterDownloadDelegate()
         {
-            var handler = AfterDownload;
+            AfterDownloadEventDelegate handler = AfterDownload;
             if (handler != null)
             {
                 handler();
@@ -68,7 +68,7 @@ namespace PowerPointLabs.AutoUpdate
 
         private void CallWhenErrorDelegate(Exception e)
         {
-            var handler = WhenError;
+            ErrorEventDelegate handler = WhenError;
             if (handler != null)
             {
                 handler(e);

--- a/PowerPointLabs/PowerPointLabs/AutoUpdate/Updater.cs
+++ b/PowerPointLabs/PowerPointLabs/AutoUpdate/Updater.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
 using System.Xml;
@@ -66,7 +67,7 @@ namespace PowerPointLabs.AutoUpdate
 
         private void AfterVstoDownloadHandler()
         {
-            var version = GetVstoVersion(_destVstoAddress);
+            string version = GetVstoVersion(_destVstoAddress);
             if (IsTheNewestVersion(version))
             {
                 return;
@@ -80,7 +81,7 @@ namespace PowerPointLabs.AutoUpdate
 
         private string GetVstoVersion(String vstoDirectory)
         {
-            var currentVsto = new XmlDocument();
+            XmlDocument currentVsto = new XmlDocument();
             try
             {
                 currentVsto.Load(vstoDirectory);
@@ -89,7 +90,7 @@ namespace PowerPointLabs.AutoUpdate
             {
                 Logger.LogException(e, "GetVstoVersion");
             }
-            var vstoNode = currentVsto.GetElementsByTagName("assemblyIdentity")[0];
+            XmlNode vstoNode = currentVsto.GetElementsByTagName("assemblyIdentity")[0];
 
             return vstoNode.Attributes != null
                 ? vstoNode.Attributes["version"].Value
@@ -120,9 +121,9 @@ namespace PowerPointLabs.AutoUpdate
 
         private void Unzip(String installerZipAddress)
         {
-            var installerZip = ZipStorer.Open(installerZipAddress, FileAccess.Read);
-            var zipDir = installerZip.ReadCentralDir();
-            foreach (var file in zipDir)
+            ZipStorer installerZip = ZipStorer.Open(installerZipAddress, FileAccess.Read);
+            List<ZipStorer.ZipFileEntry> zipDir = installerZip.ReadCentralDir();
+            foreach (ZipStorer.ZipFileEntry file in zipDir)
             {
                 installerZip.ExtractFile(file,
                     Path.Combine(_targetInstallFolder, file.FilenameInZip));

--- a/PowerPointLabs/PowerPointLabs/CaptionsLab/NotesToCaptions.cs
+++ b/PowerPointLabs/PowerPointLabs/CaptionsLab/NotesToCaptions.cs
@@ -46,7 +46,7 @@ namespace PowerPointLabs.CaptionsLab
 
         public static void EmbedCaptionsOnCurrentSlide()
         {
-            var currentSlide = PowerPointCurrentPresentationInfo.CurrentSlide;
+            PowerPointSlide currentSlide = PowerPointCurrentPresentationInfo.CurrentSlide;
             if (currentSlide != null)
             {
                 EmbedCaptionsOnSlides(
@@ -61,7 +61,7 @@ namespace PowerPointLabs.CaptionsLab
 
         public static void RemoveCaptionsFromCurrentSlide()
         {
-            var currentSlide = PowerPointCurrentPresentationInfo.CurrentSlide;
+            PowerPointSlide currentSlide = PowerPointCurrentPresentationInfo.CurrentSlide;
             if (currentSlide != null)
             {
                 RemoveCaptionsFromSlide(currentSlide);
@@ -94,8 +94,8 @@ namespace PowerPointLabs.CaptionsLab
                 return false;
             }
 
-            var separatedNotes = SplitNotesByClicks(rawNotes);
-            var captionCollection = ConvertSectionsToCaptions(separatedNotes);
+            IEnumerable<string> separatedNotes = SplitNotesByClicks(rawNotes);
+            List<string> captionCollection = ConvertSectionsToCaptions(separatedNotes);
             if (captionCollection.Count == 0)
             {
                 return false;

--- a/PowerPointLabs/PowerPointLabs/ColorPicker/ColorHelper.cs
+++ b/PowerPointLabs/PowerPointLabs/ColorPicker/ColorHelper.cs
@@ -23,8 +23,8 @@ namespace PowerPointLabs.ColorPicker
                 }
             }
 
-            var baseAngle = (float) originalColor.Hue / 240.0f * 360.0f;
-            var finalAngle = baseAngle + angle;
+            float baseAngle = (float) originalColor.Hue / 240.0f * 360.0f;
+            float finalAngle = baseAngle + angle;
             
             if (finalAngle > 360.0f)
             {
@@ -45,7 +45,7 @@ namespace PowerPointLabs.ColorPicker
 
         public static List<Color> GetAnalogousColorsForColor(HSLColor originalColor)
         {
-            var analogousColors = new List<Color>
+            List<Color> analogousColors = new List<Color>
             {
                 GetColorShiftedByAngle(originalColor, -30.0f),
                 GetColorShiftedByAngle(originalColor, 30.0f)
@@ -56,7 +56,7 @@ namespace PowerPointLabs.ColorPicker
 
         public static List<Color> GetTriadicColorsForColor(HSLColor originalColor)
         {
-            var triadicColors = new List<Color>
+            List<Color> triadicColors = new List<Color>
             {
                 GetColorShiftedByAngle(originalColor, -120.0f),
                 GetColorShiftedByAngle(originalColor, 120.0f)
@@ -67,7 +67,7 @@ namespace PowerPointLabs.ColorPicker
 
         public static List<Color> GetTetradicColorsForColor(HSLColor originalColor)
         {
-            var tetradicColors = new List<Color>
+            List<Color> tetradicColors = new List<Color>
             {
                 GetColorShiftedByAngle(originalColor, -90.0f),
                 GetColorShiftedByAngle(originalColor, 90.0f),
@@ -79,7 +79,7 @@ namespace PowerPointLabs.ColorPicker
 
         public static List<Color> GetSplitComplementaryColorsForColor(HSLColor originalColor)
         {
-            var splitComplementaryColors = new List<Color>
+            List<Color> splitComplementaryColors = new List<Color>
             {
                 GetColorShiftedByAngle(originalColor, 150.0f),
                 GetColorShiftedByAngle(originalColor, 210.0f)

--- a/PowerPointLabs/PowerPointLabs/ColorPicker/ColorInformationDialog.cs
+++ b/PowerPointLabs/PowerPointLabs/ColorPicker/ColorInformationDialog.cs
@@ -46,7 +46,7 @@ namespace PowerPointLabs.ColorPicker
 
         private void TextBox_Enter(object sender, EventArgs e)
         {
-            var textBox = (TextBox) sender;
+            TextBox textBox = (TextBox) sender;
             Clipboard.SetText(textBox.Text.Substring(5));
             if (textBox.Equals(hslTextBox))
             {

--- a/PowerPointLabs/PowerPointLabs/ColorPicker/ColorPane.cs
+++ b/PowerPointLabs/PowerPointLabs/ColorPicker/ColorPane.cs
@@ -1094,7 +1094,7 @@ namespace PowerPointLabs
         private Color GetSelectedShapeColor(PowerPoint.ShapeRange selectedShapes)
         {
             Color colorToReturn = Color.Empty;
-            foreach (PowerPoint.Shape selectedShape in selectedShapes)
+            foreach (object selectedShape in selectedShapes)
             {
                 Color color = GetSelectedShapeColor(selectedShape as PowerPoint.Shape);
                 if (colorToReturn.Equals(Color.Empty))

--- a/PowerPointLabs/PowerPointLabs/ColorPicker/ColorPane.cs
+++ b/PowerPointLabs/PowerPointLabs/ColorPicker/ColorPane.cs
@@ -451,7 +451,7 @@ namespace PowerPointLabs
         {
             try
             {
-                var selection = PowerPointCurrentPresentationInfo.CurrentSelection;
+                Selection selection = PowerPointCurrentPresentationInfo.CurrentSelection;
                 if (selection == null)
                 {
                     return;
@@ -492,11 +492,11 @@ namespace PowerPointLabs
                 {
                     try
                     {
-                        var r = ((Color)selectedColor).R;
-                        var g = ((Color)selectedColor).G;
-                        var b = ((Color)selectedColor).B;
+                        Byte r = ((Color)selectedColor).R;
+                        Byte g = ((Color)selectedColor).G;
+                        Byte b = ((Color)selectedColor).B;
 
-                        var rgb = (b << 16) | (g << 8) | (r);
+                        int rgb = (b << 16) | (g << 8) | (r);
                         ColorShapeWithColor(s, rgb, currMode);
                     }
                     catch (Exception)
@@ -510,11 +510,11 @@ namespace PowerPointLabs
             {
                 try
                 {
-                    var r = ((Color)selectedColor).R;
-                    var g = ((Color)selectedColor).G;
-                    var b = ((Color)selectedColor).B;
+                    Byte r = ((Color)selectedColor).R;
+                    Byte g = ((Color)selectedColor).G;
+                    Byte b = ((Color)selectedColor).B;
 
-                    var rgb = (b << 16) | (g << 8) | (r);
+                    int rgb = (b << 16) | (g << 8) | (r);
                     ColorShapeWithColor(_selectedText, rgb, currMode);
                 }
                 catch (Exception)
@@ -587,8 +587,8 @@ namespace PowerPointLabs
 
         private void ColorShapeWithColor(PowerPoint.TextRange text, int rgb, MODE mode)
         {
-            var frame = text.Parent as PowerPoint.TextFrame;
-            var selectedShape = frame.Parent as PowerPoint.Shape;
+            PowerPoint.TextFrame frame = text.Parent as PowerPoint.TextFrame;
+            PowerPoint.Shape selectedShape = frame.Parent as PowerPoint.Shape;
             if (mode != MODE.NONE)
             {
                 ColorShapeWithColor(selectedShape, rgb, mode);
@@ -653,7 +653,7 @@ namespace PowerPointLabs
             if (!timer1.Enabled)
             {
                 float newBrightness = brightnessBar.Value;
-                var newColor = new HSLColor();
+                HSLColor newColor = new HSLColor();
                 try
                 {
                     newColor.Hue = dataSource.SelectedColor.Hue;
@@ -679,7 +679,7 @@ namespace PowerPointLabs
         private void SaturationBar_ValueChanged(object sender, EventArgs e)
         {
             float newSaturation = saturationBar.Value;
-            var newColor = new HSLColor();
+            HSLColor newColor = new HSLColor();
             try
             {
                 newColor.Hue = dataSource.SelectedColor.Hue;
@@ -707,9 +707,9 @@ namespace PowerPointLabs
 
         private void DrawBrightnessGradient(HSLColor color)
         {
-            var dis = brightnessPanel.DisplayRectangle;
-            var screenRec = brightnessPanel.RectangleToScreen(dis);
-            var rec = brightnessPanel.Parent.RectangleToClient(screenRec);
+            Rectangle dis = brightnessPanel.DisplayRectangle;
+            Rectangle screenRec = brightnessPanel.RectangleToScreen(dis);
+            Rectangle rec = brightnessPanel.Parent.RectangleToClient(screenRec);
             brightnessPanel.Visible = false;
             LinearGradientBrush brush = new LinearGradientBrush(
                 rec,
@@ -746,9 +746,9 @@ namespace PowerPointLabs
 
         private void DrawSaturationGradient(HSLColor color)
         {
-            var dis = saturationPanel.DisplayRectangle;
-            var screenRec = saturationPanel.RectangleToScreen(dis);
-            var rec = saturationPanel.Parent.RectangleToClient(screenRec);
+            Rectangle dis = saturationPanel.DisplayRectangle;
+            Rectangle screenRec = saturationPanel.RectangleToScreen(dis);
+            Rectangle rec = saturationPanel.Parent.RectangleToClient(screenRec);
             saturationPanel.Visible = false;
             LinearGradientBrush brush = new LinearGradientBrush(
                 rec,
@@ -1083,8 +1083,8 @@ namespace PowerPointLabs
             }
             if (PowerPointCurrentPresentationInfo.CurrentSelection.Type == PpSelectionType.ppSelectionText)
             {
-                var frame = _selectedText.Parent as PowerPoint.TextFrame;
-                var selectedShape = frame.Parent as PowerPoint.Shape;
+                PowerPoint.TextFrame frame = _selectedText.Parent as PowerPoint.TextFrame;
+                PowerPoint.Shape selectedShape = frame.Parent as PowerPoint.Shape;
                 return GetSelectedShapeColor(selectedShape);
             }
 
@@ -1094,7 +1094,7 @@ namespace PowerPointLabs
         private Color GetSelectedShapeColor(PowerPoint.ShapeRange selectedShapes)
         {
             Color colorToReturn = Color.Empty;
-            foreach (var selectedShape in selectedShapes)
+            foreach (PowerPoint.Shape selectedShape in selectedShapes)
             {
                 Color color = GetSelectedShapeColor(selectedShape as PowerPoint.Shape);
                 if (colorToReturn.Equals(Color.Empty))
@@ -1124,7 +1124,7 @@ namespace PowerPointLabs
                     {
                         if (PowerPointCurrentPresentationInfo.CurrentSelection.Type == PpSelectionType.ppSelectionText)
                         {
-                            var selectedText
+                            TextRange selectedText
                                 = Globals.ThisAddIn.Application.ActiveWindow.Selection.TextRange.TrimText();
                             if (selectedText != null && selectedText.Text != "")
                             {
@@ -1201,7 +1201,7 @@ namespace PowerPointLabs
         {
             get
             {
-                var createParams = base.CreateParams;
+                CreateParams createParams = base.CreateParams;
                 createParams.ExStyle |= (int)Native.Message.WS_EX_COMPOSITED;  // Turn on WS_EX_COMPOSITED
                 return createParams;
             }

--- a/PowerPointLabs/PowerPointLabs/Converters/ColorPane/SelectedColorToAnalogousHigher.cs
+++ b/PowerPointLabs/PowerPointLabs/Converters/ColorPane/SelectedColorToAnalogousHigher.cs
@@ -8,7 +8,7 @@ namespace PowerPointLabs.Converters.ColorPane
     {
         public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
         {
-            var selectedColor = (HSLColor)value;
+            HSLColor selectedColor = (HSLColor)value;
             return ColorHelper.GetColorShiftedByAngle(selectedColor, 30.0f);
         }
 

--- a/PowerPointLabs/PowerPointLabs/Converters/ColorPane/SelectedColorToAnalogousLower.cs
+++ b/PowerPointLabs/PowerPointLabs/Converters/ColorPane/SelectedColorToAnalogousLower.cs
@@ -8,7 +8,7 @@ namespace PowerPointLabs.Converters.ColorPane
     {
         public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
         {
-            var selectedColor = (HSLColor)value;
+            HSLColor selectedColor = (HSLColor)value;
             return ColorHelper.GetColorShiftedByAngle(selectedColor, -30.0f);
         }
 

--- a/PowerPointLabs/PowerPointLabs/Converters/ColorPane/SelectedColorToBrightnessValue.cs
+++ b/PowerPointLabs/PowerPointLabs/Converters/ColorPane/SelectedColorToBrightnessValue.cs
@@ -7,7 +7,7 @@ namespace PowerPointLabs.Converters.ColorPane
     {
         public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
         {
-            var selectedColor = (HSLColor)value;
+            HSLColor selectedColor = (HSLColor)value;
             return (int)(selectedColor.Luminosity);
         }
 

--- a/PowerPointLabs/PowerPointLabs/Converters/ColorPane/SelectedColorToComplementaryColor.cs
+++ b/PowerPointLabs/PowerPointLabs/Converters/ColorPane/SelectedColorToComplementaryColor.cs
@@ -8,7 +8,7 @@ namespace PowerPointLabs.Converters.ColorPane
     {
         public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
         {
-            var selectedColor = (HSLColor)value;
+            HSLColor selectedColor = (HSLColor)value;
             return ColorHelper.GetColorShiftedByAngle(selectedColor, 180.0f);
         }
 

--- a/PowerPointLabs/PowerPointLabs/Converters/ColorPane/SelectedColorToMonochromaticFive.cs
+++ b/PowerPointLabs/PowerPointLabs/Converters/ColorPane/SelectedColorToMonochromaticFive.cs
@@ -8,7 +8,7 @@ namespace PowerPointLabs.Converters.ColorPane
     {
         public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
         {
-            var selectedColor = (HSLColor)value;
+            HSLColor selectedColor = (HSLColor)value;
             Color convertedColor = new HSLColor(selectedColor.Hue, selectedColor.Saturation, 0.40f * 240);
             return Color.FromArgb(255,
                 convertedColor.R,

--- a/PowerPointLabs/PowerPointLabs/Converters/ColorPane/SelectedColorToMonochromaticFour.cs
+++ b/PowerPointLabs/PowerPointLabs/Converters/ColorPane/SelectedColorToMonochromaticFour.cs
@@ -8,7 +8,7 @@ namespace PowerPointLabs.Converters.ColorPane
     {
         public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
         {
-            var selectedColor = (HSLColor)value;
+            HSLColor selectedColor = (HSLColor)value;
             Color convertedColor = new HSLColor(selectedColor.Hue, selectedColor.Saturation, 0.50f * 240);
             return Color.FromArgb(255,
                 convertedColor.R,

--- a/PowerPointLabs/PowerPointLabs/Converters/ColorPane/SelectedColorToMonochromaticOne.cs
+++ b/PowerPointLabs/PowerPointLabs/Converters/ColorPane/SelectedColorToMonochromaticOne.cs
@@ -8,7 +8,7 @@ namespace PowerPointLabs.Converters.ColorPane
     {
         public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
         {
-            var selectedColor = (HSLColor)value;
+            HSLColor selectedColor = (HSLColor)value;
             Color convertedColor = new HSLColor(selectedColor.Hue, selectedColor.Saturation, 0.80f * 240);
             return Color.FromArgb(255,
                 convertedColor.R,

--- a/PowerPointLabs/PowerPointLabs/Converters/ColorPane/SelectedColorToMonochromaticSeven.cs
+++ b/PowerPointLabs/PowerPointLabs/Converters/ColorPane/SelectedColorToMonochromaticSeven.cs
@@ -8,7 +8,7 @@ namespace PowerPointLabs.Converters.ColorPane
     {
         public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
         {
-            var selectedColor = (HSLColor)value;
+            HSLColor selectedColor = (HSLColor)value;
             Color convertedColor = new HSLColor(selectedColor.Hue, selectedColor.Saturation, 0.20f * 240);
             return Color.FromArgb(255,
                 convertedColor.R,

--- a/PowerPointLabs/PowerPointLabs/Converters/ColorPane/SelectedColorToMonochromaticSix.cs
+++ b/PowerPointLabs/PowerPointLabs/Converters/ColorPane/SelectedColorToMonochromaticSix.cs
@@ -8,7 +8,7 @@ namespace PowerPointLabs.Converters.ColorPane
     {
         public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
         {
-            var selectedColor = (HSLColor)value;
+            HSLColor selectedColor = (HSLColor)value;
             Color convertedColor = new HSLColor(selectedColor.Hue, selectedColor.Saturation, 0.30f * 240);
             return Color.FromArgb(255,
                 convertedColor.R,

--- a/PowerPointLabs/PowerPointLabs/Converters/ColorPane/SelectedColorToMonochromaticThree.cs
+++ b/PowerPointLabs/PowerPointLabs/Converters/ColorPane/SelectedColorToMonochromaticThree.cs
@@ -8,7 +8,7 @@ namespace PowerPointLabs.Converters.ColorPane
     {
         public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
         {
-            var selectedColor = (HSLColor)value;
+            HSLColor selectedColor = (HSLColor)value;
             Color convertedColor = new HSLColor(selectedColor.Hue, selectedColor.Saturation, 0.60f * 240);
             return Color.FromArgb(255,
                 convertedColor.R,

--- a/PowerPointLabs/PowerPointLabs/Converters/ColorPane/SelectedColorToMonochromaticTwo.cs
+++ b/PowerPointLabs/PowerPointLabs/Converters/ColorPane/SelectedColorToMonochromaticTwo.cs
@@ -8,7 +8,7 @@ namespace PowerPointLabs.Converters.ColorPane
     {
         public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
         {
-            var selectedColor = (HSLColor)value;
+            HSLColor selectedColor = (HSLColor)value;
             Color convertedColor = new HSLColor(selectedColor.Hue, selectedColor.Saturation, 0.70f * 240);
             return Color.FromArgb(255,
                 convertedColor.R,

--- a/PowerPointLabs/PowerPointLabs/Converters/ColorPane/SelectedColorToSaturationValue.cs
+++ b/PowerPointLabs/PowerPointLabs/Converters/ColorPane/SelectedColorToSaturationValue.cs
@@ -8,7 +8,7 @@ namespace PowerPointLabs.Converters.ColorPane
     {
         public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
         {
-            var selectedColor = (HSLColor)value;
+            HSLColor selectedColor = (HSLColor)value;
             return (int)(selectedColor.Saturation);
         }
 

--- a/PowerPointLabs/PowerPointLabs/Converters/ColorPane/SelectedColorToSplitComplementaryHigher.cs
+++ b/PowerPointLabs/PowerPointLabs/Converters/ColorPane/SelectedColorToSplitComplementaryHigher.cs
@@ -8,7 +8,7 @@ namespace PowerPointLabs.Converters.ColorPane
     {
         public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
         {
-            var selectedColor = (HSLColor)value;
+            HSLColor selectedColor = (HSLColor)value;
             return ColorHelper.GetColorShiftedByAngle(selectedColor, 210.0f);
         }
 

--- a/PowerPointLabs/PowerPointLabs/Converters/ColorPane/SelectedColorToSplitComplementaryLower.cs
+++ b/PowerPointLabs/PowerPointLabs/Converters/ColorPane/SelectedColorToSplitComplementaryLower.cs
@@ -8,7 +8,7 @@ namespace PowerPointLabs.Converters.ColorPane
     {
         public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
         {
-            var selectedColor = (HSLColor)value;
+            HSLColor selectedColor = (HSLColor)value;
             return ColorHelper.GetColorShiftedByAngle(selectedColor, 150.0f);
         }
 

--- a/PowerPointLabs/PowerPointLabs/Converters/ColorPane/SelectedColorToTetradicOne.cs
+++ b/PowerPointLabs/PowerPointLabs/Converters/ColorPane/SelectedColorToTetradicOne.cs
@@ -8,7 +8,7 @@ namespace PowerPointLabs.Converters.ColorPane
     {
         public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
         {
-            var selectedColor = (HSLColor)value;
+            HSLColor selectedColor = (HSLColor)value;
             return ColorHelper.GetColorShiftedByAngle(selectedColor, 90.0f);
         }
 

--- a/PowerPointLabs/PowerPointLabs/Converters/ColorPane/SelectedColorToTetradicThree.cs
+++ b/PowerPointLabs/PowerPointLabs/Converters/ColorPane/SelectedColorToTetradicThree.cs
@@ -8,7 +8,7 @@ namespace PowerPointLabs.Converters.ColorPane
     {
         public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
         {
-            var selectedColor = (HSLColor)value;
+            HSLColor selectedColor = (HSLColor)value;
             return ColorHelper.GetColorShiftedByAngle(selectedColor, 270.0f);
         }
 

--- a/PowerPointLabs/PowerPointLabs/Converters/ColorPane/SelectedColorToTetradicTwo.cs
+++ b/PowerPointLabs/PowerPointLabs/Converters/ColorPane/SelectedColorToTetradicTwo.cs
@@ -8,7 +8,7 @@ namespace PowerPointLabs.Converters.ColorPane
     {
         public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
         {
-            var selectedColor = (HSLColor)value;
+            HSLColor selectedColor = (HSLColor)value;
             return ColorHelper.GetColorShiftedByAngle(selectedColor, 180.0f);
         }
 

--- a/PowerPointLabs/PowerPointLabs/Converters/ColorPane/SelectedColorToTriadicHigher.cs
+++ b/PowerPointLabs/PowerPointLabs/Converters/ColorPane/SelectedColorToTriadicHigher.cs
@@ -8,7 +8,7 @@ namespace PowerPointLabs.Converters.ColorPane
     {
         public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
         {
-            var selectedColor = (HSLColor)value;
+            HSLColor selectedColor = (HSLColor)value;
             return ColorHelper.GetColorShiftedByAngle(selectedColor, 120.0f);
         }
 

--- a/PowerPointLabs/PowerPointLabs/Converters/ColorPane/SelectedColorToTriadicLower.cs
+++ b/PowerPointLabs/PowerPointLabs/Converters/ColorPane/SelectedColorToTriadicLower.cs
@@ -8,7 +8,7 @@ namespace PowerPointLabs.Converters.ColorPane
     {
         public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
         {
-            var selectedColor = (HSLColor)value;
+            HSLColor selectedColor = (HSLColor)value;
             return ColorHelper.GetColorShiftedByAngle(selectedColor, -120.0f);
         }
 

--- a/PowerPointLabs/PowerPointLabs/CropLab/CropLabErrorHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/CropLab/CropLabErrorHandler.cs
@@ -90,7 +90,7 @@ namespace PowerPointLabs.CropLab
             {
                 return;
             }
-            var errorMsg = string.Format(GetErrorMessage(errorType), optionalParameters);
+            string errorMsg = string.Format(GetErrorMessage(errorType), optionalParameters);
             View.ShowErrorMessageBox(errorMsg);
         }
 

--- a/PowerPointLabs/PowerPointLabs/CropLab/CropToAspectRatio.cs
+++ b/PowerPointLabs/PowerPointLabs/CropLab/CropToAspectRatio.cs
@@ -11,7 +11,7 @@ namespace PowerPointLabs.CropLab
 
         public static PowerPoint.ShapeRange Crop(PowerPoint.Selection selection, float aspectRatio)
         {
-            var croppedShape = Crop(selection.ShapeRange, aspectRatio);
+            PowerPoint.ShapeRange croppedShape = Crop(selection.ShapeRange, aspectRatio);
             if (croppedShape != null)
             {
                 croppedShape.Select();

--- a/PowerPointLabs/PowerPointLabs/CropLab/CropToShape.cs
+++ b/PowerPointLabs/PowerPointLabs/CropLab/CropToShape.cs
@@ -25,13 +25,13 @@ namespace PowerPointLabs.CropLab
         public static Shape Crop(PowerPointSlide currentSlide, Selection selection,
                                 double magnifyRatio = 1.0, bool isInPlace = false, bool handleError = true)
         {
-            var shapeRange = selection.ShapeRange;
+            ShapeRange shapeRange = selection.ShapeRange;
             if (selection.HasChildShapeRange)
             {
                 shapeRange = selection.ChildShapeRange;
             }
 
-            var croppedShape = Crop(currentSlide, shapeRange, isInPlace: isInPlace, handleError: handleError);
+            Shape croppedShape = Crop(currentSlide, shapeRange, isInPlace: isInPlace, handleError: handleError);
             if (croppedShape != null)
             {
                 croppedShape.Select();
@@ -45,10 +45,10 @@ namespace PowerPointLabs.CropLab
         {
             try
             {
-                var hasManyShapes = shapeRange.Count > 1;
-                var shape = hasManyShapes ? shapeRange.Group() : shapeRange[1];
-                var left = shape.Left;
-                var top = shape.Top;
+                bool hasManyShapes = shapeRange.Count > 1;
+                Shape shape = hasManyShapes ? shapeRange.Group() : shapeRange[1];
+                float left = shape.Left;
+                float top = shape.Top;
                 shape.Cut();
                 shapeRange = currentSlide.Shapes.Paste();
                 shapeRange.Left = left;
@@ -60,17 +60,17 @@ namespace PowerPointLabs.CropLab
 
                 TakeScreenshotProxy(currentSlide, shapeRange);
 
-                var ungroupedRange = EffectsLabUtil.UngroupAllShapeRange(currentSlide, shapeRange);
+                ShapeRange ungroupedRange = EffectsLabUtil.UngroupAllShapeRange(currentSlide, shapeRange);
                 List<Shape> shapeList = new List<Shape>();
 
                 for (int i = 1; i <= ungroupedRange.Count; i++)
                 {
-                    var filledShape = FillInShapeWithImage(currentSlide, SlidePicture, ungroupedRange[i], magnifyRatio, isInPlace);
+                    Shape filledShape = FillInShapeWithImage(currentSlide, SlidePicture, ungroupedRange[i], magnifyRatio, isInPlace);
                     shapeList.Add(filledShape);
                 }
                 
-                var croppedRange = currentSlide.ToShapeRange(shapeList);
-                var croppedShape = (croppedRange.Count == 1) ? croppedRange[1] : croppedRange.Group();
+                ShapeRange croppedRange = currentSlide.ToShapeRange(shapeList);
+                Shape croppedShape = (croppedRange.Count == 1) ? croppedRange[1] : croppedRange.Group();
 
                 return croppedShape;
             }
@@ -94,7 +94,7 @@ namespace PowerPointLabs.CropLab
             }
 
             shape.Copy();
-            var shapeToReturn = currentSlide.Shapes.Paste()[1];
+            Shape shapeToReturn = currentSlide.Shapes.Paste()[1];
             shape.Delete();
             return shapeToReturn;
         }
@@ -105,16 +105,16 @@ namespace PowerPointLabs.CropLab
             if (original == null) { return null; }
             try
             {
-                var outputImage = new Bitmap((int)width, (int)height, PixelFormat.Format32bppArgb);
+                Bitmap outputImage = new Bitmap((int)width, (int)height, PixelFormat.Format32bppArgb);
 
-                var inverseRatio = 1 / magnifyRatio;
+                double inverseRatio = 1 / magnifyRatio;
 
-                var newWidth = width * inverseRatio;
-                var newHeight = height * inverseRatio;
-                var newY = startY + (1 - inverseRatio) / 2 * width;
-                var newX = startX + (1 - inverseRatio) / 2 * width;
+                double newWidth = width * inverseRatio;
+                double newHeight = height * inverseRatio;
+                double newY = startY + (1 - inverseRatio) / 2 * width;
+                double newX = startX + (1 - inverseRatio) / 2 * width;
 
-                var inputGraphics = Graphics.FromImage(outputImage);
+                Graphics inputGraphics = Graphics.FromImage(outputImage);
                 inputGraphics.DrawImage(original,
                     new Rectangle(0, 0, (int)width, (int)height),
                     new Rectangle((int)newX, (int)newY, (int)newWidth, (int)newHeight),
@@ -131,7 +131,7 @@ namespace PowerPointLabs.CropLab
 
         private static void CreateFillInBackgroundForShape(string imageFile, Shape shape, double magnifyRatio = 1.0)
         {
-            using (var slideImage = (Bitmap)Image.FromFile(imageFile))
+            using (Bitmap slideImage = (Bitmap)Image.FromFile(imageFile))
             {
                 if (shape.Rotation == 0)
                 {
@@ -146,7 +146,7 @@ namespace PowerPointLabs.CropLab
 
         private static void CreateFillInBackground(Shape shape, Bitmap slideImage, double magnifyRatio = 1.0)
         {
-            var croppedImage = KiCut(slideImage,
+            Bitmap croppedImage = KiCut(slideImage,
                 shape.Left * GraphicsUtil.PictureExportingRatio,
                 shape.Top * GraphicsUtil.PictureExportingRatio,
                 shape.Width * GraphicsUtil.PictureExportingRatio,
@@ -157,8 +157,8 @@ namespace PowerPointLabs.CropLab
 
         private static void CreateRotatedFillInBackground(Shape shape, Bitmap slideImage, double magnifyRatio = 1.0)
         {
-            var rotatedShape = new PPShape(shape, false);
-            var topLeftPoint = new PointF(rotatedShape.ActualTopLeft.X * GraphicsUtil.PictureExportingRatio,
+            PPShape rotatedShape = new PPShape(shape, false);
+            PointF topLeftPoint = new PointF(rotatedShape.ActualTopLeft.X * GraphicsUtil.PictureExportingRatio,
                 rotatedShape.ActualTopLeft.Y * GraphicsUtil.PictureExportingRatio);
 
             Bitmap rotatedImage = new Bitmap(slideImage.Width, slideImage.Height);
@@ -177,7 +177,7 @@ namespace PowerPointLabs.CropLab
                 }
             }
 
-            var magnifiedImage = KiCut(rotatedImage, 0, 0, shape.Width * GraphicsUtil.PictureExportingRatio,
+            Bitmap magnifiedImage = KiCut(rotatedImage, 0, 0, shape.Width * GraphicsUtil.PictureExportingRatio,
                 shape.Height * GraphicsUtil.PictureExportingRatio, magnifyRatio);
             magnifiedImage.Save(FillInBackgroundPicture, ImageFormat.Png);
         }

--- a/PowerPointLabs/PowerPointLabs/CropLab/CropToSlide.cs
+++ b/PowerPointLabs/PowerPointLabs/CropLab/CropToSlide.cs
@@ -39,7 +39,7 @@ namespace PowerPointLabs.CropLab
             if (!ShapeUtil.IsPicture(shape) || shape.Rotation != 0)
             {
                 GraphicsUtil.ExportShape(shape, ShapePicture);
-                var newShape = currentSlide.Shapes.AddPicture(ShapePicture,
+                Shape newShape = currentSlide.Shapes.AddPicture(ShapePicture,
                     Office.MsoTriState.msoFalse,
                     Office.MsoTriState.msoTrue,
                     shapeBounds.Left, shapeBounds.Top, shapeBounds.Width, shapeBounds.Height);

--- a/PowerPointLabs/PowerPointLabs/CustomBinding.cs
+++ b/PowerPointLabs/PowerPointLabs/CustomBinding.cs
@@ -49,7 +49,7 @@ namespace PowerPointLabs
         {
             if (this._converter != null)
             {
-                var converterdValue = this._converter.Convert(cevent.Value, cevent.DesiredType, _converterParameter,
+                object converterdValue = this._converter.Convert(cevent.Value, cevent.DesiredType, _converterParameter,
                                                               _converterCulture);
                 cevent.Value = converterdValue;
             }
@@ -63,7 +63,7 @@ namespace PowerPointLabs
         {
             if (this._converter != null)
             {
-                var converterdValue = this._converter.ConvertBack(cevent.Value, cevent.DesiredType, _converterParameter,
+                object converterdValue = this._converter.ConvertBack(cevent.Value, cevent.DesiredType, _converterParameter,
                                                                   _converterCulture);
 
                 cevent.Value = converterdValue;

--- a/PowerPointLabs/PowerPointLabs/EffectsLab/EffectsLabRecolor.cs
+++ b/PowerPointLabs/PowerPointLabs/EffectsLab/EffectsLabRecolor.cs
@@ -8,7 +8,7 @@ namespace PowerPointLabs.EffectsLab
     {
         public static void GreyScaleRemainderEffect(PowerPointSlide curSlide, Selection selection)
         {
-            var effectSlide = EffectsLabUtil.GenerateEffectSlide(curSlide, selection, true);
+            PowerPointBgEffectSlide effectSlide = EffectsLabUtil.GenerateEffectSlide(curSlide, selection, true);
 
             if (effectSlide == null)
             {
@@ -21,7 +21,7 @@ namespace PowerPointLabs.EffectsLab
 
         public static void BlackWhiteRemainderEffect(PowerPointSlide curSlide, Selection selection)
         {
-            var effectSlide = EffectsLabUtil.GenerateEffectSlide(curSlide, selection, true);
+            PowerPointBgEffectSlide effectSlide = EffectsLabUtil.GenerateEffectSlide(curSlide, selection, true);
             
             if (effectSlide == null)
             {
@@ -35,7 +35,7 @@ namespace PowerPointLabs.EffectsLab
         public static void GothamRemainderEffect(PowerPointSlide curSlide, Selection selection)
         {
 
-            var effectSlide = EffectsLabUtil.GenerateEffectSlide(curSlide, selection, true);
+            PowerPointBgEffectSlide effectSlide = EffectsLabUtil.GenerateEffectSlide(curSlide, selection, true);
 
             if (effectSlide == null)
             {
@@ -48,7 +48,7 @@ namespace PowerPointLabs.EffectsLab
 
         public static void SepiaRemainderEffect(PowerPointSlide curSlide, Selection selection)
         {
-            var effectSlide = EffectsLabUtil.GenerateEffectSlide(curSlide, selection, true);
+            PowerPointBgEffectSlide effectSlide = EffectsLabUtil.GenerateEffectSlide(curSlide, selection, true);
 
             if (effectSlide == null)
             {
@@ -61,7 +61,7 @@ namespace PowerPointLabs.EffectsLab
 
         public static void GreyScaleBackgroundEffect(PowerPointSlide curSlide, Selection selection)
         {
-            var effectSlide = EffectsLabUtil.GenerateEffectSlide(curSlide, selection, false);
+            PowerPointBgEffectSlide effectSlide = EffectsLabUtil.GenerateEffectSlide(curSlide, selection, false);
 
             if (effectSlide == null)
             {
@@ -74,7 +74,7 @@ namespace PowerPointLabs.EffectsLab
 
         public static void BlackWhiteBackgroundEffect(PowerPointSlide curSlide, Selection selection)
         {
-            var effectSlide = EffectsLabUtil.GenerateEffectSlide(curSlide, selection, false);
+            PowerPointBgEffectSlide effectSlide = EffectsLabUtil.GenerateEffectSlide(curSlide, selection, false);
 
             if (effectSlide == null)
             {
@@ -87,7 +87,7 @@ namespace PowerPointLabs.EffectsLab
 
         public static void GothamBackgroundEffect(PowerPointSlide curSlide, Selection selection)
         {
-            var effectSlide = EffectsLabUtil.GenerateEffectSlide(curSlide, selection, false);
+            PowerPointBgEffectSlide effectSlide = EffectsLabUtil.GenerateEffectSlide(curSlide, selection, false);
 
             if (effectSlide == null)
             {
@@ -100,7 +100,7 @@ namespace PowerPointLabs.EffectsLab
 
         public static void SepiaBackgroundEffect(PowerPointSlide curSlide, Selection selection)
         {
-            var effectSlide = EffectsLabUtil.GenerateEffectSlide(curSlide, selection, false);
+            PowerPointBgEffectSlide effectSlide = EffectsLabUtil.GenerateEffectSlide(curSlide, selection, false);
 
             if (effectSlide == null)
             {

--- a/PowerPointLabs/PowerPointLabs/EffectsLab/EffectsLabUtil.cs
+++ b/PowerPointLabs/PowerPointLabs/EffectsLab/EffectsLabUtil.cs
@@ -22,7 +22,7 @@ namespace PowerPointLabs.EffectsLab
 
             for (int i = 1; i <= shapeRange.Count; i++)
             {
-                var shape = shapeRange[i];
+                Shape shape = shapeRange[i];
                 if (ShapeUtil.IsCorrupted(shape))
                 {
                     shape = ShapeUtil.CorruptionCorrection(shape, curSlide);
@@ -34,7 +34,7 @@ namespace PowerPointLabs.EffectsLab
             {
                 if (originalShapeList[i].Type == Office.MsoShapeType.msoGroup)
                 {
-                    var subRange = originalShapeList[i].Ungroup();
+                    ShapeRange subRange = originalShapeList[i].Ungroup();
                     foreach (Shape item in subRange)
                     {
                         originalShapeList.Add(item);
@@ -53,7 +53,7 @@ namespace PowerPointLabs.EffectsLab
                 }
             }
 
-            var ungroupedShapeRange = curSlide.ToShapeRange(ungroupedShapeList);
+            ShapeRange ungroupedShapeRange = curSlide.ToShapeRange(ungroupedShapeList);
 
             return ungroupedShapeRange;
         }
@@ -77,7 +77,7 @@ namespace PowerPointLabs.EffectsLab
 
                 shapeRange.Cut();
 
-                var effectSlide = PowerPointBgEffectSlide.BgEffectFactory(curSlide.GetNativeSlide(), generateOnRemainder);
+                PowerPointBgEffectSlide effectSlide = PowerPointBgEffectSlide.BgEffectFactory(curSlide.GetNativeSlide(), generateOnRemainder);
 
                 if (dupSlide != null)
                 {
@@ -123,11 +123,11 @@ namespace PowerPointLabs.EffectsLab
 
         internal static Shape DuplicateShapeInPlace(Shape shape)
         {
-            var duplicateShape = shape.Duplicate()[1];
+            Shape duplicateShape = shape.Duplicate()[1];
             duplicateShape.Left = shape.Left;
             duplicateShape.Top = shape.Top;
 
-            var match = System.Text.RegularExpressions.Regex.Match(duplicateShape.Name, @"\d+$");
+            System.Text.RegularExpressions.Match match = System.Text.RegularExpressions.Regex.Match(duplicateShape.Name, @"\d+$");
             if (!match.Success || int.Parse(match.Value) != duplicateShape.Id - 1)
             {
                 duplicateShape.Name += " " + (duplicateShape.Id - 1);

--- a/PowerPointLabs/PowerPointLabs/FitToSlide.cs
+++ b/PowerPointLabs/PowerPointLabs/FitToSlide.cs
@@ -17,13 +17,13 @@ namespace PowerPointLabs
                 (slideWidth / slideHeight))
             {
                 FitToHeight(selectedShape, slideWidth, slideHeight);
-                var availableOffset = selectedShape.Width/2 - slideWidth/2;
+                float availableOffset = selectedShape.Width/2 - slideWidth/2;
                 selectedShape.Left += availableOffset * offset / 100f;
             }
             else
             {
                 FitToWidth(selectedShape, slideWidth, slideHeight);
-                var availableOffset = selectedShape.Height/2 - slideHeight/2;
+                float availableOffset = selectedShape.Height/2 - slideHeight/2;
                 selectedShape.Top += availableOffset * offset / 100f;
             }
         }

--- a/PowerPointLabs/PowerPointLabs/FunctionalTestInterface.Impl/Controller/ShapesLabController.cs
+++ b/PowerPointLabs/PowerPointLabs/FunctionalTestInterface.Impl/Controller/ShapesLabController.cs
@@ -72,7 +72,7 @@ namespace PowerPointLabs.FunctionalTestInterface.Impl.Controller
         {
             if (_pane != null)
             {
-                var slideData = _pane.GetShapeGallery()
+                List<ISlideData> slideData = _pane.GetShapeGallery()
                     .Slides.Cast<Slide>().Select(SlideData.FromSlide).ToList();
                 return slideData;
             }

--- a/PowerPointLabs/PowerPointLabs/FunctionalTestInterface.Impl/PowerPointLabsFeatures.cs
+++ b/PowerPointLabs/PowerPointLabs/FunctionalTestInterface.Impl/PowerPointLabsFeatures.cs
@@ -63,7 +63,7 @@ namespace PowerPointLabs.FunctionalTestInterface.Impl
         {
             UIThreadExecutor.Execute((Action)(() =>
             {
-                var control = new RibbonControl("CropToAspectRatioOption1_10");
+                RibbonControl control = new RibbonControl("CropToAspectRatioOption1_10");
                 control.Tag = CropLabText.CropToAspectRatioTag;
                 Ribbon.OnAction(control);
             }));
@@ -285,7 +285,7 @@ namespace PowerPointLabs.FunctionalTestInterface.Impl
         {
             UIThreadExecutor.Execute((Action)(() =>
             {
-                var control = new RibbonControl("BlurSelectedOption90");
+                RibbonControl control = new RibbonControl("BlurSelectedOption90");
                 control.Tag = EffectsLabText.BlurrinessTag;
                 Ribbon.OnAction(control);
             }));
@@ -295,7 +295,7 @@ namespace PowerPointLabs.FunctionalTestInterface.Impl
         {
             UIThreadExecutor.Execute((Action)(() =>
             {
-                var control = new RibbonControl("BlurRemainderOption90");
+                RibbonControl control = new RibbonControl("BlurRemainderOption90");
                 control.Tag = EffectsLabText.BlurrinessTag;
                 Ribbon.OnAction(control);
             }));
@@ -305,7 +305,7 @@ namespace PowerPointLabs.FunctionalTestInterface.Impl
         {
             UIThreadExecutor.Execute((Action)(() =>
             {
-                var control = new RibbonControl("BlurBackgroundOption90");
+                RibbonControl control = new RibbonControl("BlurBackgroundOption90");
                 control.Tag = EffectsLabText.BlurrinessTag;
                 Ribbon.OnAction(control);
             }));
@@ -315,7 +315,7 @@ namespace PowerPointLabs.FunctionalTestInterface.Impl
         {
             UIThreadExecutor.Execute((Action)(() =>
             {
-                var control = new RibbonControl("GrayScaleRecolorRemainderMenu");
+                RibbonControl control = new RibbonControl("GrayScaleRecolorRemainderMenu");
                 control.Tag = EffectsLabText.RecolorTag;
                 Ribbon.OnAction(control);
             }));
@@ -325,7 +325,7 @@ namespace PowerPointLabs.FunctionalTestInterface.Impl
         {
             UIThreadExecutor.Execute((Action)(() =>
             {
-                var control = new RibbonControl("BlackAndWhiteRecolorRemainderMenu");
+                RibbonControl control = new RibbonControl("BlackAndWhiteRecolorRemainderMenu");
                 control.Tag = EffectsLabText.RecolorTag;
                 Ribbon.OnAction(control);
             }));
@@ -335,7 +335,7 @@ namespace PowerPointLabs.FunctionalTestInterface.Impl
         {
             UIThreadExecutor.Execute((Action)(() =>
             {
-                var control = new RibbonControl("GothamRecolorRemainderMenu");
+                RibbonControl control = new RibbonControl("GothamRecolorRemainderMenu");
                 control.Tag = EffectsLabText.RecolorTag;
                 Ribbon.OnAction(control);
             }));
@@ -345,7 +345,7 @@ namespace PowerPointLabs.FunctionalTestInterface.Impl
         {
             UIThreadExecutor.Execute((Action)(() =>
             {
-                var control = new RibbonControl("SepiaRecolorRemainderMenu");
+                RibbonControl control = new RibbonControl("SepiaRecolorRemainderMenu");
                 control.Tag = EffectsLabText.RecolorTag;
                 Ribbon.OnAction(control);
             }));
@@ -355,7 +355,7 @@ namespace PowerPointLabs.FunctionalTestInterface.Impl
         {
             UIThreadExecutor.Execute((Action)(() =>
             {
-                var control = new RibbonControl("GrayScaleRecolorBackgroundMenu");
+                RibbonControl control = new RibbonControl("GrayScaleRecolorBackgroundMenu");
                 control.Tag = EffectsLabText.RecolorTag;
                 Ribbon.OnAction(control);
             }));
@@ -365,7 +365,7 @@ namespace PowerPointLabs.FunctionalTestInterface.Impl
         {
             UIThreadExecutor.Execute((Action)(() =>
             {
-                var control = new RibbonControl("BlackAndWhiteRecolorBackgroundMenu");
+                RibbonControl control = new RibbonControl("BlackAndWhiteRecolorBackgroundMenu");
                 control.Tag = EffectsLabText.RecolorTag;
                 Ribbon.OnAction(control);
             }));
@@ -375,7 +375,7 @@ namespace PowerPointLabs.FunctionalTestInterface.Impl
         {
             UIThreadExecutor.Execute((Action)(() =>
             {
-                var control = new RibbonControl("GothamRecolorBackgroundMenu");
+                RibbonControl control = new RibbonControl("GothamRecolorBackgroundMenu");
                 control.Tag = EffectsLabText.RecolorTag;
                 Ribbon.OnAction(control);
             }));
@@ -385,7 +385,7 @@ namespace PowerPointLabs.FunctionalTestInterface.Impl
         {
             UIThreadExecutor.Execute((Action)(() =>
             {
-                var control = new RibbonControl("SepiaRecolorBackgroundMenu");
+                RibbonControl control = new RibbonControl("SepiaRecolorBackgroundMenu");
                 control.Tag = EffectsLabText.RecolorTag;
                 Ribbon.OnAction(control);
             }));

--- a/PowerPointLabs/PowerPointLabs/FunctionalTestInterface.Impl/PowerPointOperations.cs
+++ b/PowerPointLabs/PowerPointLabs/FunctionalTestInterface.Impl/PowerPointOperations.cs
@@ -40,16 +40,16 @@ namespace PowerPointLabs.FunctionalTestInterface.Impl
 
         public List<ISlideData> FetchPresentationData(string pathToPresentation)
         {
-            var presentation = FunctionalTestExtensions.GetPresentations().Open(pathToPresentation,
+            Presentation presentation = FunctionalTestExtensions.GetPresentations().Open(pathToPresentation,
                                                                                 WithWindow: MsoTriState.msoFalse);
-            var slideData = presentation.Slides.Cast<Slide>().Select(SlideData.FromSlide).ToList();
+            List<ISlideData> slideData = presentation.Slides.Cast<Slide>().Select(SlideData.FromSlide).ToList();
             presentation.Close();
             return slideData;
         }
 
         public List<ISlideData> FetchCurrentPresentationData()
         {
-            var slideData = FunctionalTestExtensions.GetCurrentPresentation().Presentation
+            List<ISlideData> slideData = FunctionalTestExtensions.GetCurrentPresentation().Presentation
                 .Slides.Cast<Slide>().Select(SlideData.FromSlide).ToList();
             return slideData;
         }
@@ -110,12 +110,12 @@ namespace PowerPointLabs.FunctionalTestInterface.Impl
 
         public Slide SelectSlide(int index)
         {
-            var slides = FunctionalTestExtensions.GetCurrentPresentation().Slides;
+            List<Models.PowerPointSlide> slides = FunctionalTestExtensions.GetCurrentPresentation().Slides;
             for (int i = 0; i <= slides.Count; i++)
             {
                 if (i == (index - 1))
                 {
-                    var slide = slides[i].GetNativeSlide();
+                    Slide slide = slides[i].GetNativeSlide();
                     slide.Select();
                     FunctionalTestExtensions.GetCurrentWindow().View.GotoSlide(index);
                     return slide;
@@ -126,12 +126,12 @@ namespace PowerPointLabs.FunctionalTestInterface.Impl
 
         public Slide SelectSlide(string slideName)
         {
-            var slides = FunctionalTestExtensions.GetCurrentPresentation().Slides;
+            List<Models.PowerPointSlide> slides = FunctionalTestExtensions.GetCurrentPresentation().Slides;
             for (int i = 0; i <= slides.Count; i++)
             {
                 if (slideName == slides[i].Name)
                 {
-                    var slide = slides[i].GetNativeSlide();
+                    Slide slide = slides[i].GetNativeSlide();
                     slide.Select();
                     FunctionalTestExtensions.GetCurrentWindow().View.GotoSlide(i + 1);
                     return slide;
@@ -147,8 +147,8 @@ namespace PowerPointLabs.FunctionalTestInterface.Impl
                 return string.Empty;
             }
 
-            var notesPagePlaceholders = slide.NotesPage.Shapes.Placeholders.Cast<Shape>();
-            var notesPageBody = notesPagePlaceholders
+            IEnumerable<Shape> notesPagePlaceholders = slide.NotesPage.Shapes.Placeholders.Cast<Shape>();
+            Shape notesPageBody = notesPagePlaceholders
                 .FirstOrDefault(shape => shape.PlaceholderFormat.Type == PpPlaceholderType.ppPlaceholderBody);
 
             string notesText = notesPageBody != null ? notesPageBody.TextFrame.TextRange.Text : string.Empty;
@@ -162,8 +162,8 @@ namespace PowerPointLabs.FunctionalTestInterface.Impl
                 return;
             }
 
-            var notesPagePlaceholders = slide.NotesPage.Shapes.Placeholders.Cast<Shape>();
-            var notesPageBody = notesPagePlaceholders
+            IEnumerable<Shape> notesPagePlaceholders = slide.NotesPage.Shapes.Placeholders.Cast<Shape>();
+            Shape notesPageBody = notesPagePlaceholders
                 .FirstOrDefault(shape => shape.PlaceholderFormat.Type == PpPlaceholderType.ppPlaceholderBody);
 
             if (notesPageBody != null)
@@ -179,14 +179,14 @@ namespace PowerPointLabs.FunctionalTestInterface.Impl
 
         public ShapeRange SelectShape(string shapeName)
         {
-            var nameList = new List<String>();
+            List<string> nameList = new List<String>();
             nameList.Add(shapeName);
             return SelectShapes(nameList);
         }
 
         public ShapeRange SelectShapes(IEnumerable<string> shapeNames)
         {
-            var range = FunctionalTestExtensions.GetCurrentSlide().Shapes.Range(shapeNames.ToArray());
+            ShapeRange range = FunctionalTestExtensions.GetCurrentSlide().Shapes.Range(shapeNames.ToArray());
 
             if (range.Count > 0)
             {
@@ -198,8 +198,8 @@ namespace PowerPointLabs.FunctionalTestInterface.Impl
 
         public ShapeRange SelectShapesByPrefix(string prefix)
         {
-            var nameList = new List<String>();
-            var shapes = FunctionalTestExtensions.GetCurrentSlide().Shapes;
+            List<string> nameList = new List<String>();
+            Microsoft.Office.Interop.PowerPoint.Shapes shapes = FunctionalTestExtensions.GetCurrentSlide().Shapes;
             foreach (Shape sh in shapes)
             {
                 if (sh.Name.StartsWith(prefix))
@@ -212,7 +212,7 @@ namespace PowerPointLabs.FunctionalTestInterface.Impl
 
         public Shape RecursiveGetShapeWithPrefix(params string[] prefixes)
         {
-            var parentShape = SelectShapesByPrefix(prefixes[0])[1];
+            Shape parentShape = SelectShapesByPrefix(prefixes[0])[1];
             for (int i = 1; i < prefixes.Length; ++i)
             {
                 parentShape = parentShape.GroupItems.Cast<Shape>().FirstOrDefault(shape => shape.Name.StartsWith(prefixes[i]));
@@ -222,29 +222,29 @@ namespace PowerPointLabs.FunctionalTestInterface.Impl
 
         public FileInfo ExportSelectedShapes()
         {
-            var shapes = FunctionalTestExtensions.GetCurrentSelection().ShapeRange;
-            var hashCode = DateTime.Now.GetHashCode();
-            var pathName = TempPath.GetTempTestFolder() + "shapeName" + hashCode;
+            ShapeRange shapes = FunctionalTestExtensions.GetCurrentSelection().ShapeRange;
+            int hashCode = DateTime.Now.GetHashCode();
+            string pathName = TempPath.GetTempTestFolder() + "shapeName" + hashCode;
             shapes.Export(pathName, PpShapeFormat.ppShapeFormatPNG);
             return new FileInfo(pathName);
         }
 
         public string SelectAllTextInShape(string shapeName)
         {
-            var shape = FunctionalTestExtensions.GetCurrentSlide().Shapes
+            Shape shape = FunctionalTestExtensions.GetCurrentSlide().Shapes
                                                                   .Cast<Shape>()
                                                                   .FirstOrDefault(sh => sh.Name == shapeName);
-            var textRange = shape.TextFrame2.TextRange;
+            TextRange2 textRange = shape.TextFrame2.TextRange;
             textRange.Select();
             return textRange.Text;
         }
 
         public string SelectTextInShape(string shapeName, int startIndex, int endIndex)
         {
-            var shape = FunctionalTestExtensions.GetCurrentSlide().Shapes
+            Shape shape = FunctionalTestExtensions.GetCurrentSlide().Shapes
                                                                       .Cast<Shape>()
                                                                       .FirstOrDefault(sh => sh.Name == shapeName);
-            var textRange = shape.TextFrame2.TextRange.Characters[startIndex, endIndex - startIndex];
+            TextRange2 textRange = shape.TextFrame2.TextRange.Characters[startIndex, endIndex - startIndex];
             textRange.Select();
             return textRange.Text;
         }

--- a/PowerPointLabs/PowerPointLabs/FunctionalTestInterface.Impl/SlideData.cs
+++ b/PowerPointLabs/PowerPointLabs/FunctionalTestInterface.Impl/SlideData.cs
@@ -17,15 +17,15 @@ namespace PowerPointLabs.FunctionalTestInterface.Impl
 
         private SlideData(Slide slide)
         {
-            var hashCode = DateTime.Now.GetHashCode();
+            int hashCode = DateTime.Now.GetHashCode();
             SlideImage = "slide" + hashCode;
             slide.Export(TempPath.GetTempTestFolder() + SlideImage, "PNG");
 
             Animation = new List<IEffectData>();
-            var seq = slide.TimeLine.MainSequence;
+            Sequence seq = slide.TimeLine.MainSequence;
             for (int i = 1; i <= seq.Count; ++i)
             {
-                var effect = seq[i];
+                Effect effect = seq[i];
                 Animation.Add(EffectData.FromEffect(effect));
             }
         }

--- a/PowerPointLabs/PowerPointLabs/HighlightLab/HighlightBulletsBackground.cs
+++ b/PowerPointLabs/PowerPointLabs/HighlightLab/HighlightBulletsBackground.cs
@@ -21,7 +21,7 @@ namespace PowerPointLabs.HighlightLab
         {
             try
             {
-                var currentSlide = PowerPointCurrentPresentationInfo.CurrentSlide as PowerPointSlide;
+                PowerPointSlide currentSlide = PowerPointCurrentPresentationInfo.CurrentSlide as PowerPointSlide;
                 currentSlide.Name = "PPTLabsHighlightBulletsSlide" + DateTime.Now.ToString("yyyyMMddHHmmssffff");
 
                 PowerPoint.ShapeRange selectedShapes = null;
@@ -82,14 +82,14 @@ namespace PowerPointLabs.HighlightLab
         {
             bool anySelected = false;
 
-            foreach (var sh in shapesToUse)
+            foreach (PowerPoint.Shape sh in shapesToUse)
             {
                 sh.Name = "HighlightBackgroundShape" + Guid.NewGuid();
             }
 
             if (userSelection == HighlightBackgroundSelection.kTextSelected)
             {
-                foreach (var sh in shapesToUse)
+                foreach (PowerPoint.Shape sh in shapesToUse)
                 {
                     foreach (Office.TextRange2 paragraph in sh.TextFrame2.TextRange.Paragraphs)
                     {
@@ -105,7 +105,7 @@ namespace PowerPointLabs.HighlightLab
             }
             else
             {
-                foreach (var sh in shapesToUse)
+                foreach (PowerPoint.Shape sh in shapesToUse)
                 {
                     bool anySelectedForShape = false;
                     foreach (Office.TextRange2 paragraph in sh.TextFrame2.TextRange.Paragraphs)
@@ -137,7 +137,7 @@ namespace PowerPointLabs.HighlightLab
 
         private static void GenerateHighlightShape(PowerPointSlide currentSlide, Office.TextRange2 paragraph, PowerPoint.Shape sh)
         {
-            var highlightShape = currentSlide.Shapes.AddShape(Office.MsoAutoShapeType.msoShapeRoundedRectangle,
+            PowerPoint.Shape highlightShape = currentSlide.Shapes.AddShape(Office.MsoAutoShapeType.msoShapeRoundedRectangle,
                                                             paragraph.BoundLeft,
                                                             paragraph.BoundTop,
                                                             paragraph.BoundWidth,
@@ -157,8 +157,8 @@ namespace PowerPointLabs.HighlightLab
             List<PowerPoint.Shape> shapesToDelete = new List<PowerPoint.Shape>();
             bool shouldSelect;
 
-            var shapes = currentSlide.GetShapesOrderedByTimeline();
-            foreach (var sh in shapes)
+            List<PowerPoint.Shape> shapes = currentSlide.GetShapesOrderedByTimeline();
+            foreach (PowerPoint.Shape sh in shapes)
             {
                 shouldSelect = true; //We should not select existing highlight shapes. Instead they should be deleted
                 if (sh.Name.Contains("PPTLabsHighlightBackgroundShape"))
@@ -206,7 +206,7 @@ namespace PowerPointLabs.HighlightLab
         /// </summary>
         private static List<PowerPoint.Shape> GetShapesToUse(PowerPointSlide currentSlide, PowerPoint.ShapeRange shapes)
         {
-            var shapesToUse = shapes.Cast<PowerPoint.Shape>()
+            List<PowerPoint.Shape> shapesToUse = shapes.Cast<PowerPoint.Shape>()
                                     .Where(sh => !sh.Name.Contains("PPTLabsHighlightBackgroundShape")
                                                     && HasText(sh))
                                     .ToList();
@@ -221,15 +221,15 @@ namespace PowerPointLabs.HighlightLab
         /// </summary>
         private static List<PowerPoint.Shape> GetAllUsableShapesInSlide(PowerPointSlide currentSlide)
         {
-            var selectedShapes = currentSlide.Shapes.Range().Cast<PowerPoint.Shape>().ToArray();
+            PowerPoint.Shape[] selectedShapes = currentSlide.Shapes.Range().Cast<PowerPoint.Shape>().ToArray();
 
-            var usableShapesWithBullets = selectedShapes
+            List<PowerPoint.Shape> usableShapesWithBullets = selectedShapes
                                             .Where(sh => !sh.Name.Contains("PPTLabsHighlightBackgroundShape")
                                                         && HasText(sh)
                                                         && HasBullets(sh))
                                             .ToList();
 
-            var allUsableShapes = selectedShapes
+            List<PowerPoint.Shape> allUsableShapes = selectedShapes
                                     .Where(sh => !sh.Name.Contains("PPTLabsHighlightBackgroundShape")
                                                     && HasText(sh))
                                     .ToList();

--- a/PowerPointLabs/PowerPointLabs/HighlightLab/HighlightBulletsText.cs
+++ b/PowerPointLabs/PowerPointLabs/HighlightLab/HighlightBulletsText.cs
@@ -21,7 +21,7 @@ namespace PowerPointLabs.HighlightLab
         {
             try
             {
-                var currentSlide = PowerPointCurrentPresentationInfo.CurrentSlide as PowerPointSlide;
+                PowerPointSlide currentSlide = PowerPointCurrentPresentationInfo.CurrentSlide as PowerPointSlide;
 
                 PowerPoint.ShapeRange selectedShapes = null;
                 Office.TextRange2 selectedText = null;
@@ -73,15 +73,15 @@ namespace PowerPointLabs.HighlightLab
                     //Add Font Appear effect for all paragraphs within shape
                     int currentIndex = sequence.Count;
                     sequence.AddEffect(sh, PowerPoint.MsoAnimEffect.msoAnimEffectChangeFontColor, PowerPoint.MsoAnimateByLevel.msoAnimateTextByFifthLevel, PowerPoint.MsoAnimTriggerType.msoAnimTriggerOnPageClick);
-                    var appearEffects = AsList(sequence, currentIndex + 1, sequence.Count + 1);
+                    List<PowerPoint.Effect> appearEffects = AsList(sequence, currentIndex + 1, sequence.Count + 1);
 
                     //Add Font Disappear effect for all paragraphs within shape
                     currentIndex = sequence.Count;
                     sequence.AddEffect(sh, PowerPoint.MsoAnimEffect.msoAnimEffectChangeFontColor, PowerPoint.MsoAnimateByLevel.msoAnimateTextByFifthLevel, PowerPoint.MsoAnimTriggerType.msoAnimTriggerWithPrevious);
-                    var disappearEffects = AsList(sequence, currentIndex + 1, sequence.Count + 1);
+                    List<PowerPoint.Effect> disappearEffects = AsList(sequence, currentIndex + 1, sequence.Count + 1);
 
                     //Remove effects for paragraphs without bullet points 
-                    var markedForRemoval = GetParagraphsToRemove(sh, selectedText);
+                    List<int> markedForRemoval = GetParagraphsToRemove(sh, selectedText);
                     // assert appearEffects.Count == disappearEffects.Count;
                     // assert markedForRemoval.Count <= appearEffects.Count;
                     for (int i = markedForRemoval.Count - 1; i >= 0; --i)
@@ -123,7 +123,7 @@ namespace PowerPointLabs.HighlightLab
         /// </summary>
         private static List<PowerPoint.Effect> AsList(PowerPoint.Sequence sequence, int startIndex, int endIndex)
         {
-            var list = new List<PowerPoint.Effect>();
+            List<PowerPoint.Effect> list = new List<PowerPoint.Effect>();
             for (int i = startIndex; i < endIndex; ++i)
             {
                 list.Add(sequence[i]);
@@ -157,7 +157,7 @@ namespace PowerPointLabs.HighlightLab
         /// </summary>
         private static List<int> GetParagraphsToRemove(PowerPoint.Shape sh, Office.TextRange2 selectedText)
         {
-            var textRange = sh.TextFrame2.TextRange;
+            Office.TextRange2 textRange = sh.TextFrame2.TextRange;
             if (userSelection == HighlightTextSelection.kTextSelected)
             {
                 return GetUnselectedParagraphs(textRange, selectedText);
@@ -174,12 +174,12 @@ namespace PowerPointLabs.HighlightLab
         /// </summary>
         private static List<int> GetParagraphsWithoutBullets(Office.TextRange2 textRange)
         {
-            var indexList = new List<int>();
+            List<int> indexList = new List<int>();
             int index = 0;
             bool hasBulletPoint = false;
             for (int i = 1; i <= textRange.Paragraphs.Count; ++i)
             {
-                var paragraph = textRange.Paragraphs[i];
+                Office.TextRange2 paragraph = textRange.Paragraphs[i];
                 if (paragraph.Text.Trim().Length == 0)
                 {
                     continue;
@@ -208,11 +208,11 @@ namespace PowerPointLabs.HighlightLab
         /// </summary>
         private static List<int> GetUnselectedParagraphs(Office.TextRange2 textRange, Office.TextRange2 selectedText)
         {
-            var indexList = new List<int>();
+            List<int> indexList = new List<int>();
             int index = 0;
             for (int i = 1; i <= textRange.Paragraphs.Count; ++i)
             {
-                var paragraph = textRange.Paragraphs[i];
+                Office.TextRange2 paragraph = textRange.Paragraphs[i];
                 if (paragraph.Text.Trim().Length == 0)
                 {
                     continue;
@@ -263,7 +263,7 @@ namespace PowerPointLabs.HighlightLab
         /// </summary>
         private static void FormatAppearEffects(List<PowerPoint.Effect> appearEffects, bool isFirstShape)
         {
-            foreach (var effect in appearEffects)
+            foreach (PowerPoint.Effect effect in appearEffects)
             {
                 effect.Timing.TriggerType = PowerPoint.MsoAnimTriggerType.msoAnimTriggerOnPageClick;
                 // TODO: Orange text bug occurs on this line. effect.EffectParameters.Color2.RGB is not changed for some reason.
@@ -282,7 +282,7 @@ namespace PowerPointLabs.HighlightLab
         /// </summary>
         private static void FormatDisappearEffects(List<PowerPoint.Effect> disappearEffects)
         {
-            foreach (var effect in disappearEffects)
+            foreach (PowerPoint.Effect effect in disappearEffects)
             {
                 effect.Timing.TriggerType = PowerPoint.MsoAnimTriggerType.msoAnimTriggerWithPrevious;
                 effect.EffectParameters.Color2.RGB = Utils.GraphicsUtil.ConvertColorToRgb(HighlightLabSettings.bulletsTextDefaultColor);
@@ -329,14 +329,14 @@ namespace PowerPointLabs.HighlightLab
         /// </summary>
         private static List<PowerPoint.Shape> GetAllUsableShapesInSlide(PowerPointSlide currentSlide)
         {
-            var selectedShapes = currentSlide.Shapes.Range().Cast<PowerPoint.Shape>().ToArray();
+            PowerPoint.Shape[] selectedShapes = currentSlide.Shapes.Range().Cast<PowerPoint.Shape>().ToArray();
 
-            var usableShapesWithBullets = selectedShapes
+            List<PowerPoint.Shape> usableShapesWithBullets = selectedShapes
                                             .Where(sh => HasText(sh)
                                                         && HasBullets(sh))
                                             .ToList();
 
-            var allUsableShapes = selectedShapes
+            List<PowerPoint.Shape> allUsableShapes = selectedShapes
                                     .Where(HasText)
                                     .ToList();
 

--- a/PowerPointLabs/PowerPointLabs/HighlightLab/HighlightTextFragments.cs
+++ b/PowerPointLabs/PowerPointLabs/HighlightLab/HighlightTextFragments.cs
@@ -21,7 +21,7 @@ namespace PowerPointLabs.HighlightLab
         {
             try
             {
-                var currentSlide = PowerPointCurrentPresentationInfo.CurrentSlide as PowerPointSlide;
+                PowerPointSlide currentSlide = PowerPointCurrentPresentationInfo.CurrentSlide as PowerPointSlide;
 
                 PowerPoint.ShapeRange selectedShapes = null;
                 Office.TextRange2 selectedText = null;

--- a/PowerPointLabs/PowerPointLabs/Models/PowerPointBgEffectSlide.cs
+++ b/PowerPointLabs/PowerPointLabs/Models/PowerPointBgEffectSlide.cs
@@ -144,7 +144,7 @@ namespace PowerPointLabs.Models
 
             if (filter == null && isTint)
             {
-                Shape overlayShape = EffectsLab.EffectsLabBlur.GenerateOverlayShape(this, newBackground);
+                EffectsLab.EffectsLabBlur.GenerateOverlayShape(this, newBackground);
             }
         }
 

--- a/PowerPointLabs/PowerPointLabs/Models/PowerPointBgEffectSlide.cs
+++ b/PowerPointLabs/PowerPointLabs/Models/PowerPointBgEffectSlide.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 
@@ -33,7 +34,7 @@ namespace PowerPointLabs.Models
             }
 
             // here we cut-paste the shape to get a reference of those shapes
-            var oriShapeRange = refSlide.Shapes.Paste();
+            ShapeRange oriShapeRange = refSlide.Shapes.Paste();
 
             // preprocess the shapes, eliminate animations for shapes
             foreach (Shape shape in oriShapeRange)
@@ -45,10 +46,10 @@ namespace PowerPointLabs.Models
             // cut the original shape cover again and duplicate the slide
             // here the slide will be duplicated without the original shape cover
             oriShapeRange.Cut();
-            var newSlide = FromSlideFactory(refSlide.Duplicate()[1]);
+            PowerPointSlide newSlide = FromSlideFactory(refSlide.Duplicate()[1]);
             
             // get a copy of original cover shapes
-            var copyShapeRange = newSlide.Shapes.Paste();
+            ShapeRange copyShapeRange = newSlide.Shapes.Paste();
             // paste the original shape cover back
             oriShapeRange = refSlide.Shapes.Paste();
             
@@ -63,7 +64,7 @@ namespace PowerPointLabs.Models
             newSlide.Transition.EntryEffect = PpEntryEffect.ppEffectFadeSmoothly;
             newSlide.Transition.Duration = 0.5f;
 
-            var bgEffectSlide = new PowerPointBgEffectSlide(newSlide.GetNativeSlide());
+            PowerPointBgEffectSlide bgEffectSlide = new PowerPointBgEffectSlide(newSlide.GetNativeSlide());
 
             try
             {
@@ -123,9 +124,9 @@ namespace PowerPointLabs.Models
             }
             else
             {
-                using (var imageFactory = new ImageFactory())
+                using (ImageFactory imageFactory = new ImageFactory())
                 {
-                    var image = imageFactory.Load(AnimatedBackgroundPath);
+                    ImageFactory image = imageFactory.Load(AnimatedBackgroundPath);
 
                     image = image.Filter(filter);
 
@@ -133,7 +134,7 @@ namespace PowerPointLabs.Models
                 }
             }
 
-            var newBackground = Shapes.AddPicture(AnimatedBackgroundPath, Core.MsoTriState.msoFalse,
+            Shape newBackground = Shapes.AddPicture(AnimatedBackgroundPath, Core.MsoTriState.msoFalse,
                                                   Core.MsoTriState.msoTrue,
                                                   0, 0,
                                                   PowerPointPresentation.Current.SlideWidth,
@@ -143,7 +144,7 @@ namespace PowerPointLabs.Models
 
             if (filter == null && isTint)
             {
-                var overlayShape = EffectsLab.EffectsLabBlur.GenerateOverlayShape(this, newBackground);
+                Shape overlayShape = EffectsLab.EffectsLabBlur.GenerateOverlayShape(this, newBackground);
             }
         }
 
@@ -166,14 +167,14 @@ namespace PowerPointLabs.Models
                 }
             }
 
-            var croppedShape = CropToShape.Crop(FromSlideFactory(refSlide), shapeRange, handleError: false);
+            Shape croppedShape = CropToShape.Crop(FromSlideFactory(refSlide), shapeRange, handleError: false);
 
             return croppedShape;
         }
 
         private static void MakeAnimatedBackground(PowerPointSlide curSlide)
         {
-            foreach (var shape in curSlide.Shapes.Cast<Shape>().Where(curSlide.HasExitAnimation))
+            foreach (Shape shape in curSlide.Shapes.Cast<Shape>().Where(curSlide.HasExitAnimation))
             {
                 shape.Delete();
             }
@@ -182,17 +183,17 @@ namespace PowerPointLabs.Models
 
             Utils.GraphicsUtil.ExportSlide(curSlide, AnimatedBackgroundPath);
 
-            var visibleShape = curSlide.Shapes.Cast<Shape>().Where(x => x.Visible == Core.MsoTriState.msoTrue).ToList();
+            List<Shape> visibleShape = curSlide.Shapes.Cast<Shape>().Where(x => x.Visible == Core.MsoTriState.msoTrue).ToList();
             
-            foreach (var shape in visibleShape)
+            foreach (Shape shape in visibleShape)
             {
                 shape.Delete();
             }
 
-            var placeHolders =
+            List<Shape> placeHolders =
                 curSlide.Shapes.Cast<Shape>().Where(x => x.Type == Core.MsoShapeType.msoPlaceholder).ToList();
 
-            foreach (var placeHolder in placeHolders)
+            foreach (Shape placeHolder in placeHolders)
             {
                 placeHolder.Delete();
             }
@@ -204,12 +205,12 @@ namespace PowerPointLabs.Models
             try
             {
                 // crop in the original slide and put into clipboard
-                var croppedShape = MakeFrontImage(refSlide, oriShapeRange);
+                Shape croppedShape = MakeFrontImage(refSlide, oriShapeRange);
 
                 croppedShape.Cut();
 
                 // swap the uncropped shapes and cropped shapes
-                var pastedCrop = newSlide.Shapes.Paste();
+                ShapeRange pastedCrop = newSlide.Shapes.Paste();
 
                 // calibrate pasted shapes
                 pastedCrop.Left -= 12;
@@ -241,7 +242,7 @@ namespace PowerPointLabs.Models
             }
             catch (Exception e)
             {
-                var errorMessage = e.Message;
+                string errorMessage = e.Message;
                 errorMessage = errorMessage.Replace("Crop To Shape", "Blur/Recolor Remainder");
 
                 newSlide.Delete();

--- a/PowerPointLabs/PowerPointLabs/Models/PowerPointCurrentPresentationInfo.cs
+++ b/PowerPointLabs/PowerPointLabs/Models/PowerPointCurrentPresentationInfo.cs
@@ -14,7 +14,7 @@ namespace PowerPointLabs.Models
             {
                 try
                 {
-                    var interopSlide = Globals.ThisAddIn.Application.ActiveWindow.View.Slide as Slide;
+                    Slide interopSlide = Globals.ThisAddIn.Application.ActiveWindow.View.Slide as Slide;
                     return PowerPointSlide.FromSlideFactory(interopSlide);
                 }
                 catch (COMException)
@@ -37,15 +37,15 @@ namespace PowerPointLabs.Models
         {
             get
             {
-                var slides = new List<PowerPointSlide>();
+                List<PowerPointSlide> slides = new List<PowerPointSlide>();
 
                 try
                 {
-                    var interopSlides = Globals.ThisAddIn.Application.ActiveWindow.Selection.SlideRange;
+                    SlideRange interopSlides = Globals.ThisAddIn.Application.ActiveWindow.Selection.SlideRange;
 
                     foreach (Slide interopSlide in interopSlides)
                     {
-                        var s = PowerPointSlide.FromSlideFactory(interopSlide);
+                        PowerPointSlide s = PowerPointSlide.FromSlideFactory(interopSlide);
                         slides.Add(s);
                     }
                 }

--- a/PowerPointLabs/PowerPointLabs/Models/PowerPointDeMagnifyingSlide.cs
+++ b/PowerPointLabs/PowerPointLabs/Models/PowerPointDeMagnifyingSlide.cs
@@ -80,7 +80,7 @@ namespace PowerPointLabs.Models
             else
             {
                 GetShapeToZoomWithBackground(zoomShape);
-                var lastDisappearEffect = DefaultMotionAnimation.AddZoomOutMotionAnimation(this,
+                PowerPoint.Effect lastDisappearEffect = DefaultMotionAnimation.AddZoomOutMotionAnimation(this,
                     zoomSlideCroppedShapes, PowerPoint.MsoAnimTriggerType.msoAnimTriggerWithPrevious);
                 DefaultMotionAnimation.PreloadShape(this, zoomSlideCroppedShapes);
                 

--- a/PowerPointLabs/PowerPointLabs/Models/PowerPointMagnifiedPanSlide.cs
+++ b/PowerPointLabs/PowerPointLabs/Models/PowerPointMagnifiedPanSlide.cs
@@ -43,7 +43,7 @@ namespace PowerPointLabs.Models
         {
             //Delete all shapes from slide excpet last magnified shape
             List<PowerPoint.Shape> shapes = _slide.Shapes.Cast<PowerPoint.Shape>().ToList();
-            var matchingShapes = shapes.Where(current => (!current.Name.Contains("PPTLabsMagnifyAreaGroup")));
+            IEnumerable<PowerPoint.Shape> matchingShapes = shapes.Where(current => (!current.Name.Contains("PPTLabsMagnifyAreaGroup")));
             foreach (PowerPoint.Shape s in matchingShapes)
             {
                 s.Delete();

--- a/PowerPointLabs/PowerPointLabs/Models/PowerPointMagnifiedSlide.cs
+++ b/PowerPointLabs/PowerPointLabs/Models/PowerPointMagnifiedSlide.cs
@@ -65,7 +65,7 @@ namespace PowerPointLabs.Models
         {
             //Delete all shapes on slide except slide-size crop copied from magnifying slide
             List<PowerPoint.Shape> shapes = _slide.Shapes.Cast<PowerPoint.Shape>().ToList();
-            var matchingShapes = shapes.Where(current => (!current.Name.Contains("PPTLabsMagnifyAreaGroup")));
+            IEnumerable<PowerPoint.Shape> matchingShapes = shapes.Where(current => (!current.Name.Contains("PPTLabsMagnifyAreaGroup")));
             foreach (PowerPoint.Shape s in matchingShapes)
             {
                 s.Delete();

--- a/PowerPointLabs/PowerPointLabs/Models/PowerPointMagnifyingSlide.cs
+++ b/PowerPointLabs/PowerPointLabs/Models/PowerPointMagnifyingSlide.cs
@@ -65,7 +65,7 @@ namespace PowerPointLabs.Models
 
             //Delete zoom shapes and shapes with exit animations
             List<PowerPoint.Shape> shapes = _slide.Shapes.Cast<PowerPoint.Shape>().ToList();
-            var matchingShapes = shapes.Where(current => (HasExitAnimation(current) || current.Equals(zoomShape)));
+            IEnumerable<PowerPoint.Shape> matchingShapes = shapes.Where(current => (HasExitAnimation(current) || current.Equals(zoomShape)));
             foreach (PowerPoint.Shape s in matchingShapes)
             {
                 s.Delete();

--- a/PowerPointLabs/PowerPointLabs/Models/PowerPointPresentation.cs
+++ b/PowerPointLabs/PowerPointLabs/Models/PowerPointPresentation.cs
@@ -61,14 +61,14 @@ namespace PowerPointLabs.Models
         {
             get
             {
-                var sectionProperties = SectionProperties;
+                SectionProperties sectionProperties = SectionProperties;
 
                 // Fix for rare case where the ack slide is the only slide in the section.
                 // This should be counted as an empty section. so we temporarily remove the ack slide and add it back after.
                 bool hasAckSlide = HasAckSlide();
                 RemoveAckSlide();
 
-                for (var i = 1; i <= sectionProperties.Count; i++)
+                for (int i = 1; i <= sectionProperties.Count; i++)
                 {
                     if (sectionProperties.SlidesCount(i) == 0)
                     {
@@ -142,10 +142,10 @@ namespace PowerPointLabs.Models
         {
             get
             {
-                var sectionProperty = Presentation.SectionProperties;
-                var sectionNames = new List<string>();
+                SectionProperties sectionProperty = Presentation.SectionProperties;
+                List<string> sectionNames = new List<string>();
 
-                for (var i = 1; i <= sectionProperty.Count; i++)
+                for (int i = 1; i <= sectionProperty.Count; i++)
                 {
                     sectionNames.Add(sectionProperty.Name(i));
                 }
@@ -158,7 +158,7 @@ namespace PowerPointLabs.Models
         {
             get
             {
-                var slides = Presentation.Slides;
+                Slides slides = Presentation.Slides;
                 if (slides.Count > 0)
                 {
                     return PowerPointSlide.FromSlideFactory(slides[1]);
@@ -174,13 +174,13 @@ namespace PowerPointLabs.Models
         {
             get
             {
-                var slides = new List<PowerPointSlide>();
+                List<PowerPointSlide> slides = new List<PowerPointSlide>();
 
-                var interopSlides = Presentation.Slides;
+                Slides interopSlides = Presentation.Slides;
 
                 foreach (Slide interopSlide in interopSlides)
                 {
-                    var s = PowerPointSlide.FromSlideFactory(interopSlide);
+                    PowerPointSlide s = PowerPointSlide.FromSlideFactory(interopSlide);
                     slides.Add(s);
                 }
 
@@ -213,7 +213,7 @@ namespace PowerPointLabs.Models
         {
             get
             {
-                var dimensions = Presentation.PageSetup;
+                PageSetup dimensions = Presentation.PageSetup;
                 return dimensions.SlideWidth;
             }
             set
@@ -226,7 +226,7 @@ namespace PowerPointLabs.Models
         {
             get
             {
-                var dimensions = Presentation.PageSetup;
+                PageSetup dimensions = Presentation.PageSetup;
                 return dimensions.SlideHeight;
             }
             set
@@ -261,7 +261,7 @@ namespace PowerPointLabs.Models
         {
             if (!HasAckSlide())
             {
-                var lastSlide = Slides.Last();
+                PowerPointSlide lastSlide = Slides.Last();
                 lastSlide.CreateAckSlide();
             }
         }
@@ -280,13 +280,13 @@ namespace PowerPointLabs.Models
         /// </summary>
         public void GotoNextSlide()
         {
-            var currentSlide = PowerPointCurrentPresentationInfo.CurrentSlide;
+            PowerPointSlide currentSlide = PowerPointCurrentPresentationInfo.CurrentSlide;
             if (currentSlide == null)
             {
                 return;
             }
 
-            var index = currentSlide.Index;
+            int index = currentSlide.Index;
             if (index < Slides.Count)
             {
                 GotoSlide(index + 1);
@@ -295,13 +295,13 @@ namespace PowerPointLabs.Models
 
         public bool IsLastSlide()
         {
-            var currentSlide = PowerPointCurrentPresentationInfo.CurrentSlide;
+            PowerPointSlide currentSlide = PowerPointCurrentPresentationInfo.CurrentSlide;
             if (currentSlide == null)
             {
                 return false;
             }
 
-            var index = currentSlide.Index;
+            int index = currentSlide.Index;
             return index == Slides.Count;
         }
 
@@ -317,15 +317,15 @@ namespace PowerPointLabs.Models
                 index = SlideCount + 1;
             }
 
-            var customLayout = Presentation.SlideMaster.CustomLayouts[layout];
-            var newSlide = Presentation.Slides.AddSlide(index, customLayout);
+            CustomLayout customLayout = Presentation.SlideMaster.CustomLayouts[layout];
+            Slide newSlide = Presentation.Slides.AddSlide(index, customLayout);
 
             if (name != "")
             {
                 newSlide.Name = name;
             }
 
-            var slideFromFactory = PowerPointSlide.FromSlideFactory(newSlide);
+            PowerPointSlide slideFromFactory = PowerPointSlide.FromSlideFactory(newSlide);
 
             Slides.Add(slideFromFactory);
 
@@ -344,9 +344,9 @@ namespace PowerPointLabs.Models
 
         public void RemoveSlide(Func<Slide, bool> condition, bool deleteAll)
         {
-            var slides = Presentation.Slides.Cast<Slide>().Where(condition).ToList();
+            List<Slide> slides = Presentation.Slides.Cast<Slide>().Where(condition).ToList();
 
-            foreach (var slide in slides)
+            foreach (Slide slide in slides)
             {
                 slide.Delete();
 
@@ -359,9 +359,9 @@ namespace PowerPointLabs.Models
 
         public void RemoveSlide(Regex rule, bool deleteAll)
         {
-            var slides = Presentation.Slides.Cast<Slide>().Where(slide => rule.IsMatch(slide.Name)).ToList();
+            List<Slide> slides = Presentation.Slides.Cast<Slide>().Where(slide => rule.IsMatch(slide.Name)).ToList();
 
-            foreach (var slide in slides)
+            foreach (Slide slide in slides)
             {
                 slide.Delete();
 
@@ -402,7 +402,7 @@ namespace PowerPointLabs.Models
 
             if (!focus && Globals.ThisAddIn != null)
             {
-                var workingWindow = Globals.ThisAddIn.Application.ActiveWindow;
+                DocumentWindow workingWindow = Globals.ThisAddIn.Application.ActiveWindow;
                 workingWindow.Activate();
             }
 
@@ -450,7 +450,7 @@ namespace PowerPointLabs.Models
                 return true;
             }
 
-            var workingWindow = Globals.ThisAddIn.Application.ActiveWindow;
+            DocumentWindow workingWindow = Globals.ThisAddIn.Application.ActiveWindow;
 
             try
             {

--- a/PowerPointLabs/PowerPointLabs/Models/PowerPointSlide.cs
+++ b/PowerPointLabs/PowerPointLabs/Models/PowerPointSlide.cs
@@ -93,8 +93,8 @@ namespace PowerPointLabs.Models
                     return String.Empty;
                 }
 
-                var notesPagePlaceholders = _slide.NotesPage.Shapes.Placeholders.Cast<Shape>();
-                var notesPageBody = notesPagePlaceholders.FirstOrDefault(shape => shape.PlaceholderFormat.Type == PpPlaceholderType.ppPlaceholderBody);
+                IEnumerable<Shape> notesPagePlaceholders = _slide.NotesPage.Shapes.Placeholders.Cast<Shape>();
+                Shape notesPageBody = notesPagePlaceholders.FirstOrDefault(shape => shape.PlaceholderFormat.Type == PpPlaceholderType.ppPlaceholderBody);
 
                 String notesText = notesPageBody != null ? notesPageBody.TextFrame.TextRange.Text : String.Empty;
                 return notesText;
@@ -107,8 +107,8 @@ namespace PowerPointLabs.Models
                     return;
                 }
 
-                var notesPagePlaceholders = _slide.NotesPage.Shapes.Placeholders.Cast<Shape>();
-                var notesPageBody = notesPagePlaceholders.FirstOrDefault(shape => shape.PlaceholderFormat.Type == PpPlaceholderType.ppPlaceholderBody);
+                IEnumerable<Shape> notesPagePlaceholders = _slide.NotesPage.Shapes.Placeholders.Cast<Shape>();
+                Shape notesPageBody = notesPagePlaceholders.FirstOrDefault(shape => shape.PlaceholderFormat.Type == PpPlaceholderType.ppPlaceholderBody);
 
                 if (notesPageBody != null)
                 {
@@ -128,7 +128,7 @@ namespace PowerPointLabs.Models
 
         public string RetrieveDataFromNotes()
         {
-            var text = NotesPageText;
+            string text = NotesPageText;
             if (!text.StartsWith(CommonText.NotesPageStorageText))
             {
                 return "";
@@ -169,8 +169,8 @@ namespace PowerPointLabs.Models
         /// </summary>
         public void CopyBackgroundColourFrom(PowerPointSlide refSlide)
         {
-            var myFill = _slide.Background[1].Fill;
-            var refFill = refSlide._slide.Background[1].Fill;
+            Microsoft.Office.Interop.PowerPoint.FillFormat myFill = _slide.Background[1].Fill;
+            Microsoft.Office.Interop.PowerPoint.FillFormat refFill = refSlide._slide.Background[1].Fill;
 
             if (refFill.Type == MsoFillType.msoFillSolid)
             {
@@ -236,20 +236,20 @@ namespace PowerPointLabs.Models
 
         public bool HasAnimationForClick(int clickNumber)
         {
-            var mainSequence = _slide.TimeLine.MainSequence;
-            var effect = mainSequence.FindFirstAnimationForClick(clickNumber);
+            Sequence mainSequence = _slide.TimeLine.MainSequence;
+            Effect effect = mainSequence.FindFirstAnimationForClick(clickNumber);
 
             return effect != null;
         }
 
         public void DeleteShapesWithPrefixTimelineInvariant(string prefix)
         {
-            var mainSequence = _slide.TimeLine.MainSequence;
-            var effectCnt = 1;
+            Sequence mainSequence = _slide.TimeLine.MainSequence;
+            int effectCnt = 1;
 
             while (effectCnt <= mainSequence.Count)
             {
-                var effect = mainSequence[effectCnt];
+                Effect effect = mainSequence[effectCnt];
 
                 if (effect.Shape.Name.StartsWith(prefix))
                 {
@@ -259,7 +259,7 @@ namespace PowerPointLabs.Models
                     if (effect.Timing.TriggerType == MsoAnimTriggerType.msoAnimTriggerOnPageClick &&
                         effect.Index + 1 <= mainSequence.Count)
                     {
-                        var nextEffect = mainSequence[effect.Index + 1];
+                        Effect nextEffect = mainSequence[effect.Index + 1];
 
                         if (nextEffect.Timing.TriggerType == MsoAnimTriggerType.msoAnimTriggerWithPrevious)
                         {
@@ -282,7 +282,7 @@ namespace PowerPointLabs.Models
         {
             List<Shape> shapes = _slide.Shapes.Cast<Shape>().ToList();
 
-            var matchingShapes = shapes.Where(current => current.Name.StartsWith(prefix));
+            IEnumerable<Shape> matchingShapes = shapes.Where(current => current.Name.StartsWith(prefix));
             
             foreach (Shape s in matchingShapes)
             {
@@ -294,7 +294,7 @@ namespace PowerPointLabs.Models
         {
             List<Shape> shapes = _slide.Shapes.Cast<Shape>().ToList();
 
-            var matchingShapes = shapes.Where(current => regex.IsMatch(current.Name));
+            IEnumerable<Shape> matchingShapes = shapes.Where(current => regex.IsMatch(current.Name));
             foreach (Shape s in matchingShapes)
             {
                 s.Delete();
@@ -304,9 +304,9 @@ namespace PowerPointLabs.Models
         public void DeleteShapeWithName(string name)
         {
             List<Shape> shapes = _slide.Shapes.Cast<Shape>().ToList();
-            var matchingShapes = shapes.Where(current => current.Name == name);
+            IEnumerable<Shape> matchingShapes = shapes.Where(current => current.Name == name);
 
-            foreach (var s in matchingShapes)
+            foreach (Shape s in matchingShapes)
             {
                 s.Delete();
             }
@@ -325,7 +325,7 @@ namespace PowerPointLabs.Models
         {
             List<Shape> shapes = _slide.Shapes.Cast<Shape>().ToList();
 
-            var matchingShapes = shapes;
+            List<Shape> matchingShapes = shapes;
             foreach (Shape s in matchingShapes)
             {
                 s.Delete();
@@ -334,7 +334,7 @@ namespace PowerPointLabs.Models
 
         public void SetShapeAsAutoplay(Shape shape)
         {
-            var mainSequence = _slide.TimeLine.MainSequence;
+            Sequence mainSequence = _slide.TimeLine.MainSequence;
 
             Effect firstClickEvent = mainSequence.FindFirstAnimationForClick(1);
             bool hasNoClicksOnSlide = firstClickEvent == null;
@@ -351,7 +351,7 @@ namespace PowerPointLabs.Models
 
         public void SetAudioAsAutoplay(Shape shape)
         {
-            var mainSequence = _slide.TimeLine.MainSequence;
+            Sequence mainSequence = _slide.TimeLine.MainSequence;
 
             Effect firstClickEvent = mainSequence.FindFirstAnimationForClick(1);
             bool hasNoClicksOnSlide = firstClickEvent == null;
@@ -454,8 +454,8 @@ namespace PowerPointLabs.Models
         {
             if (IsNextSlideTransitionBlacklisted())
             {
-                var animationSequence = _slide.TimeLine.MainSequence;
-                var effect = animationSequence.AddEffect(shape, MsoAnimEffect.msoAnimEffectFade);
+                Sequence animationSequence = _slide.TimeLine.MainSequence;
+                Effect effect = animationSequence.AddEffect(shape, MsoAnimEffect.msoAnimEffectFade);
                 effect.Exit = MsoTriState.msoTrue;
             }
         }
@@ -506,7 +506,7 @@ namespace PowerPointLabs.Models
             shape.Width = newWidth;
             shape.Height = newHeight;
 
-            var effects = TimeLine.MainSequence.Cast<Effect>();
+            IEnumerable<Effect> effects = TimeLine.MainSequence.Cast<Effect>();
             // TODO: Generalize to paths other than msoAnimEffectPathDown?
             effects = effects.Where(e => e.Shape.Equals(shape) && e.EffectType == MsoAnimEffect.msoAnimEffectPathDown).ToList();
 
@@ -515,9 +515,9 @@ namespace PowerPointLabs.Models
             xShift /= PowerPointPresentation.Current.SlideWidth;
             yShift /= PowerPointPresentation.Current.SlideHeight;
 
-            foreach (var effect in effects)
+            foreach (Effect effect in effects)
             {
-                var motionEffect = effect.Behaviors[1].MotionEffect;
+                MotionEffect motionEffect = effect.Behaviors[1].MotionEffect;
                 motionEffect.Path = TranslateVmlPath(motionEffect.Path, xShift, yShift);
             }
         }
@@ -535,15 +535,15 @@ namespace PowerPointLabs.Models
 
         public ShapeRange ToShapeRange(IEnumerable<Shape> shapes)
         {
-            var shapeList = shapes.ToList();
-            var oldNames = shapeList.Select(shape => shape.Name).ToList();
+            List<Shape> shapeList = shapes.ToList();
+            List<string> oldNames = shapeList.Select(shape => shape.Name).ToList();
 
-            var currentShapeNames = Shapes.Cast<Shape>().Select(shape => shape.Name);
-            var unusedNames = CommonUtil.GetUnusedStrings(currentShapeNames, shapeList.Count);
+            IEnumerable<string> currentShapeNames = Shapes.Cast<Shape>().Select(shape => shape.Name);
+            string[] unusedNames = CommonUtil.GetUnusedStrings(currentShapeNames, shapeList.Count);
             shapeList.Zip(unusedNames, (shape, name) => shape.Name = name).ToList();
 
 
-            var shapeRange = Shapes.Range(unusedNames);
+            ShapeRange shapeRange = Shapes.Range(unusedNames);
 
             shapeList.Zip(oldNames, (shape, name) => shape.Name = name).ToList();
 
@@ -558,7 +558,7 @@ namespace PowerPointLabs.Models
             try
             {
                 shape.Copy();
-                var newShape = _slide.Shapes.Paste()[1];
+                Shape newShape = _slide.Shapes.Paste()[1];
 
                 newShape.Name = shape.Name;
                 newShape.Left = shape.Left;
@@ -608,11 +608,11 @@ namespace PowerPointLabs.Models
         {
             // First Index all the shapes by name, so they can be identified later.
             int index = 0;
-            var originalShapes = new Dictionary<string, Shape>();
-            var originalNames = new Dictionary<string, string>();
+            Dictionary<string, Shape> originalShapes = new Dictionary<string, Shape>();
+            Dictionary<string, string> originalNames = new Dictionary<string, string>();
             foreach (Shape shape in shapes)
             {
-                var tempName = index.ToString();
+                string tempName = index.ToString();
                 index++;
 
                 originalNames.Add(tempName, shape.Name);
@@ -623,14 +623,14 @@ namespace PowerPointLabs.Models
 
             // Copy all the shapes over.
             shapes.Copy();
-            var newShapes = _slide.Shapes.Paste();
+            ShapeRange newShapes = _slide.Shapes.Paste();
 
             // Now use the indexed names to set back the names and positions to the original shapes'
             foreach (Shape shape in newShapes)
             {
-                var key = shape.Name;
-                var originalName = originalNames[key];
-                var originalShape = originalShapes[key];
+                string key = shape.Name;
+                string originalName = originalNames[key];
+                Shape originalShape = originalShapes[key];
 
                 originalShape.Name = originalName;
                 shape.Name = originalName;
@@ -644,7 +644,7 @@ namespace PowerPointLabs.Models
         public void TransferAnimation(Shape source, Shape destination)
         {
             Sequence sequence = _slide.TimeLine.MainSequence;
-            var enumerableSequence = sequence.Cast<Effect>().ToList();
+            List<Effect> enumerableSequence = sequence.Cast<Effect>().ToList();
 
             Effect entryDetails = enumerableSequence.FirstOrDefault(effect => effect.Shape.Equals(source));
             if (entryDetails != null)
@@ -716,9 +716,9 @@ namespace PowerPointLabs.Models
         /// </summary>
         public Dictionary<string, Shape> GetNameToShapeDictionary()
         {
-            var shapes = _slide.Shapes.Cast<Shape>();
-            var dictionary = new Dictionary<string, Shape>(shapes.Count());
-            foreach (var shape in shapes)
+            IEnumerable<Shape> shapes = _slide.Shapes.Cast<Shape>();
+            Dictionary<string, Shape> dictionary = new Dictionary<string, Shape>(shapes.Count());
+            foreach (Shape shape in shapes)
             {
                 if (!dictionary.ContainsKey(shape.Name))
                 {
@@ -745,16 +745,16 @@ namespace PowerPointLabs.Models
 
         public List<Shape> GetShapesWithRule(Regex nameRule)
         {
-            var shapes = _slide.Shapes.Cast<Shape>().ToList();
-            var matchingShapes = shapes.Where(current => nameRule.IsMatch(current.Name)).ToList();
+            List<Shape> shapes = _slide.Shapes.Cast<Shape>().ToList();
+            List<Shape> matchingShapes = shapes.Where(current => nameRule.IsMatch(current.Name)).ToList();
 
             return matchingShapes;
         }
 
         public List<Shape> GetShapesWithTypeAndRule(MsoShapeType type, Regex nameRule)
         {
-            var shapes = _slide.Shapes.Cast<Shape>().ToList();
-            var matchingShapes = shapes.Where(current => current.Type == type &&
+            List<Shape> shapes = _slide.Shapes.Cast<Shape>().ToList();
+            List<Shape> matchingShapes = shapes.Where(current => current.Type == type &&
                                               nameRule.IsMatch(current.Name)).ToList();
 
             return matchingShapes;
@@ -1084,15 +1084,15 @@ namespace PowerPointLabs.Models
         /// </summary>
         public List<Shape> GetShapesOrderedByTimeline()
         {
-            var shapesWithEntry = new List<Shape>();
-            var shapesWithoutEntry = new List<Shape>();
-            var identifiedShapeIds = new HashSet<int>();
+            List<Shape> shapesWithEntry = new List<Shape>();
+            List<Shape> shapesWithoutEntry = new List<Shape>();
+            HashSet<int> identifiedShapeIds = new HashSet<int>();
 
-            var seq = _slide.TimeLine.MainSequence;
+            Sequence seq = _slide.TimeLine.MainSequence;
             for (int i = 1; i <= seq.Count; ++i)
             {
-                var effect = seq[i];
-                var shape = effect.Shape;
+                Effect effect = seq[i];
+                Shape shape = effect.Shape;
                 if (!identifiedShapeIds.Contains(shape.Id))
                 {
                     identifiedShapeIds.Add(shape.Id);
@@ -1107,9 +1107,9 @@ namespace PowerPointLabs.Models
                 }
             }
 
-            var remainingShapes = _slide.Shapes.Cast<Shape>().Where(shape => !identifiedShapeIds.Contains(shape.Id));
+            IEnumerable<Shape> remainingShapes = _slide.Shapes.Cast<Shape>().Where(shape => !identifiedShapeIds.Contains(shape.Id));
 
-            var shapes = shapesWithoutEntry;
+            List<Shape> shapes = shapesWithoutEntry;
             shapes.AddRange(shapesWithEntry);
             shapes.AddRange(remainingShapes);
             return shapes;
@@ -1120,7 +1120,7 @@ namespace PowerPointLabs.Models
         /// </summary>
         public List<Shape> GetTextFragments()
         {
-            var allShapes = GetShapesOrderedByTimeline();
+            List<Shape> allShapes = GetShapesOrderedByTimeline();
             return allShapes.Where(shape => shape.Name.StartsWith("PPTLabsHighlightTextFragmentsShape")).ToList();
         }
 
@@ -1162,8 +1162,8 @@ namespace PowerPointLabs.Models
         /// </summary>
         public void MakeShapeNamesNonDefault()
         {
-            var shapes = _slide.Shapes.Cast<Shape>();
-            foreach (var shape in shapes)
+            IEnumerable<Shape> shapes = _slide.Shapes.Cast<Shape>();
+            foreach (Shape shape in shapes)
             {
                 if (ShapeUtil.HasDefaultName(shape))
                 {
@@ -1184,10 +1184,10 @@ namespace PowerPointLabs.Models
                 restrictTo = shape => true;
             }
 
-            var currentNames = new HashSet<string>();
-            var shapes = _slide.Shapes.Cast<Shape>().Where(restrictTo);
+            HashSet<string> currentNames = new HashSet<string>();
+            IEnumerable<Shape> shapes = _slide.Shapes.Cast<Shape>().Where(restrictTo);
 
-            foreach (var shape in shapes)
+            foreach (Shape shape in shapes)
             {
                 if (currentNames.Contains(shape.Name))
                 {
@@ -1201,7 +1201,7 @@ namespace PowerPointLabs.Models
         {
             List<Shape> shapes = _slide.Shapes.Cast<Shape>().ToList();
 
-            var matchingShapes = shapes.Where(current => current.Type == MsoShapeType.msoPlaceholder && current.PlaceholderFormat.Type == PpPlaceholderType.ppPlaceholderSlideNumber);
+            IEnumerable<Shape> matchingShapes = shapes.Where(current => current.Type == MsoShapeType.msoPlaceholder && current.PlaceholderFormat.Type == PpPlaceholderType.ppPlaceholderSlideNumber);
 
             foreach (Shape s in matchingShapes)
             {
@@ -1260,7 +1260,7 @@ namespace PowerPointLabs.Models
         private Effect InsertAnimationAtIndex(Shape shape, int index, MsoAnimEffect animationEffect,
             MsoAnimTriggerType triggerType)
         {
-            var animationSequence = _slide.TimeLine.MainSequence;
+            Sequence animationSequence = _slide.TimeLine.MainSequence;
             Effect effect = animationSequence.AddEffect(shape, animationEffect, MsoAnimateByLevel.msoAnimateLevelNone,
                 triggerType);
             effect.MoveTo(index);
@@ -1300,7 +1300,7 @@ namespace PowerPointLabs.Models
 
         private static void DeleteEffectsForShape(Shape shape, IEnumerable<Effect> mainEffects)
         {
-            var shapeToDeleteList = mainEffects.Where(e => e.Shape.Equals(shape)).ToList();
+            List<Effect> shapeToDeleteList = mainEffects.Where(e => e.Shape.Equals(shape)).ToList();
 
             foreach (Effect e in shapeToDeleteList)
             {
@@ -1328,7 +1328,7 @@ namespace PowerPointLabs.Models
 
         private Effect InsertAnimationBeforeExisting(Shape shape, Effect existing, MsoAnimEffect effect)
         {
-            var sequence = _slide.TimeLine.MainSequence;
+            Sequence sequence = _slide.TimeLine.MainSequence;
 
             Effect newAnimation = sequence.AddEffect(shape, effect, MsoAnimateByLevel.msoAnimateLevelNone,
                 MsoAnimTriggerType.msoAnimTriggerWithPrevious);

--- a/PowerPointLabs/PowerPointLabs/Models/PowerPointSpotlightSlide.cs
+++ b/PowerPointLabs/PowerPointLabs/Models/PowerPointSpotlightSlide.cs
@@ -43,7 +43,7 @@ namespace PowerPointLabs.Models
 
             //Delete shapes with exit animations
             List<PowerPoint.Shape> shapes = _slide.Shapes.Cast<PowerPoint.Shape>().ToList();
-            var matchingShapes = shapes.Where(current => (HasExitAnimation(current)));
+            IEnumerable<PowerPoint.Shape> matchingShapes = shapes.Where(current => (HasExitAnimation(current)));
             foreach (PowerPoint.Shape s in matchingShapes)
             {
                 s.Delete();
@@ -118,7 +118,7 @@ namespace PowerPointLabs.Models
             //export formatted spotlight picture to a temp folder
             spotlightPicture.Export(dirOfRenderedPicture, PowerPoint.PpShapeFormat.ppShapeFormatPNG);
             //then add the exported new picture back
-            var renderedPicture = PowerPointCurrentPresentationInfo.CurrentSlide.Shapes.AddPicture(
+            PowerPoint.Shape renderedPicture = PowerPointCurrentPresentationInfo.CurrentSlide.Shapes.AddPicture(
                 dirOfRenderedPicture, Office.MsoTriState.msoFalse, Office.MsoTriState.msoTrue,
                 spotlightPicture.Left, spotlightPicture.Top, spotlightPicture.Width, spotlightPicture.Height);
 

--- a/PowerPointLabs/PowerPointLabs/Models/TaggedText.cs
+++ b/PowerPointLabs/PowerPointLabs/Models/TaggedText.cs
@@ -51,7 +51,7 @@ namespace PowerPointLabs.Models
             PromptBuilder builder = new PromptBuilder(CultureUtil.GetOriginalCulture());
             builder.StartVoice(defaultVoice);
 
-            var tags = GetTagsInText();
+            IEnumerable<ITag> tags = GetTagsInText();
 
             int startIndex = 0;
             foreach (ITag tag in tags)
@@ -75,7 +75,7 @@ namespace PowerPointLabs.Models
         public String ToPrettyString()
         {
             StringBuilder builder = new StringBuilder();
-            var tags = GetTagsInText();
+            IEnumerable<ITag> tags = GetTagsInText();
 
             int startIndex = 0;
             foreach (ITag tag in tags)
@@ -102,7 +102,7 @@ namespace PowerPointLabs.Models
             List<ITag> tags = new List<ITag>();
             foreach (ITagMatcher tagMatcher in Matchers.All)
             {
-                var matches = tagMatcher.Matches(_contents);
+                List<ITag> matches = tagMatcher.Matches(_contents);
                 tags.AddRange(matches);
             }
 

--- a/PowerPointLabs/PowerPointLabs/NarrationsLab/NotesToAudio.cs
+++ b/PowerPointLabs/PowerPointLabs/NarrationsLab/NotesToAudio.cs
@@ -48,7 +48,7 @@ namespace PowerPointLabs.NarrationsLab
 
         public static string[] EmbedCurrentSlideNotes()
         {
-            var currentSlide = PowerPointCurrentPresentationInfo.CurrentSlide;
+            PowerPointSlide currentSlide = PowerPointCurrentPresentationInfo.CurrentSlide;
             
             if (currentSlide != null)
             {
@@ -60,20 +60,20 @@ namespace PowerPointLabs.NarrationsLab
 
         public static List<string[]> EmbedSelectedSlideNotes()
         {
-            var progressBarForm = new ProcessingStatusForm();
+            ProcessingStatusForm progressBarForm = new ProcessingStatusForm();
             progressBarForm.Show();
-            var audioList = new List<string[]>();
+            List<string[]> audioList = new List<string[]>();
 
-            var slides = PowerPointCurrentPresentationInfo.SelectedSlides.ToList();
+            List<PowerPointSlide> slides = PowerPointCurrentPresentationInfo.SelectedSlides.ToList();
 
             int numberOfSlides = slides.Count;
             for (int currentSlideIndex = 0; currentSlideIndex < numberOfSlides; currentSlideIndex++)
             {
-                var percentage = (int)Math.Round(((double)currentSlideIndex + 1) / numberOfSlides * 100);
+                int percentage = (int)Math.Round(((double)currentSlideIndex + 1) / numberOfSlides * 100);
                 progressBarForm.UpdateProgress(percentage);
                 progressBarForm.UpdateSlideNumber(currentSlideIndex, numberOfSlides);
 
-                var slide = slides[currentSlideIndex];
+                PowerPointSlide slide = slides[currentSlideIndex];
                 audioList.Add(EmbedSlideNotes(slide));
             }
             progressBarForm.Close();
@@ -83,20 +83,20 @@ namespace PowerPointLabs.NarrationsLab
 
         public static List<string[]> EmbedAllSlideNotes()
         {
-            var progressBarForm = new ProcessingStatusForm();
+            ProcessingStatusForm progressBarForm = new ProcessingStatusForm();
             progressBarForm.Show();
-            var audioList = new List<string[]>();
+            List<string[]> audioList = new List<string[]>();
 
-            var slides = PowerPointPresentation.Current.Slides;
+            List<PowerPointSlide> slides = PowerPointPresentation.Current.Slides;
 
             int numberOfSlides = slides.Count;
             for (int currentSlideIndex = 0; currentSlideIndex < numberOfSlides; currentSlideIndex++)
             {
-                var percentage = (int)Math.Round(((double)currentSlideIndex + 1) / numberOfSlides * 100);
+                int percentage = (int)Math.Round(((double)currentSlideIndex + 1) / numberOfSlides * 100);
                 progressBarForm.UpdateProgress(percentage);
                 progressBarForm.UpdateSlideNumber(currentSlideIndex, numberOfSlides);
 
-                var slide = slides[currentSlideIndex];
+                PowerPointSlide slide = slides[currentSlideIndex];
                 audioList.Add(EmbedSlideNotes(slide));
             }
             progressBarForm.Close();
@@ -163,7 +163,7 @@ namespace PowerPointLabs.NarrationsLab
 
         public static void ReplaceSelectedAudio()
         {
-            var selectedShape = Globals.ThisAddIn.Application.ActiveWindow.Selection.ShapeRange;
+            Microsoft.Office.Interop.PowerPoint.ShapeRange selectedShape = Globals.ThisAddIn.Application.ActiveWindow.Selection.ShapeRange;
             if (selectedShape.Count != 1 || selectedShape.MediaType != PpMediaType.ppMediaTypeSound)
             {
                 return;
@@ -177,7 +177,7 @@ namespace PowerPointLabs.NarrationsLab
 
             if (result == DialogResult.OK)
             {
-                var selectedFile = audioPicker.FileName;
+                string selectedFile = audioPicker.FileName;
 
                 PowerPointSlide currentSlide = PowerPointCurrentPresentationInfo.CurrentSlide;
                 Shape newAudio = InsertAudioFileOnSlide(currentSlide, selectedFile);
@@ -208,8 +208,8 @@ namespace PowerPointLabs.NarrationsLab
             // changed, leave the audio.
 
             // to avoid duplicate records, delete all old audios in the current slide
-            var audiosInCurrentSlide = Directory.GetFiles(folderPath);
-            foreach (var audio in audiosInCurrentSlide)
+            string[] audiosInCurrentSlide = Directory.GetFiles(folderPath);
+            foreach (string audio in audiosInCurrentSlide)
             {
                 if (audio.Contains(fileNameSearchPattern))
                 {
@@ -275,9 +275,9 @@ namespace PowerPointLabs.NarrationsLab
 
         private static string[] GetAudioFilePaths(string folderPath, string fileNameSearchPattern)
         {
-            var filePaths = Directory.EnumerateFiles(folderPath, "*." + Audio.RecordedFormatExtension);
-            var comparer = new Utils.Comparers.AtomicNumberStringCompare();
-            var audioFiles =
+            IEnumerable<string> filePaths = Directory.EnumerateFiles(folderPath, "*." + Audio.RecordedFormatExtension);
+            Utils.Comparers.AtomicNumberStringCompare comparer = new Utils.Comparers.AtomicNumberStringCompare();
+            string[] audioFiles =
                 filePaths.Where(path => path.Contains(fileNameSearchPattern)).OrderBy(x => new FileInfo(x).Name,
                                                                                       comparer).ToArray();
 

--- a/PowerPointLabs/PowerPointLabs/NarrationsLab/Views/InShowRecordingControl.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/NarrationsLab/Views/InShowRecordingControl.xaml.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Windows;
 using System.Windows.Media;
@@ -49,7 +50,7 @@ namespace PowerPointLabs.NarrationsLab.Views
             _recorder = recorder;
 
             // get slide show window
-            var slideShowWindow = new IntPtr(_slideShowWindow.HWND);
+            IntPtr slideShowWindow = new IntPtr(_slideShowWindow.HWND);
 
             Native.RECT rec;
             Native.GetWindowRect(new HandleRef(new object(), slideShowWindow), out rec);
@@ -125,7 +126,7 @@ namespace PowerPointLabs.NarrationsLab.Views
                     _recorder.StopButtonRecordingHandler(_recordStartClick, _recordStartSlide, true);
                     _slideShowWindow.Activate();
 
-                    var totalClick = _slideShowWindow.View.GetClickCount();
+                    int totalClick = _slideShowWindow.View.GetClickCount();
 
                     if (click + 1 > totalClick)
                     {
@@ -152,8 +153,8 @@ namespace PowerPointLabs.NarrationsLab.Views
                 return;
             }
 
-            var temp = _recorder.AudioBuffer[_recordStartSlide.Index - 1];
-
+            List<Tuple<AudioMisc.Audio, int>> temp = _recorder.AudioBuffer[_recordStartSlide.Index - 1];
+            
             // disable undo since we allow only 1 step undo
             undoButton.IsEnabled = false;
 

--- a/PowerPointLabs/PowerPointLabs/NarrationsLab/Views/RecorderTaskPane.cs
+++ b/PowerPointLabs/PowerPointLabs/NarrationsLab/Views/RecorderTaskPane.cs
@@ -182,7 +182,7 @@ namespace PowerPointLabs.NarrationsLab.Views
         {
             try
             {
-                var buffer = new byte[2048];
+                byte[] buffer = new byte[2048];
                 WaveFileWriter writer = null;
 
                 // delete the old file if it exists
@@ -201,9 +201,9 @@ namespace PowerPointLabs.NarrationsLab.Views
                     return;
                 }
 
-                foreach (var audio in audios)
+                foreach (string audio in audios)
                 {
-                    using (var reader = new WaveFileReader(audio))
+                    using (WaveFileReader reader = new WaveFileReader(audio))
                     {
                         if (writer == null)
                         {
@@ -242,8 +242,8 @@ namespace PowerPointLabs.NarrationsLab.Views
 
         private void NMergeAudios(string path, string baseName, string outputName)
         {
-            var audioFiles = Directory.EnumerateFiles(path, String.Format("*.{0}", Audio.RecordedFormatExtension));
-            var audios = audioFiles.Where(audio => audio.Contains(baseName)).ToArray();
+            IEnumerable<string> audioFiles = Directory.EnumerateFiles(path, String.Format("*.{0}", Audio.RecordedFormatExtension));
+            string[] audios = audioFiles.Where(audio => audio.Contains(baseName)).ToArray();
 
             NMergeAudios(audios, outputName);
         }
@@ -325,7 +325,7 @@ namespace PowerPointLabs.NarrationsLab.Views
 
         private int GetRecordIndexFromScriptIndex(int relativeId, int scriptIndex)
         {
-            var recordIndex = -1;
+            int recordIndex = -1;
 
             // if no matched script, return -1 directly
             if (scriptIndex == -1)
@@ -333,9 +333,9 @@ namespace PowerPointLabs.NarrationsLab.Views
                 return -1;
             }
 
-            for (var i = 0; i < _audioList[relativeId].Count; i++)
+            for (int i = 0; i < _audioList[relativeId].Count; i++)
             {
-                var audio = _audioList[relativeId][i];
+                Audio audio = _audioList[relativeId][i];
 
                 if (audio.MatchScriptID == scriptIndex)
                 {
@@ -356,7 +356,7 @@ namespace PowerPointLabs.NarrationsLab.Views
 
         private Audio GetPlaybackFromList()
         {
-            var relativeSlideId = GetRelativeSlideIndex(PowerPointCurrentPresentationInfo.CurrentSlide.ID);
+            int relativeSlideId = GetRelativeSlideIndex(PowerPointCurrentPresentationInfo.CurrentSlide.ID);
             int playbackIndex = -1;
             
             if (recDisplay.SelectedIndices.Count != 0)
@@ -374,7 +374,7 @@ namespace PowerPointLabs.NarrationsLab.Views
 
         private Audio GetPlaybackFromList(int scriptIndex, int slideId)
         {
-            var relativeSlideId = GetRelativeSlideIndex(slideId);
+            int relativeSlideId = GetRelativeSlideIndex(slideId);
             int recordIndex = -1;
 
             if (scriptIndex == -1)
@@ -399,11 +399,11 @@ namespace PowerPointLabs.NarrationsLab.Views
 
         private void MapShapesWithAudio(PowerPointSlide slide)
         {
-            var relativeSlideId = GetRelativeSlideIndex(slide.ID);
+            int relativeSlideId = GetRelativeSlideIndex(slide.ID);
             XmlParser xmlParser;
 
             string searchRule = string.Format("^({0}|{1})", SpeechShapePrefixOld, SpeechShapePrefix);
-            var shapes = slide.GetShapesWithMediaType(PpMediaType.ppMediaTypeSound, new Regex(searchRule));
+            List<Shape> shapes = slide.GetShapesWithMediaType(PpMediaType.ppMediaTypeSound, new Regex(searchRule));
 
             if (shapes.Count == 0)
             {
@@ -422,9 +422,9 @@ namespace PowerPointLabs.NarrationsLab.Views
             }
 
             // iterate through all shapes, skip audios that are not generated speech
-            foreach (var shape in shapes)
+            foreach (Shape shape in shapes)
             {
-                var saveName = _tempFullPath + xmlParser.GetCorrespondingAudio(shape.Name);
+                string saveName = _tempFullPath + xmlParser.GetCorrespondingAudio(shape.Name);
                 Audio audio = null;
 
                 try
@@ -465,11 +465,11 @@ namespace PowerPointLabs.NarrationsLab.Views
 
         private void RefreshScriptList(PowerPointSlide slide)
         {
-            var relativeSlideId = GetRelativeSlideIndex(slide.ID);
+            int relativeSlideId = GetRelativeSlideIndex(slide.ID);
 
-            var taggedNotes = new TaggedText(slide.NotesPageText.Trim());
-            var prettyNotes = taggedNotes.ToPrettyString();
-            var splitScript = (new TaggedText(prettyNotes)).SplitByClicks();
+            TaggedText taggedNotes = new TaggedText(slide.NotesPageText.Trim());
+            string prettyNotes = taggedNotes.ToPrettyString();
+            List<string> splitScript = (new TaggedText(prettyNotes)).SplitByClicks();
 
             while (relativeSlideId >= _scriptList.Count)
             {
@@ -481,7 +481,7 @@ namespace PowerPointLabs.NarrationsLab.Views
 
         private void RefreshAudioList(PowerPointSlide slide, string[] names)
         {
-            var relativeSlideId = GetRelativeSlideIndex(slide.ID);
+            int relativeSlideId = GetRelativeSlideIndex(slide.ID);
 
             while (relativeSlideId >= _audioList.Count)
             {
@@ -502,7 +502,7 @@ namespace PowerPointLabs.NarrationsLab.Views
                 {
                     string saveName = names[i];
                     string name = String.Format(SpeechShapeFormat, i);
-                    var audio = new Audio(name, saveName, i);
+                    Audio audio = new Audio(name, saveName, i);
 
                     _audioList[relativeSlideId].Add(audio);
                 }
@@ -543,7 +543,7 @@ namespace PowerPointLabs.NarrationsLab.Views
 
             for (int index = 0; index < _audioList[relativeSlideId].Count; index++)
             {
-                var audio = _audioList[relativeSlideId][index];
+                Audio audio = _audioList[relativeSlideId][index];
 
                 ListViewItem item = recDisplay.Items.Add((index + 1).ToString(CultureInfo.InvariantCulture));
                 item.SubItems.Add(audio.Name);
@@ -617,7 +617,7 @@ namespace PowerPointLabs.NarrationsLab.Views
             scriptDisplay.BeginUpdate();
             for (int i = 0; i < scirpt.Count; i++)
             {
-                var corresRecIndex = GetRecordIndexFromScriptIndex(relativeSlideId, i);
+                int corresRecIndex = GetRecordIndexFromScriptIndex(relativeSlideId, i);
 
                 if (corresRecIndex != -1)
                 {
@@ -689,7 +689,7 @@ namespace PowerPointLabs.NarrationsLab.Views
         public void ClearRecordDataList()
         {
             // clear the data structure
-            foreach (var audioInslide in _audioList)
+            foreach (List<Audio> audioInslide in _audioList)
             {
                 audioInslide.Clear();
             }
@@ -713,7 +713,7 @@ namespace PowerPointLabs.NarrationsLab.Views
 
         public void ClearScriptDataList()
         {
-            foreach (var slide in _scriptList)
+            foreach (List<string> slide in _scriptList)
             {
                 slide.Clear();
             }
@@ -739,16 +739,16 @@ namespace PowerPointLabs.NarrationsLab.Views
 
         private List<Audio> CopySlideAudio(int slideId)
         {
-            var relativeSlideId = GetRelativeSlideIndex(slideId);
-            var audioList = new List<Audio>(_audioList[relativeSlideId]);
+            int relativeSlideId = GetRelativeSlideIndex(slideId);
+            List<Audio> audioList = new List<Audio>(_audioList[relativeSlideId]);
 
             return audioList;
         }
 
         private List<string> CopySlideScript(int slideId)
         {
-            var relativeSlideId = GetRelativeSlideIndex(slideId);
-            var scriptList = new List<string>(_scriptList[relativeSlideId]);
+            int relativeSlideId = GetRelativeSlideIndex(slideId);
+            List<string> scriptList = new List<string>(_scriptList[relativeSlideId]);
 
             return scriptList;
         }
@@ -760,15 +760,15 @@ namespace PowerPointLabs.NarrationsLab.Views
             // some of them haven't been initialized.
             InitializeAudioAndScript(slide, null, false);
 
-            var audio = CopySlideAudio(slide.ID);
-            var script = CopySlideScript(slide.ID);
+            List<Audio> audio = CopySlideAudio(slide.ID);
+            List<string> script = CopySlideScript(slide.ID);
 
             return new Tuple<List<Audio>, List<string>>(audio, script);
         }
 
         private void PasteSlideAudio(int slideId, List<Audio> audioList)
         {
-            var relativeSlideId = GetRelativeSlideIndex(slideId);
+            int relativeSlideId = GetRelativeSlideIndex(slideId);
 
             while (relativeSlideId >= _audioList.Count)
             {
@@ -780,7 +780,7 @@ namespace PowerPointLabs.NarrationsLab.Views
 
         private void PasteSlideScript(int slideId, List<string> scriptList)
         {
-            var relativeSlideId = GetRelativeSlideIndex(slideId);
+            int relativeSlideId = GetRelativeSlideIndex(slideId);
 
             while (relativeSlideId >= _scriptList.Count)
             {
@@ -798,10 +798,10 @@ namespace PowerPointLabs.NarrationsLab.Views
 
         private void DeleteTempAudioFiles()
         {
-            var audioFiles = Directory.EnumerateFiles(_tempFullPath, String.Format("*.{0}", Audio.RecordedFormatExtension));
-            var tempAudios = audioFiles.Where(audio => audio.Contains("temp")).ToArray();
+            IEnumerable<string> audioFiles = Directory.EnumerateFiles(_tempFullPath, String.Format("*.{0}", Audio.RecordedFormatExtension));
+            string[] tempAudios = audioFiles.Where(audio => audio.Contains("temp")).ToArray();
 
-            foreach (var audio in tempAudios)
+            foreach (string audio in tempAudios)
             {
                 File.Delete(audio);
             }
@@ -850,9 +850,9 @@ namespace PowerPointLabs.NarrationsLab.Views
         {
             try
             {
-                var slides = PowerPointPresentation.Current.Slides.ToList();
+                List<PowerPointSlide> slides = PowerPointPresentation.Current.Slides.ToList();
 
-                foreach (var slide in slides)
+                foreach (PowerPointSlide slide in slides)
                 {
                     // because of lazy loading, each slide will not be initialized
                     // until it is viewed.Therefore we need to remember the original
@@ -869,8 +869,8 @@ namespace PowerPointLabs.NarrationsLab.Views
 
         public void InitializeAudioAndScript(PowerPointSlide slide, string[] names, bool forceRefresh)
         {
-            var relativeSlideId = GetRelativeSlideIndex(slide.ID);
-            var initialized = _audioList != null &&
+            int relativeSlideId = GetRelativeSlideIndex(slide.ID);
+            bool initialized = _audioList != null &&
                               _audioList.Count > relativeSlideId &&
                               _audioList[relativeSlideId].Count != 0;
 
@@ -887,7 +887,7 @@ namespace PowerPointLabs.NarrationsLab.Views
         {
             for (int i = 0; i < slides.Count; i++)
             {
-                var slide = slides[i];
+                PowerPointSlide slide = slides[i];
 
                 InitializeAudioAndScript(slide, names[i], forceRefresh);
             }
@@ -934,7 +934,7 @@ namespace PowerPointLabs.NarrationsLab.Views
             // been selected
             SetAllRecorderButtonState(false);
 
-            var currentSlide = PowerPointCurrentPresentationInfo.CurrentSlide;
+            PowerPointSlide currentSlide = PowerPointCurrentPresentationInfo.CurrentSlide;
             if (currentSlide != null)
             {
                 InitializeAudioAndScript(currentSlide, null, false);
@@ -953,7 +953,7 @@ namespace PowerPointLabs.NarrationsLab.Views
             // been selected
             SetAllRecorderButtonState(false);
 
-            var currentSlide = PowerPointCurrentPresentationInfo.CurrentSlide;
+            PowerPointSlide currentSlide = PowerPointCurrentPresentationInfo.CurrentSlide;
             if (currentSlide != null)
             {
                 RefreshScriptList(currentSlide);
@@ -1006,7 +1006,7 @@ namespace PowerPointLabs.NarrationsLab.Views
             }
             else
             {
-                var temp = (int) (value / (double) _playbackLenMillis * bar.Maximum);
+                int temp = (int) (value / (double) _playbackLenMillis * bar.Maximum);
                 if (temp > bar.Maximum)
                 {
                     temp = bar.Maximum;
@@ -1133,7 +1133,7 @@ namespace PowerPointLabs.NarrationsLab.Views
             _recordClipCnt = 0;
             _recordTotalLength = 0;
             // construct new save name
-            var tempSaveName = String.Format(_tempWaveFileNameFormat, _recordClipCnt);
+            string tempSaveName = String.Format(_tempWaveFileNameFormat, _recordClipCnt);
 
             // start recording
             NStartRecordAudio(tempSaveName, Audio.RecordedSamplingRate, Audio.RecordedBitRate, Audio.RecordedChannels, true);
@@ -1188,7 +1188,7 @@ namespace PowerPointLabs.NarrationsLab.Views
             recButton.Image = Properties.Resources.Pause;
 
             // start a new recording, name it after clip counter and restart the timer
-            var tempSaveName = String.Format(_tempWaveFileNameFormat, _recordClipCnt);
+            string tempSaveName = String.Format(_tempWaveFileNameFormat, _recordClipCnt);
             NStartRecordAudio(tempSaveName, Audio.RecordedSamplingRate, Audio.RecordedBitRate, Audio.RecordedChannels, true);
             _timer = new System.Threading.Timer(TimerEvent, null, _resumeWaitingTime, 1000);
         }
@@ -1206,7 +1206,7 @@ namespace PowerPointLabs.NarrationsLab.Views
             ResetTimer();
 
             // get current playback, can be null if there's no matched audio
-            var currentPlayback = GetPlaybackFromList(scriptIndex, currentSlide.ID);
+            Audio currentPlayback = GetPlaybackFromList(scriptIndex, currentSlide.ID);
 
             try
             {
@@ -1221,7 +1221,7 @@ namespace PowerPointLabs.NarrationsLab.Views
                 NCleanup();
 
                 // ask if the user wants to do the replacement
-                var result = DialogResult.Yes;
+                DialogResult result = DialogResult.Yes;
 
                 // prompt to the user only when escaping the slide show while recording
                 if (_inShowControlBox != null && 
@@ -1255,14 +1255,14 @@ namespace PowerPointLabs.NarrationsLab.Views
                     string displayName;
                     Audio newRec;
 
-                    var relativeSlideId = GetRelativeSlideIndex(currentSlide.ID);
+                    int relativeSlideId = GetRelativeSlideIndex(currentSlide.ID);
 
                     // map the script index with record index
                     // here a simple iteration will find:
                     // 1. the replacement position if a record exists;
                     // 2. an insertion position if a record needs to be added
                     // specially, index == -1 means the record needs to be appended
-                    var recordIndex = -1;
+                    int recordIndex = -1;
 
                     if (scriptIndex == -1)
                     {
@@ -1275,7 +1275,7 @@ namespace PowerPointLabs.NarrationsLab.Views
                     {
                         for (int i = 0; i < _audioList[relativeSlideId].Count; i++)
                         {
-                            var audio = _audioList[relativeSlideId][i];
+                            Audio audio = _audioList[relativeSlideId][i];
 
                             if (audio.MatchScriptID >= scriptIndex)
                             {
@@ -1291,7 +1291,7 @@ namespace PowerPointLabs.NarrationsLab.Views
                     {
                         saveName = currentPlayback.SaveName.Replace("." + Audio.RecordedFormatExtension, " rec." + Audio.RecordedFormatExtension);
                         displayName = currentPlayback.Name;
-                        var matchId = currentPlayback.MatchScriptID;
+                        int matchId = currentPlayback.MatchScriptID;
                         
                         if (scriptIndex == -1)
                         {
@@ -1321,7 +1321,7 @@ namespace PowerPointLabs.NarrationsLab.Views
                     // script, we need to construct the new record and insert it to a proper
                     // position
                     {
-                        var saveNameSuffix = String.Format(" {0} rec.{1}", scriptIndex, Audio.RecordedFormatExtension);
+                        string saveNameSuffix = String.Format(" {0} rec.{1}", scriptIndex, Audio.RecordedFormatExtension);
                         saveName = _tempFullPath + String.Format(SaveNameFormat, relativeSlideId) + saveNameSuffix;
                         
                         // the display name -> which script it corresponds to
@@ -1429,7 +1429,7 @@ namespace PowerPointLabs.NarrationsLab.Views
             ResetRecorder();
             
             // get play back length
-            var playback = GetPlaybackFromList();
+            Audio playback = GetPlaybackFromList();
 
             if (playback == null)
             {
@@ -1583,10 +1583,10 @@ namespace PowerPointLabs.NarrationsLab.Views
             slideShowButton.Enabled = false;
 
             // get current slide number
-            var slideIndex = PowerPointCurrentPresentationInfo.CurrentSlide.Index;
+            int slideIndex = PowerPointCurrentPresentationInfo.CurrentSlide.Index;
             
             // set the starting slide and start the slide show
-            var slideShowSettings = PowerPointPresentation.Current.Presentation.SlideShowSettings;
+            SlideShowSettings slideShowSettings = PowerPointPresentation.Current.Presentation.SlideShowSettings;
             
             // start from the selected slide
             slideShowSettings.StartingSlide = slideIndex;
@@ -1594,7 +1594,7 @@ namespace PowerPointLabs.NarrationsLab.Views
             slideShowSettings.RangeType = PpSlideShowRangeType.ppShowSlideRange;
             
             // get the slideShowWindow and slideShowView object
-            var slideShowWindow = slideShowSettings.Run();
+            SlideShowWindow slideShowWindow = slideShowSettings.Run();
 
             // unhide the pointer
             slideShowWindow.View.PointerType = PpSlideShowPointerType.ppSlideShowPointerArrow;
@@ -1707,9 +1707,9 @@ namespace PowerPointLabs.NarrationsLab.Views
             // ensure there is and only 1 item has been selected
             if (scriptDisplay.SelectedItems.Count == 1)
             {
-                var index = scriptDisplay.SelectedIndices[0];
-                var relativeSlideId = GetRelativeSlideIndex(PowerPointCurrentPresentationInfo.CurrentSlide.ID);
-                var recordIndex = GetRecordIndexFromScriptIndex(relativeSlideId, index);
+                int index = scriptDisplay.SelectedIndices[0];
+                int relativeSlideId = GetRelativeSlideIndex(PowerPointCurrentPresentationInfo.CurrentSlide.ID);
+                int recordIndex = GetRecordIndexFromScriptIndex(relativeSlideId, index);
                 
                 // there is a corresponding record
                 if (recordIndex != -1)
@@ -1730,7 +1730,7 @@ namespace PowerPointLabs.NarrationsLab.Views
 
         private void ContextMenuStrip1ItemClicked(object sender, ToolStripItemClickedEventArgs e)
         {
-            var item = e.ClickedItem;
+            ToolStripItem item = e.ClickedItem;
 
             if (item.Name.Contains("play"))
             {
@@ -1750,11 +1750,11 @@ namespace PowerPointLabs.NarrationsLab.Views
             {
                 if (recDisplay.SelectedItems.Count == 1)
                 {
-                    var currentSlide = PowerPointCurrentPresentationInfo.CurrentSlide;
-                    var recordIndex = recDisplay.SelectedIndices[0];
-                    var relativeSlideId = GetRelativeSlideIndex(currentSlide.ID);
-                    var audio = _audioList[relativeSlideId][recordIndex];
-                    var scriptIndex = audio.MatchScriptID;
+                    PowerPointSlide currentSlide = PowerPointCurrentPresentationInfo.CurrentSlide;
+                    int recordIndex = recDisplay.SelectedIndices[0];
+                    int relativeSlideId = GetRelativeSlideIndex(currentSlide.ID);
+                    Audio audio = _audioList[relativeSlideId][recordIndex];
+                    int scriptIndex = audio.MatchScriptID;
 
                     // delete the corresponding audio shape
                     currentSlide.DeleteShapesWithPrefix(audio.Name);
@@ -1781,7 +1781,7 @@ namespace PowerPointLabs.NarrationsLab.Views
         {
             get
             {
-                var createParams = base.CreateParams;
+                CreateParams createParams = base.CreateParams;
                 createParams.ExStyle |= (int)Native.Message.WS_EX_COMPOSITED;  // Turn on WS_EX_COMPOSITED
                 return createParams;
             }

--- a/PowerPointLabs/PowerPointLabs/NativeMethods.cs
+++ b/PowerPointLabs/PowerPointLabs/NativeMethods.cs
@@ -193,11 +193,11 @@ namespace PPExtraEventHelper
 
         internal static Point GetPoint(IntPtr lParam)
         {
-            var uLParam = GetUncheckedInt(lParam);
+            uint uLParam = GetUncheckedInt(lParam);
             
             // cast to long first so that it's 64-bit compatible
-            var x = unchecked((short)(long)uLParam);
-            var y = unchecked((short)((long)uLParam >> 16));
+            short x = unchecked((short)(long)uLParam);
+            short y = unchecked((short)((long)uLParam >> 16));
 
             return new Point(x, y);
         }

--- a/PowerPointLabs/PowerPointLabs/PPExtraEventHelper/PPKeyboard.cs
+++ b/PowerPointLabs/PowerPointLabs/PPExtraEventHelper/PPKeyboard.cs
@@ -115,7 +115,7 @@ namespace PPExtraEventHelper
             _keyDownActions = new Dictionary<int, List<BindedAction>>();
             _keyUpActions = new Dictionary<int, List<BindedAction>>();
 
-            foreach (var key in Enum.GetValues(typeof(Native.VirtualKey)))
+            foreach (object key in Enum.GetValues(typeof(Native.VirtualKey)))
             {
                 int keyIndex = (int)key;
                 _keyStatuses.Add(keyIndex, new KeyStatus());
@@ -237,7 +237,7 @@ namespace PPExtraEventHelper
                 int keyIndex = wParam.ToInt32();
                 if (_keyStatuses.ContainsKey(keyIndex))
                 {
-                    var keyStatus = _keyStatuses[keyIndex];
+                    KeyStatus keyStatus = _keyStatuses[keyIndex];
                     if (IsKeydownCommand(lParam))
                     {
                         if (!keyStatus.IsPressed)
@@ -245,9 +245,9 @@ namespace PPExtraEventHelper
                             keyStatus.Press();
                         }
 
-                        foreach (var action in _keyDownActions[keyIndex])
+                        foreach (BindedAction action in _keyDownActions[keyIndex])
                         {
-                            var block = action.RunConditionally(keyStatus);
+                            bool block = action.RunConditionally(keyStatus);
                             if (block)
                             {
                                 blockInput = true;
@@ -258,9 +258,9 @@ namespace PPExtraEventHelper
                     {
                         if (keyStatus.IsPressed)
                         {
-                            foreach (var action in _keyUpActions[keyIndex])
+                            foreach (BindedAction action in _keyUpActions[keyIndex])
                             {
-                                var block = action.RunConditionally(keyStatus);
+                                bool block = action.RunConditionally(keyStatus);
                                 if (block)
                                 {
                                     blockInput = true;

--- a/PowerPointLabs/PowerPointLabs/PPExtraEventHelper/PPMouse.cs
+++ b/PowerPointLabs/PowerPointLabs/PPExtraEventHelper/PPMouse.cs
@@ -100,7 +100,7 @@ namespace PPExtraEventHelper
                 if (wParam.ToInt32() == (int)Native.Message.WM_LBUTTONDBLCLK 
                     && !IsReEnteredCallback())
                 {
-                    var handle = Process.GetCurrentProcess().MainWindowHandle;
+                    IntPtr handle = Process.GetCurrentProcess().MainWindowHandle;
                     FindSlideViewWindowHandle(handle);
                     if (IsMouseWithinSlideViewWindow()
                         && DoubleClick != null)

--- a/PowerPointLabs/PowerPointLabs/PPExtraEventHelper/PPMouseLegacy.cs
+++ b/PowerPointLabs/PowerPointLabs/PPExtraEventHelper/PPMouseLegacy.cs
@@ -73,7 +73,7 @@ namespace PPExtraEventHelper
                 if (wParam.ToInt32() == (int)Native.Message.WM_LBUTTONDBLCLK
                     && !IsReEnteredCallback())
                 {
-                    var handle = Process.GetCurrentProcess().MainWindowHandle;
+                    IntPtr handle = Process.GetCurrentProcess().MainWindowHandle;
                     FindSlideViewWindowHandle(handle);
                     if (IsMouseWithinSlideViewWindow()
                         && DoubleClick != null)

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Model/Settings.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Model/Settings.cs
@@ -44,7 +44,7 @@ namespace PowerPointLabs.PictureSlidesLab.Model
         {
             foreach (PropertyDescriptor property in TypeDescriptor.GetProperties(this))
             {
-                var myAttribute = (DefaultValueAttribute) property
+                DefaultValueAttribute myAttribute = (DefaultValueAttribute) property
                     .Attributes[typeof(DefaultValueAttribute)];
                 if (myAttribute != null)
                 {

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Model/StyleOption.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Model/StyleOption.cs
@@ -34,9 +34,9 @@ namespace PowerPointLabs.PictureSlidesLab.Model
         {
             try
             {
-                using (var writer = new StreamWriter(filename))
+                using (StreamWriter writer = new StreamWriter(filename))
                 {
-                    var serializer = new XmlSerializer(GetType());
+                    XmlSerializer serializer = new XmlSerializer(GetType());
                     serializer.Serialize(writer, this);
                     writer.Flush();
                 }
@@ -56,10 +56,10 @@ namespace PowerPointLabs.PictureSlidesLab.Model
         {
             try
             {
-                using (var stream = File.OpenRead(filename))
+                using (FileStream stream = File.OpenRead(filename))
                 {
-                    var serializer = new XmlSerializer(typeof(StyleOption));
-                    var opt = serializer.Deserialize(stream) as StyleOption;
+                    XmlSerializer serializer = new XmlSerializer(typeof(StyleOption));
+                    StyleOption opt = serializer.Deserialize(stream) as StyleOption;
                     return opt ?? new StyleOption();
                 }
             }
@@ -77,7 +77,7 @@ namespace PowerPointLabs.PictureSlidesLab.Model
         {
             foreach (PropertyDescriptor property in TypeDescriptor.GetProperties(this))
             {
-                var myAttribute = (DefaultValueAttribute) property
+                DefaultValueAttribute myAttribute = (DefaultValueAttribute) property
                     .Attributes[typeof(DefaultValueAttribute)];
                 if (myAttribute != null)
                 {

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Model/StyleVariant.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Model/StyleVariant.cs
@@ -28,10 +28,10 @@ namespace PowerPointLabs.PictureSlidesLab.Model
 
         public void Apply(StyleOption opt)
         {
-            foreach (var pair in _variants)
+            foreach (KeyValuePair<string, object> pair in _variants)
             {
-                var type = opt.GetType();
-                var prop = type.GetProperty(pair.Key);
+                System.Type type = opt.GetType();
+                System.Reflection.PropertyInfo prop = type.GetProperty(pair.Key);
                 prop.SetValue(opt, pair.Value, null);
             }
         }
@@ -41,8 +41,8 @@ namespace PowerPointLabs.PictureSlidesLab.Model
         /// </summary>
         public StyleVariant Copy(StyleOption opt, string givenOptionName = null)
         {
-            var newVariants = new Dictionary<string, object>();
-            foreach (var pair in _variants)
+            Dictionary<string, object> newVariants = new Dictionary<string, object>();
+            foreach (KeyValuePair<string, object> pair in _variants)
             {
                 if (pair.Key.Equals("OptionName"))
                 {
@@ -50,9 +50,9 @@ namespace PowerPointLabs.PictureSlidesLab.Model
                 }
                 else
                 {
-                    var type = opt.GetType();
-                    var prop = type.GetProperty(pair.Key);
-                    var optValue = prop.GetValue(opt, null);
+                    System.Type type = opt.GetType();
+                    System.Reflection.PropertyInfo prop = type.GetProperty(pair.Key);
+                    object optValue = prop.GetValue(opt, null);
                     newVariants[pair.Key] = optValue;
                 }
             }
@@ -65,16 +65,16 @@ namespace PowerPointLabs.PictureSlidesLab.Model
         /// <param name="opt"></param>
         public bool IsNoEffect(StyleOption opt)
         {
-            foreach (var pair in _variants)
+            foreach (KeyValuePair<string, object> pair in _variants)
             {
                 if (pair.Key.Equals("OptionName") || pair.Value is bool)
                 {
                     continue;
                 }
 
-                var type = opt.GetType();
-                var prop = type.GetProperty(pair.Key);
-                var optValue = prop.GetValue(opt, null);
+                System.Type type = opt.GetType();
+                System.Reflection.PropertyInfo prop = type.GetProperty(pair.Key);
+                object optValue = prop.GetValue(opt, null);
                 if (!pair.Value.Equals(optValue))
                 {
                     return false;

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/ModelFactory/Options/BannerStyleOptions.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/ModelFactory/Options/BannerStyleOptions.cs
@@ -13,8 +13,8 @@ namespace PowerPointLabs.PictureSlidesLab.ModelFactory.Options
     {
         public override List<StyleOption> GetOptionsForVariation()
         {
-            var options = new TextBoxStyleOptions().GetOptionsForVariation();
-            foreach (var option in options)
+            List<StyleOption> options = new TextBoxStyleOptions().GetOptionsForVariation();
+            foreach (StyleOption option in options)
             {
                 option.FontFamily = "Times New Roman";
             }

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/ModelFactory/Options/BaseStyleOptions.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/ModelFactory/Options/BaseStyleOptions.cs
@@ -12,8 +12,8 @@ namespace PowerPointLabs.PictureSlidesLab.ModelFactory.Options
 
         protected List<StyleOption> GetOptions()
         {
-            var result = new List<StyleOption>();
-            for (var i = 0; i < 8; i++)
+            List<StyleOption> result = new List<StyleOption>();
+            for (int i = 0; i < 8; i++)
             {
                 result.Add(new StyleOption());
             }
@@ -22,7 +22,7 @@ namespace PowerPointLabs.PictureSlidesLab.ModelFactory.Options
 
         protected List<StyleOption> GetOptionsWithSuitableFontColor()
         {
-            var result = GetOptions();
+            List<StyleOption> result = GetOptions();
             result[0].FontColor = "#000000"; //white(bg color) + black
             result[1].FontColor = "#FFD700"; //black + yellow
             result[2].FontColor = "#000000"; //yellow + black
@@ -34,7 +34,7 @@ namespace PowerPointLabs.PictureSlidesLab.ModelFactory.Options
 
         protected List<StyleOption> UpdateStyleName(List<StyleOption> opts, string styleName)
         {
-            foreach (var styleOption in opts)
+            foreach (StyleOption styleOption in opts)
             {
                 styleOption.StyleName = styleName;
             }

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/ModelFactory/Options/BlurStyleOptions.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/ModelFactory/Options/BlurStyleOptions.cs
@@ -13,8 +13,8 @@ namespace PowerPointLabs.PictureSlidesLab.ModelFactory.Options
     {
         public override List<StyleOption> GetOptionsForVariation()
         {
-            var result = GetOptions();
-            foreach (var styleOption in result)
+            List<StyleOption> result = GetOptions();
+            foreach (StyleOption styleOption in result)
             {
                 styleOption.IsUseTextGlow = true;
                 styleOption.TextGlowColor = "#000000";

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/ModelFactory/Options/CircleStyleOptions.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/ModelFactory/Options/CircleStyleOptions.cs
@@ -13,8 +13,8 @@ namespace PowerPointLabs.PictureSlidesLab.ModelFactory.Options
     {
         public override List<StyleOption> GetOptionsForVariation()
         {
-            var result = GetOptionsWithSuitableFontColor();
-            foreach (var styleOption in result)
+            List<StyleOption> result = GetOptionsWithSuitableFontColor();
+            foreach (StyleOption styleOption in result)
             {
                 styleOption.IsUseCircleStyle = true;
                 styleOption.CircleTransparency = 25;

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/ModelFactory/Options/DirectTextStyleOptions.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/ModelFactory/Options/DirectTextStyleOptions.cs
@@ -13,8 +13,8 @@ namespace PowerPointLabs.PictureSlidesLab.ModelFactory.Options
     {
         public override List<StyleOption> GetOptionsForVariation()
         {
-            var result = GetOptions();
-            foreach (var styleOption in result)
+            List<StyleOption> result = GetOptions();
+            foreach (StyleOption styleOption in result)
             {
                 styleOption.IsUseTextGlow = true;
                 styleOption.TextGlowColor = "#000000";

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/ModelFactory/Options/FrameStyleOptions.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/ModelFactory/Options/FrameStyleOptions.cs
@@ -13,8 +13,8 @@ namespace PowerPointLabs.PictureSlidesLab.ModelFactory.Options
     {
         public override List<StyleOption> GetOptionsForVariation()
         {
-            var result = GetOptions();
-            foreach (var styleOption in result)
+            List<StyleOption> result = GetOptions();
+            foreach (StyleOption styleOption in result)
             {
                 styleOption.IsUseFrameStyle = true;
                 styleOption.IsUseTextGlow = true;

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/ModelFactory/Options/FrostedGlassBannerStyleOptions.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/ModelFactory/Options/FrostedGlassBannerStyleOptions.cs
@@ -13,8 +13,8 @@ namespace PowerPointLabs.PictureSlidesLab.ModelFactory.Options
     {
         public override List<StyleOption> GetOptionsForVariation()
         {
-            var options = GetOptions();
-            foreach (var option in options)
+            List<StyleOption> options = GetOptions();
+            foreach (StyleOption option in options)
             {
                 option.IsUseFrostedGlassBannerStyle = true;
                 option.FontFamily = "Segoe UI";

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/ModelFactory/Options/FrostedGlassTextBoxStyleOptions.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/ModelFactory/Options/FrostedGlassTextBoxStyleOptions.cs
@@ -13,8 +13,8 @@ namespace PowerPointLabs.PictureSlidesLab.ModelFactory.Options
     {
         public override List<StyleOption> GetOptionsForVariation()
         {
-            var options = GetOptions();
-            foreach (var option in options)
+            List<StyleOption> options = GetOptions();
+            foreach (StyleOption option in options)
             {
                 option.IsUseFrostedGlassTextBoxStyle = true;
                 option.FontFamily = "Segoe UI";

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/ModelFactory/Options/OutlineStyleOptions.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/ModelFactory/Options/OutlineStyleOptions.cs
@@ -13,8 +13,8 @@ namespace PowerPointLabs.PictureSlidesLab.ModelFactory.Options
     {
         public override List<StyleOption> GetOptionsForVariation()
         {
-            var result = GetOptionsWithSuitableFontColorForOutline();
-            foreach (var styleOption in result)
+            List<StyleOption> result = GetOptionsWithSuitableFontColorForOutline();
+            foreach (StyleOption styleOption in result)
             {
                 styleOption.IsUseTextGlow = true;
                 styleOption.TextGlowColor = "#000000";
@@ -39,7 +39,7 @@ namespace PowerPointLabs.PictureSlidesLab.ModelFactory.Options
 
         private List<StyleOption> GetOptionsWithSuitableFontColorForOutline()
         {
-            var result = GetOptions();
+            List<StyleOption> result = GetOptions();
             result[0].FontColor = "#FFFFFF"; //white
             result[1].FontColor = "#000000"; //black
             result[2].FontColor = "#FFD700"; //yellow

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/ModelFactory/Options/OverlayStyleOptions.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/ModelFactory/Options/OverlayStyleOptions.cs
@@ -13,8 +13,8 @@ namespace PowerPointLabs.PictureSlidesLab.ModelFactory.Options
     {
         public override List<StyleOption> GetOptionsForVariation()
         {
-            var result = GetOptionsWithSuitableFontColor();
-            foreach (var styleOption in result)
+            List<StyleOption> result = GetOptionsWithSuitableFontColor();
+            foreach (StyleOption styleOption in result)
             {
                 styleOption.OverlayTransparency = 35;
                 styleOption.FontFamily = "Trebuchet MS";

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/ModelFactory/Options/SpecialEffectStyleOptions.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/ModelFactory/Options/SpecialEffectStyleOptions.cs
@@ -13,8 +13,8 @@ namespace PowerPointLabs.PictureSlidesLab.ModelFactory.Options
     {
         public override List<StyleOption> GetOptionsForVariation()
         {
-            var result = GetOptions();
-            foreach (var styleOption in result)
+            List<StyleOption> result = GetOptions();
+            foreach (StyleOption styleOption in result)
             {
                 styleOption.IsUseTextGlow = true;
                 styleOption.TextGlowColor = "#000000";

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/ModelFactory/Options/TextBoxStyleOptions.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/ModelFactory/Options/TextBoxStyleOptions.cs
@@ -13,8 +13,8 @@ namespace PowerPointLabs.PictureSlidesLab.ModelFactory.Options
     {
         public override List<StyleOption> GetOptionsForVariation()
         {
-            var result = GetOptionsWithSuitableFontColor();
-            foreach (var option in result)
+            List<StyleOption> result = GetOptionsWithSuitableFontColor();
+            foreach (StyleOption option in result)
             {
                 option.TextBoxPosition = 7; //bottom-left;
                 option.FontFamily = "Calibri";

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/ModelFactory/Options/TriangleStyleOptions.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/ModelFactory/Options/TriangleStyleOptions.cs
@@ -13,8 +13,8 @@ namespace PowerPointLabs.PictureSlidesLab.ModelFactory.Options
     {
         public override List<StyleOption> GetOptionsForVariation()
         {
-            var result = GetOptionsWithSuitableFontColor();
-            foreach (var styleOption in result)
+            List<StyleOption> result = GetOptionsWithSuitableFontColor();
+            foreach (StyleOption styleOption in result)
             {
                 styleOption.IsUseTriangleStyle = true;
                 styleOption.TextBoxPosition = 4; // left

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/ModelFactory/StyleOptionsFactory.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/ModelFactory/StyleOptionsFactory.cs
@@ -24,9 +24,9 @@ namespace PowerPointLabs.PictureSlidesLab.ModelFactory
 
         public StyleOptionsFactory()
         {
-            var catalog = new AggregateCatalog(
+            AggregateCatalog catalog = new AggregateCatalog(
                 new AssemblyCatalog(Assembly.GetExecutingAssembly()));
-            var container = new CompositionContainer(catalog);
+            CompositionContainer container = new CompositionContainer(catalog);
             container.ComposeParts(this);
         }
 
@@ -36,8 +36,8 @@ namespace PowerPointLabs.PictureSlidesLab.ModelFactory
         /// <returns></returns>
         public List<List<StyleOption>> GetAllStylesVariationOptions()
         {
-            var options = new List<List<StyleOption>>();
-            foreach (var styleOptions in GetAllStyleOptions())
+            List<List<StyleOption>> options = new List<List<StyleOption>>();
+            foreach (IStyleOptions styleOptions in GetAllStyleOptions())
             {
                 options.Add(styleOptions.GetOptionsForVariation());
             }
@@ -50,8 +50,8 @@ namespace PowerPointLabs.PictureSlidesLab.ModelFactory
         /// <returns></returns>
         public List<StyleOption> GetAllStylesPreviewOptions()
         {
-            var options = new List<StyleOption>();
-            foreach (var styleOptions in GetAllStyleOptions())
+            List<StyleOption> options = new List<StyleOption>();
+            foreach (IStyleOptions styleOptions in GetAllStyleOptions())
             {
                 options.Add(styleOptions.GetDefaultOptionForPreview());
             }
@@ -60,8 +60,8 @@ namespace PowerPointLabs.PictureSlidesLab.ModelFactory
 
         public StyleOption GetStylesPreviewOption(string targetStyle)
         {
-            var options = GetAllStylesPreviewOptions();
-            foreach (var option in options)
+            List<StyleOption> options = GetAllStylesPreviewOptions();
+            foreach (StyleOption option in options)
             {
                 if (option.StyleName == targetStyle)
                 {
@@ -73,8 +73,8 @@ namespace PowerPointLabs.PictureSlidesLab.ModelFactory
 
         public List<StyleOption> GetStylesVariationOptions(string targetStyle)
         {
-            var allStylesVariationOptions = GetAllStylesVariationOptions();
-            foreach (var stylesVariationOptions in allStylesVariationOptions)
+            List<List<StyleOption>> allStylesVariationOptions = GetAllStylesVariationOptions();
+            foreach (List<StyleOption> stylesVariationOptions in allStylesVariationOptions)
             {
                 if (stylesVariationOptions[0].StyleName == targetStyle)
                 {

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/ModelFactory/StyleVariantsFactory.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/ModelFactory/StyleVariantsFactory.cs
@@ -25,15 +25,15 @@ namespace PowerPointLabs.PictureSlidesLab.ModelFactory
 
         public StyleVariantsFactory()
         {
-            var catalog = new AggregateCatalog(
+            AggregateCatalog catalog = new AggregateCatalog(
                 new AssemblyCatalog(Assembly.GetExecutingAssembly()));
-            var container = new CompositionContainer(catalog);
+            CompositionContainer container = new CompositionContainer(catalog);
             container.ComposeParts(this);
         }
 
         public Dictionary<string, List<StyleVariant>> GetVariants(string targetStyle)
         {
-            foreach (var styleVariants in GetAllStyleVariants())
+            foreach (IStyleVariants styleVariants in GetAllStyleVariants())
             {
                 if (styleVariants.GetStyleName() == targetStyle)
                 {

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/ModelFactory/Variants/BaseStyleVariants.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/ModelFactory/Variants/BaseStyleVariants.cs
@@ -17,11 +17,11 @@ namespace PowerPointLabs.PictureSlidesLab.ModelFactory.Variants
 
         public Dictionary<string, List<StyleVariant>> GetVariantsForStyle()
         {
-            var workers = GetRequiredVariantWorkers();
-            var orderedGeneralVariantWorkers = ImportedGeneralVariantWorkers
+            IList<IVariantWorker> workers = GetRequiredVariantWorkers();
+            IEnumerable<IVariantWorker> orderedGeneralVariantWorkers = ImportedGeneralVariantWorkers
                 .OrderBy(worker => worker.Metadata.GeneralVariantWorkerOrder)
                 .Select(worker => worker.Value);
-            foreach (var importedGeneralVariantWorker in orderedGeneralVariantWorkers)
+            foreach (IVariantWorker importedGeneralVariantWorker in orderedGeneralVariantWorkers)
             {
                 workers.Add(importedGeneralVariantWorker);
             }

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/Effect/TextBoxes.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/Effect/TextBoxes.cs
@@ -37,7 +37,7 @@ namespace PowerPointLabs.PictureSlidesLab.Service.Effect
             _slideWidth = slideWidth;
             _slideHeight = slideHeight;
             TextShapes = new List<Shape>();
-            var shape = ShapeUtil.GetTextShapeToProcess(shapes);
+            Shape shape = ShapeUtil.GetTextShapeToProcess(shapes);
             if (shape != null)
             {
                 TextShapes.Add(shape);
@@ -83,7 +83,7 @@ namespace PowerPointLabs.PictureSlidesLab.Service.Effect
 
         public void StartTextWrapping()
         {
-            foreach (var textShape in TextShapes)
+            foreach (Shape textShape in TextShapes)
             {
                 if (textShape.Width > _slideWidth / 2)
                 {
@@ -96,7 +96,7 @@ namespace PowerPointLabs.PictureSlidesLab.Service.Effect
 
         public void RecoverTextWrapping()
         {
-            foreach (var textShape in TextShapes)
+            foreach (Shape textShape in TextShapes)
             {
                 if (StringUtil.IsNotEmpty(textShape.Tags[Tag.OriginalShapeWidth]))
                 {
@@ -126,13 +126,13 @@ namespace PowerPointLabs.PictureSlidesLab.Service.Effect
 
             SetupTextBoxesAlignment();
 
-            var boxesInfo = GetTextBoxesInfo(TextShapes);
+            TextBoxInfo boxesInfo = GetTextBoxesInfo(TextShapes);
             SetupTextBoxesPosition(boxesInfo);
 
-            var accumulatedHeight = 0f;
-            foreach (var textShape in TextShapes)
+            float accumulatedHeight = 0f;
+            foreach (Shape textShape in TextShapes)
             {
-                var singleBoxInfo = GetTextBoxInfo(textShape);
+                TextBoxInfo singleBoxInfo = GetTextBoxInfo(textShape);
 
                 AdjustShapeLeft(textShape, boxesInfo, singleBoxInfo);
                 AdjustShapeTop(textShape, singleBoxInfo, accumulatedHeight);
@@ -213,7 +213,7 @@ namespace PowerPointLabs.PictureSlidesLab.Service.Effect
 
         private void SetTextAlignment(MsoTextEffectAlignment alignment)
         {
-            foreach (var shape in TextShapes)
+            foreach (Shape shape in TextShapes)
             {
                 shape.TextEffect.Alignment = alignment;
             }
@@ -261,13 +261,13 @@ namespace PowerPointLabs.PictureSlidesLab.Service.Effect
 
         private TextBoxInfo GetTextBoxInfo(Shape textShape)
         {
-            var result = new TextBoxInfo();
-            var paragraphs = textShape.TextFrame2.TextRange.Paragraphs;
-            var rightMost = 0f;
-            var bottomMost = 0f;
+            TextBoxInfo result = new TextBoxInfo();
+            TextRange2 paragraphs = textShape.TextFrame2.TextRange.Paragraphs;
+            float rightMost = 0f;
+            float bottomMost = 0f;
             foreach (TextRange2 textRange in paragraphs)
             {
-                var paragraph = textRange.TrimText();
+                TextRange2 paragraph = textRange.TrimText();
                 if (StringUtil.IsNotEmpty(paragraph.Text))
                 {
                     result.Left = paragraph.BoundLeft < result.Left ? paragraph.BoundLeft : result.Left;
@@ -288,10 +288,10 @@ namespace PowerPointLabs.PictureSlidesLab.Service.Effect
 
         private TextBoxInfo GetTextBoxesInfo(IEnumerable<Shape> textShapes)
         {
-            var result = new TextBoxInfo();
-            var rightMost = 0f;
-            var bottomMost = 0f;
-            foreach (var partialResult in textShapes.Select(GetTextBoxInfo))
+            TextBoxInfo result = new TextBoxInfo();
+            float rightMost = 0f;
+            float bottomMost = 0f;
+            foreach (TextBoxInfo partialResult in textShapes.Select(GetTextBoxInfo))
             {
                 result.Left = partialResult.Left < result.Left ? partialResult.Left : result.Left;
                 result.Top = partialResult.Top < result.Top ? partialResult.Top : result.Top;

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/EffectsDesigner.Partial/EffectsDesigner.AlbumFrame.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/EffectsDesigner.Partial/EffectsDesigner.AlbumFrame.cs
@@ -9,10 +9,10 @@ namespace PowerPointLabs.PictureSlidesLab.Service
     {
         public PowerPoint.Shape ApplyAlbumFrameEffect(string overlayColor, int transparency)
         {
-            var halfFrameWidth = 15;
-            var width = SlideWidth - halfFrameWidth * 2;
-            var height = SlideHeight - halfFrameWidth * 2;
-            var frameShape = Shapes.AddShape(MsoAutoShapeType.msoShapeRectangle, halfFrameWidth, halfFrameWidth,
+            int halfFrameWidth = 15;
+            float width = SlideWidth - halfFrameWidth * 2;
+            float height = SlideHeight - halfFrameWidth * 2;
+            PowerPoint.Shape frameShape = Shapes.AddShape(MsoAutoShapeType.msoShapeRectangle, halfFrameWidth, halfFrameWidth,
                 width, height);
             ChangeName(frameShape, EffectName.Overlay);
             frameShape.Fill.Transparency = 1f;

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/EffectsDesigner.Partial/EffectsDesigner.Background.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/EffectsDesigner.Partial/EffectsDesigner.Background.cs
@@ -8,10 +8,10 @@ namespace PowerPointLabs.PictureSlidesLab.Service
     {
         public PowerPoint.Shape ApplyBackgroundEffect()
         {
-            var imageShape = AddPicture(Source.FullSizeImageFile ?? Source.ImageFile, EffectName.BackGround);
+            PowerPoint.Shape imageShape = AddPicture(Source.FullSizeImageFile ?? Source.ImageFile, EffectName.BackGround);
             imageShape.ZOrder(MsoZOrderCmd.msoSendToBack);
-            var slideWidth = SlideWidth;
-            var slideHeight = SlideHeight;
+            float slideWidth = SlideWidth;
+            float slideHeight = SlideHeight;
             FitToSlide.AutoFit(imageShape, slideWidth, slideHeight);
 
             CropPicture(imageShape);

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/EffectsDesigner.Partial/EffectsDesigner.Blur.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/EffectsDesigner.Partial/EffectsDesigner.Blur.cs
@@ -16,9 +16,9 @@ namespace PowerPointLabs.PictureSlidesLab.Service
             Source.BlurImageFile = BlurImage(imageFileToBlur
                 ?? Source.FullSizeImageFile
                 ?? Source.ImageFile, degree);
-            var blurImageShape = AddPicture(Source.BlurImageFile, EffectName.Blur);
-            var slideWidth = SlideWidth;
-            var slideHeight = SlideHeight;
+            PowerPoint.Shape blurImageShape = AddPicture(Source.BlurImageFile, EffectName.Blur);
+            float slideWidth = SlideWidth;
+            float slideHeight = SlideHeight;
             FitToSlide.AutoFit(blurImageShape, slideWidth, slideHeight);
             CropPicture(blurImageShape);
             return blurImageShape;
@@ -31,16 +31,16 @@ namespace PowerPointLabs.PictureSlidesLab.Service
                 return imageFilePath;
             }
 
-            var resizeImageFile = Util.TempPath.GetPath("fullsize_resize");
-            using (var imageFactory = new ImageFactory())
+            string resizeImageFile = Util.TempPath.GetPath("fullsize_resize");
+            using (ImageFactory imageFactory = new ImageFactory())
             {
-                var image = imageFactory
+                Image image = imageFactory
                     .Load(imageFilePath)
                     .Image;
 
-                var ratio = (float)image.Width / image.Height;
-                var targetHeight = Math.Round(MaxThumbnailHeight - (MaxThumbnailHeight - MinThumbnailHeight) / 100f * degree);
-                var targetWidth = Math.Round(targetHeight * ratio);
+                float ratio = (float)image.Width / image.Height;
+                double targetHeight = Math.Round(MaxThumbnailHeight - (MaxThumbnailHeight - MinThumbnailHeight) / 100f * degree);
+                double targetWidth = Math.Round(targetHeight * ratio);
 
                 image = imageFactory
                     .Resize(new Size((int)targetWidth, (int)targetHeight))
@@ -48,10 +48,10 @@ namespace PowerPointLabs.PictureSlidesLab.Service
                 image.Save(resizeImageFile);
             }
 
-            var blurImageFile = Util.TempPath.GetPath("fullsize_blur");
-            using (var imageFactory = new ImageFactory())
+            string blurImageFile = Util.TempPath.GetPath("fullsize_blur");
+            using (ImageFactory imageFactory = new ImageFactory())
             {
-                var image = imageFactory
+                Image image = imageFactory
                     .Load(resizeImageFile)
                     .GaussianBlur(5)
                     .Image;

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/EffectsDesigner.Partial/EffectsDesigner.CircleBanner.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/EffectsDesigner.Partial/EffectsDesigner.CircleBanner.cs
@@ -10,8 +10,8 @@ namespace PowerPointLabs.PictureSlidesLab.Service
     {
         public PowerPoint.Shape ApplyCircleRingsEffect(string color, int transparency)
         {
-            var innerCircleShape = ApplyCircleBannerEffect(color, transparency);
-            var outerCircleShape = ApplyCircleBannerEffect(color, transparency, isOutline: true, margin: 10);
+            PowerPoint.Shape innerCircleShape = ApplyCircleBannerEffect(color, transparency);
+            PowerPoint.Shape outerCircleShape = ApplyCircleBannerEffect(color, transparency, isOutline: true, margin: 10);
             if (innerCircleShape == null || outerCircleShape == null)
             {
                 return null;
@@ -22,7 +22,7 @@ namespace PowerPointLabs.PictureSlidesLab.Service
             CropPicture(innerCircleShape);
             CropPicture(outerCircleShape);
 
-            var result = Shapes.Range(new[] { innerCircleShape.Name, outerCircleShape.Name }).Group();
+            PowerPoint.Shape result = Shapes.Range(new[] { innerCircleShape.Name, outerCircleShape.Name }).Group();
             ChangeName(result, EffectName.Overlay);
             return result;
         }
@@ -30,7 +30,7 @@ namespace PowerPointLabs.PictureSlidesLab.Service
         private PowerPoint.Shape ApplyCircleBannerEffect(string overlayColor, int transparency,
             bool isOutline = false, int margin = 0)
         {
-            var tbInfo =
+            TextBoxInfo tbInfo =
                 new TextBoxes(Shapes.Range(), SlideWidth, SlideHeight)
                 .GetTextBoxesInfo();
             if (tbInfo == null)
@@ -40,7 +40,7 @@ namespace PowerPointLabs.PictureSlidesLab.Service
 
             TextBoxes.AddMargin(tbInfo, margin);
 
-            var overlayShape = ApplyCircleOverlayEffect(overlayColor, transparency, tbInfo.Left, tbInfo.Top, tbInfo.Width,
+            PowerPoint.Shape overlayShape = ApplyCircleOverlayEffect(overlayColor, transparency, tbInfo.Left, tbInfo.Top, tbInfo.Width,
                 tbInfo.Height, isOutline);
             ChangeName(overlayShape, EffectName.Banner);
             return overlayShape;
@@ -49,12 +49,12 @@ namespace PowerPointLabs.PictureSlidesLab.Service
         private PowerPoint.Shape ApplyCircleOverlayEffect(string color, int transparency,
             float left, float top, float width, float height, bool isOutline)
         {
-            var radius = (float)Math.Sqrt(width * width / 4 + height * height / 4);
-            var circleLeft = left - radius + width / 2;
-            var circleTop = top - radius + height / 2;
-            var circleWidth = radius * 2;
+            float radius = (float)Math.Sqrt(width * width / 4 + height * height / 4);
+            float circleLeft = left - radius + width / 2;
+            float circleTop = top - radius + height / 2;
+            float circleWidth = radius * 2;
 
-            var overlayShape = Shapes.AddShape(MsoAutoShapeType.msoShapeOval, circleLeft, circleTop,
+            PowerPoint.Shape overlayShape = Shapes.AddShape(MsoAutoShapeType.msoShapeOval, circleLeft, circleTop,
                 circleWidth, circleWidth);
             overlayShape.Fill.Solid();
             overlayShape.Fill.ForeColor.RGB = GraphicsUtil.ConvertColorToRgb(StringUtil.GetColorFromHexValue(color));

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/EffectsDesigner.Partial/EffectsDesigner.Common.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/EffectsDesigner.Partial/EffectsDesigner.Common.cs
@@ -13,7 +13,7 @@ namespace PowerPointLabs.PictureSlidesLab.Service
 
         private PowerPoint.Shape AddPicture(string imageFile, EffectName effectName)
         {
-            var imageShape = Shapes.AddPicture(imageFile,
+            PowerPoint.Shape imageShape = Shapes.AddPicture(imageFile,
                 MsoTriState.msoFalse, MsoTriState.msoTrue, 0,
                 0);
             ChangeName(imageShape, effectName);

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/EffectsDesigner.Partial/EffectsDesigner.EmbedStyleOption.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/EffectsDesigner.Partial/EffectsDesigner.EmbedStyleOption.cs
@@ -33,17 +33,17 @@ namespace PowerPointLabs.PictureSlidesLab.Service
                 return new List<PowerPoint.Shape>();
             }
 
-            var originalImage = AddPicture(originalImageFile, EffectName.Original_DO_NOT_REMOVE);
-            var slideWidth = SlideWidth;
-            var slideHeight = SlideHeight;
+            PowerPoint.Shape originalImage = AddPicture(originalImageFile, EffectName.Original_DO_NOT_REMOVE);
+            float slideWidth = SlideWidth;
+            float slideHeight = SlideHeight;
             FitToSlide.AutoFit(originalImage, slideWidth, slideHeight);
             originalImage.Visible = MsoTriState.msoFalse;
 
-            var croppedImage = AddPicture(croppedImageFile, EffectName.Cropped_DO_NOT_REMOVE);
+            PowerPoint.Shape croppedImage = AddPicture(croppedImageFile, EffectName.Cropped_DO_NOT_REMOVE);
             FitToSlide.AutoFit(croppedImage, slideWidth, slideHeight);
             croppedImage.Visible = MsoTriState.msoFalse;
 
-            var result = new List<PowerPoint.Shape>();
+            List<PowerPoint.Shape> result = new List<PowerPoint.Shape>();
             result.Add(originalImage);
             result.Add(croppedImage);
 
@@ -58,9 +58,9 @@ namespace PowerPointLabs.PictureSlidesLab.Service
             AddTag(originalImage, Tag.ReloadRectHeight, rect.Height.ToString(CultureInfo.InvariantCulture));
 
             // store style info
-            var type = opt.GetType();
-            var props = type.GetProperties();
-            foreach (var propertyInfo in props)
+            Type type = opt.GetType();
+            System.Reflection.PropertyInfo[] props = type.GetProperties();
+            foreach (System.Reflection.PropertyInfo propertyInfo in props)
             {
                 try
                 {

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/EffectsDesigner.Partial/EffectsDesigner.FrostedGlass.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/EffectsDesigner.Partial/EffectsDesigner.FrostedGlass.cs
@@ -10,31 +10,31 @@ namespace PowerPointLabs.PictureSlidesLab.Service
     {
         public void ApplyFrostedGlassTextBoxEffect(string overlayColor, int transparency, Shape blurImage, int fontSizeToIncrease)
         {
-            var shape = Util.ShapeUtil.GetTextShapeToProcess(Shapes);
+            Shape shape = Util.ShapeUtil.GetTextShapeToProcess(Shapes);
             if (shape == null)
             {
                 return;
             }
 
-            var margin = CalculateTextBoxMargin(fontSizeToIncrease);
+            int margin = CalculateTextBoxMargin(fontSizeToIncrease);
             // multiple paragraphs.. 
             foreach (TextRange2 textRange in shape.TextFrame2.TextRange.Paragraphs)
             {
                 if (StringUtil.IsNotEmpty(textRange.TrimText().Text))
                 {
-                    var paragraph = textRange.TrimText();
-                    var left = paragraph.BoundLeft - margin;
-                    var top = paragraph.BoundTop - margin;
-                    var width = paragraph.BoundWidth + margin * 2;
-                    var height = paragraph.BoundHeight + margin * 2;
+                    TextRange2 paragraph = textRange.TrimText();
+                    float left = paragraph.BoundLeft - margin;
+                    float top = paragraph.BoundTop - margin;
+                    float width = paragraph.BoundWidth + margin * 2;
+                    float height = paragraph.BoundHeight + margin * 2;
 
-                    var blurTextBox = blurImage.Duplicate()[1];
+                    Shape blurTextBox = blurImage.Duplicate()[1];
                     blurTextBox.Left = blurImage.Left;
                     blurTextBox.Top = blurImage.Top;
                     CropPicture(blurTextBox, left, top, width, height);
                     ChangeName(blurTextBox, EffectName.TextBox);
 
-                    var overlayShape = ApplyOverlayEffect(overlayColor, transparency,
+                    Shape overlayShape = ApplyOverlayEffect(overlayColor, transparency,
                         left, top, width, height);
                     ChangeName(overlayShape, EffectName.TextBox);
 
@@ -47,7 +47,7 @@ namespace PowerPointLabs.PictureSlidesLab.Service
         public Shape ApplyFrostedGlassBannerEffect(BannerDirection direction, Position textPos, Shape blurImage,
             string overlayColor, int transparency)
         {
-            var tbInfo =
+            TextBoxInfo tbInfo =
                 new TextBoxes(Shapes.Range(), SlideWidth, SlideHeight)
                 .GetTextBoxesInfo();
             if (tbInfo == null)
@@ -58,7 +58,7 @@ namespace PowerPointLabs.PictureSlidesLab.Service
             TextBoxes.AddMargin(tbInfo);
 
             Shape overlayShape;
-            var blurBanner = blurImage.Duplicate()[1];
+            Shape blurBanner = blurImage.Duplicate()[1];
             blurBanner.Left = blurImage.Left;
             blurBanner.Top = blurImage.Top;
             direction = HandleAutoDirection(direction, textPos);
@@ -81,8 +81,8 @@ namespace PowerPointLabs.PictureSlidesLab.Service
             overlayShape.ZOrder(MsoZOrderCmd.msoSendToBack);
             Utils.ShapeUtil.MoveZToJustBehind(blurBanner, overlayShape);
 
-            var range = Shapes.Range(new[] {blurBanner.Name, overlayShape.Name});
-            var resultShape = range.Group();
+            Microsoft.Office.Interop.PowerPoint.ShapeRange range = Shapes.Range(new[] {blurBanner.Name, overlayShape.Name});
+            Shape resultShape = range.Group();
             ChangeName(resultShape, EffectName.Banner);
             return resultShape;
         }

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/EffectsDesigner.Partial/EffectsDesigner.Outline.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/EffectsDesigner.Partial/EffectsDesigner.Outline.cs
@@ -8,7 +8,7 @@ namespace PowerPointLabs.PictureSlidesLab.Service
     {
         public PowerPoint.Shape ApplyRectOutlineEffect(PowerPoint.Shape imageShape, string overlayColor, int transparency)
         {
-            var tbInfo =
+            TextBoxInfo tbInfo =
                 new TextBoxes(Shapes.Range(), SlideWidth, SlideHeight)
                 .GetTextBoxesInfo();
             if (tbInfo == null)
@@ -18,7 +18,7 @@ namespace PowerPointLabs.PictureSlidesLab.Service
 
             TextBoxes.AddMargin(tbInfo, 10);
 
-            var overlayShape = ApplyOverlayEffect(overlayColor, transparency, tbInfo.Left, tbInfo.Top, tbInfo.Width,
+            PowerPoint.Shape overlayShape = ApplyOverlayEffect(overlayColor, transparency, tbInfo.Left, tbInfo.Top, tbInfo.Width,
                 tbInfo.Height);
             overlayShape.Fill.Visible = MsoTriState.msoFalse;
             overlayShape.Line.Visible = MsoTriState.msoTrue;

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/EffectsDesigner.Partial/EffectsDesigner.Overlay.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/EffectsDesigner.Partial/EffectsDesigner.Overlay.cs
@@ -13,7 +13,7 @@ namespace PowerPointLabs.PictureSlidesLab.Service
         {
             width = width ?? SlideWidth;
             height = height ?? SlideHeight;
-            var overlayShape = Shapes.AddShape(MsoAutoShapeType.msoShapeRectangle, left, top,
+            PowerPoint.Shape overlayShape = Shapes.AddShape(MsoAutoShapeType.msoShapeRectangle, left, top,
                 width.Value, height.Value);
             ChangeName(overlayShape, EffectName.Overlay);
             overlayShape.Fill.Solid();

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/EffectsDesigner.Partial/EffectsDesigner.PictureCitation.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/EffectsDesigner.Partial/EffectsDesigner.PictureCitation.cs
@@ -25,7 +25,7 @@ namespace PowerPointLabs.PictureSlidesLab.Service
         public void ApplyImageReferenceInsertion(string source, string fontFamily, string fontColor,
             int fontSize, string textBoxColor, Alignment citationTextAlignment)
         {
-            var imageRefShape = Shapes.AddTextbox(MsoTextOrientation.msoTextOrientationHorizontal, 0, 0, SlideWidth,
+            Microsoft.Office.Interop.PowerPoint.Shape imageRefShape = Shapes.AddTextbox(MsoTextOrientation.msoTextOrientationHorizontal, 0, 0, SlideWidth,
                 20);
             imageRefShape.TextFrame2.TextRange.Text = "Picture taken from: " + source;
 

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/EffectsDesigner.Partial/EffectsDesigner.RectangleBanner.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/EffectsDesigner.Partial/EffectsDesigner.RectangleBanner.cs
@@ -9,7 +9,7 @@ namespace PowerPointLabs.PictureSlidesLab.Service
         public PowerPoint.Shape ApplyRectBannerEffect(BannerDirection direction, Position textPos, PowerPoint.Shape imageShape,
             string overlayColor, int transparency)
         {
-            var tbInfo =
+            TextBoxInfo tbInfo =
                 new TextBoxes(Shapes.Range(), SlideWidth, SlideHeight)
                 .GetTextBoxesInfo();
             if (tbInfo == null)

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/EffectsDesigner.Partial/EffectsDesigner.SpecialEffects.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/EffectsDesigner.Partial/EffectsDesigner.SpecialEffects.cs
@@ -11,9 +11,9 @@ namespace PowerPointLabs.PictureSlidesLab.Service
         public PowerPoint.Shape ApplySpecialEffectEffect(IMatrixFilter effectFilter, bool isActualSize)
         {
             Source.SpecialEffectImageFile = SpecialEffectImage(effectFilter, Source.FullSizeImageFile ?? Source.ImageFile, isActualSize);
-            var specialEffectImageShape = AddPicture(Source.SpecialEffectImageFile, EffectName.SpecialEffect);
-            var slideWidth = SlideWidth;
-            var slideHeight = SlideHeight;
+            PowerPoint.Shape specialEffectImageShape = AddPicture(Source.SpecialEffectImageFile, EffectName.SpecialEffect);
+            float slideWidth = SlideWidth;
+            float slideHeight = SlideHeight;
             FitToSlide.AutoFit(specialEffectImageShape, slideWidth, slideHeight);
             CropPicture(specialEffectImageShape);
             return specialEffectImageShape;
@@ -22,13 +22,13 @@ namespace PowerPointLabs.PictureSlidesLab.Service
         private static string SpecialEffectImage(IMatrixFilter effectFilter, string imageFilePath,
             bool isActualSize)
         {
-            var specialEffectImageFile = Util.TempPath.GetPath("fullsize_specialeffect");
-            using (var imageFactory = new ImageFactory())
+            string specialEffectImageFile = Util.TempPath.GetPath("fullsize_specialeffect");
+            using (ImageFactory imageFactory = new ImageFactory())
             {
-                var image = imageFactory
+                Image image = imageFactory
                         .Load(imageFilePath)
                         .Image;
-                var ratio = (float)image.Width / image.Height;
+                float ratio = (float)image.Width / image.Height;
                 if (isActualSize)
                 {
                     image = imageFactory

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/EffectsDesigner.Partial/EffectsDesigner.Text.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/EffectsDesigner.Partial/EffectsDesigner.Text.cs
@@ -17,7 +17,7 @@ namespace PowerPointLabs.PictureSlidesLab.Service
         // apply text formats to textbox & placeholer
         public void ApplyTextEffect(string fontFamily, string fontColor, int fontSizeToIncrease, int fontTransparency)
         {
-            var shape = ShapeUtil.GetTextShapeToProcess(Shapes);
+            PowerPoint.Shape shape = ShapeUtil.GetTextShapeToProcess(Shapes);
             if (shape == null)
             {
                 return;
@@ -29,7 +29,7 @@ namespace PowerPointLabs.PictureSlidesLab.Service
             shape.Fill.Visible = MsoTriState.msoFalse;
             shape.Line.Visible = MsoTriState.msoFalse;
 
-            var font = shape.TextFrame2.TextRange.TrimText().Font;
+            Font2 font = shape.TextFrame2.TextRange.TrimText().Font;
 
             if (!string.IsNullOrEmpty(fontColor))
             {
@@ -60,7 +60,7 @@ namespace PowerPointLabs.PictureSlidesLab.Service
 
         public void ApplyTextGlowEffect(bool isUseTextGlow, string textGlowColor)
         {
-            var shape = ShapeUtil.GetTextShapeToProcess(Shapes);
+            PowerPoint.Shape shape = ShapeUtil.GetTextShapeToProcess(Shapes);
             if (shape == null)
             {
                 return;
@@ -92,7 +92,7 @@ namespace PowerPointLabs.PictureSlidesLab.Service
 
         public void ApplyPseudoTextWhenNoTextShapes()
         {
-            var isTextShapesEmpty = new TextBoxes(
+            bool isTextShapesEmpty = new TextBoxes(
                 Shapes.Range(), SlideWidth, SlideHeight)
                 .IsTextShapesEmpty();
 

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/EffectsDesigner.Partial/EffectsDesigner.TextBox.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/EffectsDesigner.Partial/EffectsDesigner.TextBox.cs
@@ -9,25 +9,25 @@ namespace PowerPointLabs.PictureSlidesLab.Service
     {
         public void ApplyTextboxEffect(string overlayColor, int transparency, int fontSizeToIncrease)
         {
-            var shape = Util.ShapeUtil.GetTextShapeToProcess(Shapes);
+            Microsoft.Office.Interop.PowerPoint.Shape shape = Util.ShapeUtil.GetTextShapeToProcess(Shapes);
             if (shape == null)
             {
                 return;
             }
 
-            var margin = CalculateTextBoxMargin(fontSizeToIncrease);
+            int margin = CalculateTextBoxMargin(fontSizeToIncrease);
             // multiple paragraphs.. 
             foreach (TextRange2 textRange in shape.TextFrame2.TextRange.Paragraphs)
             {
                 if (StringUtil.IsNotEmpty(textRange.TrimText().Text))
                 {
-                    var paragraph = textRange.TrimText();
-                    var left = paragraph.BoundLeft - margin;
-                    var top = paragraph.BoundTop - margin;
-                    var width = paragraph.BoundWidth + margin * 2;
-                    var height = paragraph.BoundHeight + margin * 2;
+                    TextRange2 paragraph = textRange.TrimText();
+                    float left = paragraph.BoundLeft - margin;
+                    float top = paragraph.BoundTop - margin;
+                    float width = paragraph.BoundWidth + margin * 2;
+                    float height = paragraph.BoundHeight + margin * 2;
 
-                    var overlayShape = ApplyOverlayEffect(overlayColor, transparency,
+                    Microsoft.Office.Interop.PowerPoint.Shape overlayShape = ApplyOverlayEffect(overlayColor, transparency,
                         left, top, width, height);
                     ChangeName(overlayShape, EffectName.TextBox);
                     Utils.ShapeUtil.MoveZToJustBehind(overlayShape, shape);

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/EffectsDesigner.Partial/EffectsDesigner.TriangleBanner.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/EffectsDesigner.Partial/EffectsDesigner.TriangleBanner.cs
@@ -9,12 +9,12 @@ namespace PowerPointLabs.PictureSlidesLab.Service
     {
         public PowerPoint.Shape ApplyTriangleEffect(string overlayColor1, string overlayColor2, int transparency)
         {
-            var width1 = SlideHeight;
-            var height1 = SlideWidth;
-            var centerLeft1 = SlideWidth / 2;
-            var centerTop1 = SlideHeight / 2;
+            float width1 = SlideHeight;
+            float height1 = SlideWidth;
+            float centerLeft1 = SlideWidth / 2;
+            float centerTop1 = SlideHeight / 2;
             // the bigger triangle
-            var triangle1 = Shapes.AddShape(MsoAutoShapeType.msoShapeIsoscelesTriangle,
+            PowerPoint.Shape triangle1 = Shapes.AddShape(MsoAutoShapeType.msoShapeIsoscelesTriangle,
                 centerLeft1 - centerTop1, centerLeft1 + centerTop1 - SlideWidth, width1, height1);
             triangle1.Rotation = 90;
             ChangeName(triangle1, EffectName.Overlay);
@@ -23,12 +23,12 @@ namespace PowerPointLabs.PictureSlidesLab.Service
             triangle1.Fill.Transparency = (float)transparency / 100;
             triangle1.Line.Visible = MsoTriState.msoFalse;
 
-            var width2 = SlideHeight / 2;
-            var height2 = SlideWidth / 2;
-            var centerLeft2 = SlideWidth / 4 * 3;
-            var centerTop2 = SlideHeight / 4 * 3;
+            float width2 = SlideHeight / 2;
+            float height2 = SlideWidth / 2;
+            float centerLeft2 = SlideWidth / 4 * 3;
+            float centerTop2 = SlideHeight / 4 * 3;
             // the smaller triangle
-            var triangle2 = Shapes.AddShape(MsoAutoShapeType.msoShapeIsoscelesTriangle,
+            PowerPoint.Shape triangle2 = Shapes.AddShape(MsoAutoShapeType.msoShapeIsoscelesTriangle,
                 centerLeft2 + centerTop2 - SlideHeight,
                 centerTop2 + SlideWidth / 2 - centerLeft2,
                 width2,
@@ -40,7 +40,7 @@ namespace PowerPointLabs.PictureSlidesLab.Service
             triangle2.Fill.Transparency = (float)transparency / 100;
             triangle2.Line.Visible = MsoTriState.msoFalse;
 
-            var result = Shapes.Range(new[] { triangle1.Name, triangle2.Name }).Group();
+            PowerPoint.Shape result = Shapes.Range(new[] { triangle1.Name, triangle2.Name }).Group();
             ChangeName(result, EffectName.Overlay);
             return result;
         }

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/EffectsDesigner.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/EffectsDesigner.cs
@@ -1,7 +1,10 @@
-﻿using PowerPointLabs.ActionFramework.Common.Log;
+﻿using Microsoft.Office.Interop.PowerPoint;
+
+using PowerPointLabs.ActionFramework.Common.Log;
 using PowerPointLabs.Models;
 using PowerPointLabs.PictureSlidesLab.Model;
 using PowerPointLabs.PictureSlidesLab.Util;
+
 using PowerPoint = Microsoft.Office.Interop.PowerPoint;
 
 namespace PowerPointLabs.PictureSlidesLab.Service
@@ -76,7 +79,7 @@ namespace PowerPointLabs.PictureSlidesLab.Service
             {
                 _slide.CustomLayout = contentSlide.CustomLayout;
                 // remove target textbox from the layout
-                var shape = ShapeUtil.GetTextShapeToProcess(Shapes);
+                Shape shape = ShapeUtil.GetTextShapeToProcess(Shapes);
                 if (shape != null)
                 {
                     shape.Delete();

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/PictureCitationSlide.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/PictureCitationSlide.cs
@@ -26,7 +26,7 @@ namespace PowerPointLabs.PictureSlidesLab.Service
 
         public void CreatePictureCitations()
         {
-            var citations = GenerateCitations();
+            string citations = GenerateCitations();
             foreach (Shape shape in Shapes)
             {
                 try
@@ -74,25 +74,25 @@ namespace PowerPointLabs.PictureSlidesLab.Service
         {
             try
             {
-                var strBuilder = new StringBuilder("");
-                var isAnyCitation = false;
-                var slideIndex = 1;
-                foreach (var slide in AllSlides)
+                StringBuilder strBuilder = new StringBuilder("");
+                bool isAnyCitation = false;
+                int slideIndex = 1;
+                foreach (PowerPointSlide slide in AllSlides)
                 {
-                    var originalShapeList = slide.GetShapesWithPrefix(
+                    List<Shape> originalShapeList = slide.GetShapesWithPrefix(
                         EffectsDesigner.ShapeNamePrefix + "_" + EffectName.Original_DO_NOT_REMOVE);
                     if (originalShapeList.Count == 0)
                     {
                         continue;
                     }
 
-                    var originalImageShape = originalShapeList[0];
-                    var source = originalImageShape.Tags[Tag.ReloadImgSource];
+                    Shape originalImageShape = originalShapeList[0];
+                    string source = originalImageShape.Tags[Tag.ReloadImgSource];
                     if (string.IsNullOrEmpty(source))
                     {
                         source = "somewhere";
                     }
-                    var citation = "Picture taken from " + source;
+                    string citation = "Picture taken from " + source;
                     strBuilder.Append("Slide" + slideIndex + ": " + citation + "\n");
                     isAnyCitation = true;
                     slideIndex++;

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/StylesDesigner.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/StylesDesigner.cs
@@ -49,9 +49,9 @@ namespace PowerPointLabs.PictureSlidesLab.Service
             // generate styles
             EffectsDesignerForPreview = CreateEffectsHandlerForPreview();
 
-            var catalog = new AggregateCatalog(
+            AggregateCatalog catalog = new AggregateCatalog(
                 new AssemblyCatalog(Assembly.GetExecutingAssembly()));
-            var container = new CompositionContainer(catalog);
+            CompositionContainer container = new CompositionContainer(catalog);
             container.ComposeParts(this);
         }
 
@@ -78,12 +78,12 @@ namespace PowerPointLabs.PictureSlidesLab.Service
             SlideWidth = slideWidth;
             SlideHeight = slideHeight;
 
-            var previewInfo = new PreviewInfo();
+            PreviewInfo previewInfo = new PreviewInfo();
             EffectsDesignerForPreview.PreparePreviewing(contentSlide, slideWidth, slideHeight, source);
 
             // use thumbnail to apply, in order to speed up
             source.BackupFullSizeImageFile = source.FullSizeImageFile;
-            var backupImageFile = source.ImageFile;
+            string backupImageFile = source.ImageFile;
             source.FullSizeImageFile = null;
             source.ImageFile = source.CroppedThumbnailImageFile ?? source.ImageFile;
 
@@ -110,7 +110,7 @@ namespace PowerPointLabs.PictureSlidesLab.Service
             source.BackupFullSizeImageFile = source.FullSizeImageFile;
             source.FullSizeImageFile = source.CroppedImageFile ?? source.FullSizeImageFile;
             
-            var effectsHandler = new EffectsDesigner(contentSlide, slideWidth, slideHeight, source);
+            EffectsDesigner effectsHandler = new EffectsDesigner(contentSlide, slideWidth, slideHeight, source);
 
             GenerateStyle(effectsHandler, source, isActualSize: true);
 
@@ -137,8 +137,8 @@ namespace PowerPointLabs.PictureSlidesLab.Service
                 imageShape = designer.ApplyBackgroundEffect();
             }
 
-            var resultShapes = new List<Shape>();
-            foreach (var styleWorker in WorkerFactory.StyleWorkers)
+            List<Shape> resultShapes = new List<Shape>();
+            foreach (StylesWorker.Interface.IStyleWorker styleWorker in WorkerFactory.StyleWorkers)
             {
                 resultShapes.AddRange(
                     styleWorker.Execute(Option, designer, source, imageShape, Settings));
@@ -162,7 +162,7 @@ namespace PowerPointLabs.PictureSlidesLab.Service
 
         private void SendToBack(params Shape[] shapes)
         {
-            foreach (var shape in shapes)
+            foreach (Shape shape in shapes)
             {
                 if (shape == null)
                 {
@@ -175,7 +175,7 @@ namespace PowerPointLabs.PictureSlidesLab.Service
 
         private EffectsDesigner CreateEffectsHandlerForPreview()
         {
-            var backgroundSlide = Presentation.Slides.Add(SlideCount + 1, PpSlideLayout.ppLayoutBlank);
+            Slide backgroundSlide = Presentation.Slides.Add(SlideCount + 1, PpSlideLayout.ppLayoutBlank);
             return new EffectsDesigner(backgroundSlide);
         }
         

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/StylesWorker/BannerStyleWorker.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/StylesWorker/BannerStyleWorker.cs
@@ -12,10 +12,10 @@ namespace PowerPointLabs.PictureSlidesLab.Service.StylesWorker
     {
         public IList<Shape> Execute(StyleOption option, EffectsDesigner designer, ImageItem source, Shape imageShape, Settings settings)
         {
-            var result = new List<Shape>();
+            List<Shape> result = new List<Shape>();
             if (option.IsUseBannerStyle)
             {
-                var bannerOverlayShape = ApplyBannerStyle(option, designer, imageShape);
+                Shape bannerOverlayShape = ApplyBannerStyle(option, designer, imageShape);
                 result.Add(bannerOverlayShape);
             }
             return result;

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/StylesWorker/BlurStyleWorker.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/StylesWorker/BlurStyleWorker.cs
@@ -12,10 +12,10 @@ namespace PowerPointLabs.PictureSlidesLab.Service.StylesWorker
     {
         public IList<Shape> Execute(StyleOption option, EffectsDesigner designer, ImageItem source, Shape imageShape, Settings settings)
         {
-            var result = new List<Shape>();
+            List<Shape> result = new List<Shape>();
             if (option.IsUseBlurStyle)
             {
-                var blurImageShape = option.IsUseSpecialEffectStyle
+                Shape blurImageShape = option.IsUseSpecialEffectStyle
                     ? designer.ApplyBlurEffect(source.SpecialEffectImageFile, option.BlurDegree)
                     : designer.ApplyBlurEffect(degree: option.BlurDegree);
                 result.Add(blurImageShape);

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/StylesWorker/CircleStyleWorker.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/StylesWorker/CircleStyleWorker.cs
@@ -12,10 +12,10 @@ namespace PowerPointLabs.PictureSlidesLab.Service.StylesWorker
     {
         public IList<Shape> Execute(StyleOption option, EffectsDesigner designer, ImageItem source, Shape imageShape, Settings settings)
         {
-            var result = new List<Shape>();
+            List<Shape> result = new List<Shape>();
             if (option.IsUseCircleStyle)
             {
-                var circleOverlayShape = designer.ApplyCircleRingsEffect(option.CircleColor, option.CircleTransparency);
+                Shape circleOverlayShape = designer.ApplyCircleRingsEffect(option.CircleColor, option.CircleTransparency);
                 result.Add(circleOverlayShape);
             }
             return result;

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/StylesWorker/FrameStyleWorker.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/StylesWorker/FrameStyleWorker.cs
@@ -12,10 +12,10 @@ namespace PowerPointLabs.PictureSlidesLab.Service.StylesWorker
     {
         public IList<Shape> Execute(StyleOption option, EffectsDesigner designer, ImageItem source, Shape imageShape, Settings settings)
         {
-            var result = new List<Shape>();
+            List<Shape> result = new List<Shape>();
             if (option.IsUseFrameStyle)
             {
-                var frameOverlayShape = designer.ApplyAlbumFrameEffect(option.FrameColor, option.FrameTransparency);
+                Shape frameOverlayShape = designer.ApplyAlbumFrameEffect(option.FrameColor, option.FrameTransparency);
                 result.Add(frameOverlayShape);
             }
             return result;

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/StylesWorker/FrostedGlassBannerStyleWorker.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/StylesWorker/FrostedGlassBannerStyleWorker.cs
@@ -12,14 +12,14 @@ namespace PowerPointLabs.PictureSlidesLab.Service.StylesWorker
     {
         public IList<Shape> Execute(StyleOption option, EffectsDesigner designer, ImageItem source, Shape imageShape, Settings settings)
         {
-            var result = new List<Shape>();
+            List<Shape> result = new List<Shape>();
             if (option.IsUseFrostedGlassBannerStyle)
             {
-                var blurDegreeForFrostedGlass = EffectsDesigner.BlurDegreeForFrostedGlassEffect;
-                var blurImageShape = option.IsUseSpecialEffectStyle
+                int blurDegreeForFrostedGlass = EffectsDesigner.BlurDegreeForFrostedGlassEffect;
+                Shape blurImageShape = option.IsUseSpecialEffectStyle
                     ? designer.ApplyBlurEffect(source.SpecialEffectImageFile, blurDegreeForFrostedGlass)
                     : designer.ApplyBlurEffect(degree: blurDegreeForFrostedGlass);
-                var banner = designer.ApplyFrostedGlassBannerEffect(option.GetBannerDirection(), option.GetTextBoxPosition(),
+                Shape banner = designer.ApplyFrostedGlassBannerEffect(option.GetBannerDirection(), option.GetTextBoxPosition(),
                     blurImageShape, option.FrostedGlassBannerColor, option.FrostedGlassBannerTransparency);
                 result.Add(banner);
                 blurImageShape.Delete();

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/StylesWorker/FrostedGlassTextBoxStyleWorker.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/StylesWorker/FrostedGlassTextBoxStyleWorker.cs
@@ -14,8 +14,8 @@ namespace PowerPointLabs.PictureSlidesLab.Service.StylesWorker
         {
             if (option.IsUseFrostedGlassTextBoxStyle)
             {
-                var blurDegreeForFrostedGlass = EffectsDesigner.BlurDegreeForFrostedGlassEffect;
-                var blurImageShape = option.IsUseSpecialEffectStyle
+                int blurDegreeForFrostedGlass = EffectsDesigner.BlurDegreeForFrostedGlassEffect;
+                Shape blurImageShape = option.IsUseSpecialEffectStyle
                     ? designer.ApplyBlurEffect(source.SpecialEffectImageFile, blurDegreeForFrostedGlass)
                     : designer.ApplyBlurEffect(degree: blurDegreeForFrostedGlass);
                 designer.ApplyFrostedGlassTextBoxEffect(option.FrostedGlassTextBoxColor, option.FrostedGlassTextBoxTransparency,

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/StylesWorker/OutlineStyleWorker.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/StylesWorker/OutlineStyleWorker.cs
@@ -12,10 +12,10 @@ namespace PowerPointLabs.PictureSlidesLab.Service.StylesWorker
     {
         public IList<Shape> Execute(StyleOption option, EffectsDesigner designer, ImageItem source, Shape imageShape, Settings settings)
         {
-            var result = new List<Shape>();
+            List<Shape> result = new List<Shape>();
             if (option.IsUseOutlineStyle)
             {
-                var outlineOverlayShape = designer.ApplyRectOutlineEffect(imageShape, option.OutlineColor, 0);
+                Shape outlineOverlayShape = designer.ApplyRectOutlineEffect(imageShape, option.OutlineColor, 0);
                 result.Add(outlineOverlayShape);
             }
             return result;

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/StylesWorker/OverlayStyleWorker.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/StylesWorker/OverlayStyleWorker.cs
@@ -12,10 +12,10 @@ namespace PowerPointLabs.PictureSlidesLab.Service.StylesWorker
     {
         public IList<Shape> Execute(StyleOption option, EffectsDesigner designer, ImageItem source, Shape imageShape, Settings settings)
         {
-            var result = new List<Shape>();
+            List<Shape> result = new List<Shape>();
             if (option.IsUseOverlayStyle)
             {
-                var backgroundOverlayShape = designer.ApplyOverlayEffect(option.OverlayColor, option.OverlayTransparency);
+                Shape backgroundOverlayShape = designer.ApplyOverlayEffect(option.OverlayColor, option.OverlayTransparency);
                 result.Add(backgroundOverlayShape);
             }
             return result;

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/StylesWorker/TriangleStyleWorker.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/StylesWorker/TriangleStyleWorker.cs
@@ -12,10 +12,10 @@ namespace PowerPointLabs.PictureSlidesLab.Service.StylesWorker
     {
         public IList<Shape> Execute(StyleOption option, EffectsDesigner designer, ImageItem source, Shape imageShape, Settings settings)
         {
-            var result = new List<Shape>();
+            List<Shape> result = new List<Shape>();
             if (option.IsUseTriangleStyle)
             {
-                var triangleOverlayShape = designer.ApplyTriangleEffect(option.TriangleColor, option.FontColor,
+                Shape triangleOverlayShape = designer.ApplyTriangleEffect(option.TriangleColor, option.FontColor,
                     option.TriangleTransparency);
                 result.Add(triangleOverlayShape);
             }

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Thread/ContextDownloader.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Thread/ContextDownloader.cs
@@ -57,7 +57,7 @@ namespace PowerPointLabs.PictureSlidesLab.Thread
 
         public void Start()
         {
-            var downloader = _downloader ?? new Downloader();
+            IDownloader downloader = _downloader ?? new Downloader();
             downloader
                 .Get(_downloadLink, _destination)
                 .After(_onAfterDownload)

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Util/ImageUtil.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Util/ImageUtil.cs
@@ -17,15 +17,15 @@ namespace PowerPointLabs.PictureSlidesLab.Util
                 return null;
             }
 
-            var thumbnailPath = StoragePath.GetPath("thumbnail-"
+            string thumbnailPath = StoragePath.GetPath("thumbnail-"
                 + DateTime.Now.GetHashCode() + "-"
                 + Guid.NewGuid().ToString().Substring(0, 7));
-            using (var imageFactory = new ImageFactory())
+            using (ImageFactory imageFactory = new ImageFactory())
             {
-                var image = imageFactory
+                Image image = imageFactory
                         .Load(filename)
                         .Image;
-                var ratio = (float) image.Width / image.Height;
+                float ratio = (float) image.Width / image.Height;
                 image = imageFactory
                         .Resize(new Size((int)(ThumbnailHeight * ratio), ThumbnailHeight))
                         .Image;
@@ -37,9 +37,9 @@ namespace PowerPointLabs.PictureSlidesLab.Util
         public static string GetWidthAndHeight(string filename)
         {
             string result;
-            using (var imageFactory = new ImageFactory())
+            using (ImageFactory imageFactory = new ImageFactory())
             {
-                var image = imageFactory
+                Image image = imageFactory
                         .Load(filename)
                         .Image;
                 result = image.Width + " x " + image.Height;

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Util/ListBoxUtil.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Util/ListBoxUtil.cs
@@ -8,16 +8,16 @@ namespace PowerPointLabs.PictureSlidesLab.Util
     {
         public static ScrollViewer FindScrollViewer(DependencyObject parent)
         {
-            var childCount = VisualTreeHelper.GetChildrenCount(parent);
-            for (var i = 0; i < childCount; i++)
+            int childCount = VisualTreeHelper.GetChildrenCount(parent);
+            for (int i = 0; i < childCount; i++)
             {
-                var elt = VisualTreeHelper.GetChild(parent, i);
+                DependencyObject elt = VisualTreeHelper.GetChild(parent, i);
                 if (elt is ScrollViewer)
                 {
                     return (ScrollViewer)elt;
                 }
 
-                var result = FindScrollViewer(elt);
+                ScrollViewer result = FindScrollViewer(elt);
                 if (result != null)
                 {
                     return result;

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Util/StoragePath.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Util/StoragePath.cs
@@ -80,9 +80,9 @@ namespace PowerPointLabs.PictureSlidesLab.Util
         {
             try
             {
-                using (var writer = new StreamWriter(GetPath(PictureSlidesLabImagesList)))
+                using (StreamWriter writer = new StreamWriter(GetPath(PictureSlidesLabImagesList)))
                 {
-                    var serializer = new XmlSerializer(list.GetType());
+                    XmlSerializer serializer = new XmlSerializer(list.GetType());
                     serializer.Serialize(writer, list);
                     writer.Flush();
                 }
@@ -101,9 +101,9 @@ namespace PowerPointLabs.PictureSlidesLab.Util
         {
             try
             {
-                using (var writer = new StreamWriter(GetPath(PictureSlidesLabSettings)))
+                using (StreamWriter writer = new StreamWriter(GetPath(PictureSlidesLabSettings)))
                 {
-                    var serializer = new XmlSerializer(settings.GetType());
+                    XmlSerializer serializer = new XmlSerializer(settings.GetType());
                     serializer.Serialize(writer, settings);
                     writer.Flush();
                 }
@@ -122,10 +122,10 @@ namespace PowerPointLabs.PictureSlidesLab.Util
         {
             try
             {
-                using (var stream = File.OpenRead(GetPath(PictureSlidesLabImagesList)))
+                using (FileStream stream = File.OpenRead(GetPath(PictureSlidesLabImagesList)))
                 {
-                    var serializer = new XmlSerializer(typeof(ObservableCollection<ImageItem>));
-                    var list = serializer.Deserialize(stream) as ObservableCollection<ImageItem> 
+                    XmlSerializer serializer = new XmlSerializer(typeof(ObservableCollection<ImageItem>));
+                    ObservableCollection<ImageItem> list = serializer.Deserialize(stream) as ObservableCollection<ImageItem> 
                         ?? new ObservableCollection<ImageItem>();
                     return list;
                 }
@@ -145,10 +145,10 @@ namespace PowerPointLabs.PictureSlidesLab.Util
         {
             try
             {
-                using (var stream = File.OpenRead(GetPath(PictureSlidesLabSettings)))
+                using (FileStream stream = File.OpenRead(GetPath(PictureSlidesLabSettings)))
                 {
-                    var serializer = new XmlSerializer(typeof(Model.Settings));
-                    var settings = serializer.Deserialize(stream) as Model.Settings
+                    XmlSerializer serializer = new XmlSerializer(typeof(Model.Settings));
+                    Model.Settings settings = serializer.Deserialize(stream) as Model.Settings
                         ?? new Model.Settings();
                     return settings;
                 }
@@ -176,7 +176,7 @@ namespace PowerPointLabs.PictureSlidesLab.Util
                 filesInUse.Add(NoPicturePlaceholderImgPath);
                 filesInUse.Add(SampleImg1Path);
                 filesInUse.Add(SampleImg2Path);
-                foreach (var file in directory.GetFiles())
+                foreach (FileInfo file in directory.GetFiles())
                 {
                     if (!filesInUse.Contains(file.FullName))
                     {

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Util/StyleVariationWidthConverter.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Util/StyleVariationWidthConverter.cs
@@ -8,13 +8,13 @@ namespace PowerPointLabs.PictureSlidesLab.Util
     {
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            var width = (double) value;
+            double width = (double) value;
             return width + 10;
         }
 
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            var actualWidth = (double) value;
+            double actualWidth = (double) value;
             return actualWidth - 10;
         }
     }

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Util/TempPath.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Util/TempPath.cs
@@ -26,7 +26,7 @@ namespace PowerPointLabs.PictureSlidesLab.Util
             {
                 throw new Exception("TempPath is not initialized!");
             }
-            var fullsizeImageFile = TempFolder + name + "_"
+            string fullsizeImageFile = TempFolder + name + "_"
                                     + Guid.NewGuid().ToString().Substring(0, 6)
                                     + DateTime.Now.GetHashCode();
             return fullsizeImageFile;

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Util/TwoColumnsListBoxImageWidthConverter.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Util/TwoColumnsListBoxImageWidthConverter.cs
@@ -12,14 +12,14 @@ namespace PowerPointLabs.PictureSlidesLab.Util
         public object Convert(object value, Type targetType,
             object parameter, CultureInfo culture)
         {
-            var originalValue = (double) value;
+            double originalValue = (double) value;
             return originalValue / 2 - ImageMargin - ScrollBarMargin;
         }
 
         public object ConvertBack(object value, Type targetType,
             object parameter, CultureInfo culture)
         {
-            var valueAftConverted = (double) value;
+            double valueAftConverted = (double) value;
             return (valueAftConverted + ImageMargin + ScrollBarMargin) * 2;
         }
     }

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Util/UrlUtil.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Util/UrlUtil.cs
@@ -28,8 +28,8 @@ namespace PowerPointLabs.PictureSlidesLab.Util
         {
             if (IsValidGoogleImageLink(url))
             {
-                var googleImageUri = new Uri(url);
-                var parameters = HttpUtility.ParseQueryString(googleImageUri.Query);
+                Uri googleImageUri = new Uri(url);
+                System.Collections.Specialized.NameValueCollection parameters = HttpUtility.ParseQueryString(googleImageUri.Query);
                 url = HttpUtility.UrlDecode(parameters.Get("imgurl"));
                 item.ContextLink = HttpUtility.UrlDecode(parameters.Get("imgrefurl"));
                 item.Source = item.ContextLink;

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/ViewModel/PictureSlidesLabWindowViewModel.VariationStageControls.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/ViewModel/PictureSlidesLabWindowViewModel.VariationStageControls.cs
@@ -25,16 +25,16 @@ namespace PowerPointLabs.PictureSlidesLab.ViewModel
                 return;
             }
 
-            var styleOption = _styleOptions[StylesVariationListSelectedId.Number];
-            var currentCategory = CurrentVariantCategory.Text;
-            var bc = new BrushConverter();
+            Model.StyleOption styleOption = _styleOptions[StylesVariationListSelectedId.Number];
+            string currentCategory = CurrentVariantCategory.Text;
+            BrushConverter bc = new BrushConverter();
 
             if (currentCategory.Contains(PictureSlidesLabText.ColorHasEffect))
             {
-                var propName = GetPropertyName(currentCategory);
-                var type = styleOption.GetType();
-                var prop = type.GetProperty(propName);
-                var optValue = prop.GetValue(styleOption, null);
+                string propName = GetPropertyName(currentCategory);
+                System.Type type = styleOption.GetType();
+                System.Reflection.PropertyInfo prop = type.GetProperty(propName);
+                object optValue = prop.GetValue(styleOption, null);
                 if (!string.IsNullOrEmpty(optValue as string))
                 {
                     View.SetVariantsColorPanelBackground((Brush) bc.ConvertFrom(optValue));
@@ -77,10 +77,10 @@ namespace PowerPointLabs.PictureSlidesLab.ViewModel
                 return;
             }
 
-            var styleOption = _styleOptions[StylesVariationListSelectedId.Number];
-            var styleFontFamily = styleOption.GetFontFamily();
-            var targetIndex = -1;
-            for (var i = 0; i < FontFamilies.Count; i++)
+            Model.StyleOption styleOption = _styleOptions[StylesVariationListSelectedId.Number];
+            string styleFontFamily = styleOption.GetFontFamily();
+            int targetIndex = -1;
+            for (int i = 0; i < FontFamilies.Count; i++)
             {
                 if (styleFontFamily == FontFamilies[i])
                 {
@@ -113,11 +113,11 @@ namespace PowerPointLabs.PictureSlidesLab.ViewModel
                 return;
             }
 
-            var styleOption = _styleOptions[StylesVariationListSelectedId.Number];
-            var currentCategory = CurrentVariantCategory.Text;
-            var propName = GetPropertyName(currentCategory);
-            var propHandler = PropHandlerFactory.GetSliderPropHandler(propName);
-            var sliderProperties = propHandler.GetSliderProperties(styleOption);
+            Model.StyleOption styleOption = _styleOptions[StylesVariationListSelectedId.Number];
+            string currentCategory = CurrentVariantCategory.Text;
+            string propName = GetPropertyName(currentCategory);
+            SliderPropHandler.Interface.ISliderPropHandler propHandler = PropHandlerFactory.GetSliderPropHandler(propName);
+            SliderPropHandler.Factory.SliderPropHandlerFactory.SliderProperties sliderProperties = propHandler.GetSliderProperties(styleOption);
             SelectedSliderValue.Number = sliderProperties.Value;
             SelectedSliderMaximum.Number = sliderProperties.Maximum;
             SelectedSliderTickFrequency.Number = sliderProperties.TickFrequency;
@@ -159,16 +159,16 @@ namespace PowerPointLabs.PictureSlidesLab.ViewModel
                 return;
             }
 
-            var styleOption = _styleOptions[StylesVariationListSelectedId.Number];
-            var currentCategory = CurrentVariantCategory.Text;
-            var targetColor = StringUtil.GetHexValue(color);
+            Model.StyleOption styleOption = _styleOptions[StylesVariationListSelectedId.Number];
+            string currentCategory = CurrentVariantCategory.Text;
+            string targetColor = StringUtil.GetHexValue(color);
 
             if (currentCategory.Contains(PictureSlidesLabText.ColorHasEffect))
             {
                 styleOption.OptionName = "Customized";
-                var propName = GetPropertyName(currentCategory);
-                var type = styleOption.GetType();
-                var prop = type.GetProperty(propName);
+                string propName = GetPropertyName(currentCategory);
+                System.Type type = styleOption.GetType();
+                System.Reflection.PropertyInfo prop = type.GetProperty(propName);
                 prop.SetValue(styleOption, targetColor, null);
             }
         }
@@ -180,8 +180,8 @@ namespace PowerPointLabs.PictureSlidesLab.ViewModel
                 return;
             }
 
-            var currentCategory = CurrentVariantCategory.Text;
-            var styleVariant = _styleVariants[currentCategory][StylesVariationListSelectedId.Number];
+            string currentCategory = CurrentVariantCategory.Text;
+            Model.StyleVariant styleVariant = _styleVariants[currentCategory][StylesVariationListSelectedId.Number];
 
             if (currentCategory.Contains(PictureSlidesLabText.ColorHasEffect))
             {
@@ -197,8 +197,8 @@ namespace PowerPointLabs.PictureSlidesLab.ViewModel
                 return;
             }
 
-            var styleOption = _styleOptions[StylesVariationListSelectedId.Number];
-            var currentCategory = CurrentVariantCategory.Text;
+            Model.StyleOption styleOption = _styleOptions[StylesVariationListSelectedId.Number];
+            string currentCategory = CurrentVariantCategory.Text;
 
             if (currentCategory == PictureSlidesLabText.VariantCategoryFontFamily)
             {
@@ -214,8 +214,8 @@ namespace PowerPointLabs.PictureSlidesLab.ViewModel
                 return;
             }
 
-            var currentCategory = CurrentVariantCategory.Text;
-            var styleVariant = _styleVariants[currentCategory][StylesVariationListSelectedId.Number];
+            string currentCategory = CurrentVariantCategory.Text;
+            Model.StyleVariant styleVariant = _styleVariants[currentCategory][StylesVariationListSelectedId.Number];
 
             if (currentCategory == PictureSlidesLabText.VariantCategoryFontFamily)
             {
@@ -231,9 +231,9 @@ namespace PowerPointLabs.PictureSlidesLab.ViewModel
                 return;
             }
 
-            var styleOption = _styleOptions[StylesVariationListSelectedId.Number];
-            var currentCategory = CurrentVariantCategory.Text;
-            var propName = GetPropertyName(currentCategory);
+            Model.StyleOption styleOption = _styleOptions[StylesVariationListSelectedId.Number];
+            string currentCategory = CurrentVariantCategory.Text;
+            string propName = GetPropertyName(currentCategory);
             PropHandlerFactory.GetSliderPropHandler(propName).BindStyleOption(styleOption, value);
         }
 
@@ -244,9 +244,9 @@ namespace PowerPointLabs.PictureSlidesLab.ViewModel
                 return;
             }
 
-            var currentCategory = CurrentVariantCategory.Text;
-            var styleVariant = _styleVariants[currentCategory][StylesVariationListSelectedId.Number];
-            var propName = GetPropertyName(currentCategory);
+            string currentCategory = CurrentVariantCategory.Text;
+            Model.StyleVariant styleVariant = _styleVariants[currentCategory][StylesVariationListSelectedId.Number];
+            string propName = GetPropertyName(currentCategory);
             PropHandlerFactory.GetSliderPropHandler(propName).BindStyleVariant(styleVariant, value);
         }
 
@@ -258,9 +258,9 @@ namespace PowerPointLabs.PictureSlidesLab.ViewModel
 
         private string GetPropertyName(string categoryName)
         {
-            var propName = categoryName.Replace(" ", string.Empty);
+            string propName = categoryName.Replace(" ", string.Empty);
 
-            var styleOption = _styleOptions[StylesVariationListSelectedId.Number];
+            Model.StyleOption styleOption = _styleOptions[StylesVariationListSelectedId.Number];
             if ((styleOption.IsUseFrostedGlassBannerStyle && categoryName.Contains(PictureSlidesLabText.BannerHasEffect))
                 || (styleOption.IsUseFrostedGlassTextBoxStyle && categoryName.Contains(PictureSlidesLabText.TextBoxHasEffect)))
             {

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/ViewModel/PictureSlidesLabWindowViewModel.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/ViewModel/PictureSlidesLabWindowViewModel.cs
@@ -130,9 +130,9 @@ namespace PowerPointLabs.PictureSlidesLab.ViewModel
             OptionsFactory = new StyleOptionsFactory();
             VariantsFactory = new StyleVariantsFactory();
 
-            var catalog = new AggregateCatalog(
+            AggregateCatalog catalog = new AggregateCatalog(
                 new AssemblyCatalog(Assembly.GetExecutingAssembly()));
-            var container = new CompositionContainer(catalog);
+            CompositionContainer container = new CompositionContainer(catalog);
             container.ComposeParts(this);
 
             Logger.Log("Init PSL View Model done");
@@ -173,11 +173,11 @@ namespace PowerPointLabs.PictureSlidesLab.ViewModel
             try
             {
                 Logger.Log("Add local picture begins");
-                var isToSelectPicture = ImageSelectionList.Count == 1;
-                foreach (var filename in filenames)
+                bool isToSelectPicture = ImageSelectionList.Count == 1;
+                foreach (string filename in filenames)
                 {
                     VerifyIsProperImage(filename);
-                    var fromFileItem = new ImageItem
+                    ImageItem fromFileItem = new ImageItem
                     {
                         ImageFile = ImageUtil.GetThumbnailFromFullSizeImg(filename),
                         FullSizeImageFile = filename,
@@ -225,7 +225,7 @@ namespace PowerPointLabs.PictureSlidesLab.ViewModel
                 Logger.Log("Url link error when add internet image");
                 return;
             }
-            var item = new ImageItem
+            ImageItem item = new ImageItem
             {
                 ImageFile = StoragePath.LoadingImgPath,
                 ContextLink = downloadLink,
@@ -235,7 +235,7 @@ namespace PowerPointLabs.PictureSlidesLab.ViewModel
             ImageSelectionList.Add(item);
             IsActiveDownloadProgressRing.Flag = true;
 
-            var imagePath = StoragePath.GetPath("img-"
+            string imagePath = StoragePath.GetPath("img-"
                 + DateTime.Now.GetHashCode() + "-"
                 + Guid.NewGuid().ToString().Substring(0, 7));
             ImageDownloader
@@ -314,10 +314,10 @@ namespace PowerPointLabs.PictureSlidesLab.ViewModel
         public void ApplyStyleInPreviewStage(Slide contentSlide, float slideWidth, float slideHeight)
         {
             Logger.Log("Apply style in preview stage begins");
-            var copiedPicture = LoadClipboardPicture();
+            IList<object> copiedPicture = LoadClipboardPicture();
             try
             {
-                var targetDefaultOptions = OptionsFactory
+                StyleOption targetDefaultOptions = OptionsFactory
                     .GetStylesPreviewOption(StylesPreviewListSelectedItem.ImageItem.Tooltip);
                 Designer.ApplyStyle(ImageSelectionListSelectedItem.ImageItem, contentSlide,
                     slideWidth, slideHeight, targetDefaultOptions);
@@ -364,7 +364,7 @@ namespace PowerPointLabs.PictureSlidesLab.ViewModel
             List<StyleOption> givenOptions = null, Dictionary<string, List<StyleVariant>> givenVariants = null)
         {
             Logger.Log("Variation stage is open");
-            var targetStyleItem = StylesPreviewListSelectedItem.ImageItem;
+            ImageItem targetStyleItem = StylesPreviewListSelectedItem.ImageItem;
             StylesVariationList.Clear();
 
             if (!IsAbleToUpdateStylesVariationImages(source, targetStyleItem, contentSlide))
@@ -400,9 +400,9 @@ namespace PowerPointLabs.PictureSlidesLab.ViewModel
         public void UpdateStylesVariationImagesAfterOpenFlyout(ImageItem source, Slide contentSlide, float slideWidth, float slideHeight, bool isUpdateSelectedPreviewOnly = false)
         {
             Logger.Log("Variation is already open, update preview images");
-            var selectedId = StylesVariationListSelectedId.Number;
-            var scrollOffset = View.GetVariationListBoxScrollOffset();
-            var targetStyleItem = StylesPreviewListSelectedItem.ImageItem;
+            int selectedId = StylesVariationListSelectedId.Number;
+            double scrollOffset = View.GetVariationListBoxScrollOffset();
+            ImageItem targetStyleItem = StylesPreviewListSelectedItem.ImageItem;
             if (!isUpdateSelectedPreviewOnly)
             {
                 StylesVariationList.Clear();
@@ -444,35 +444,35 @@ namespace PowerPointLabs.PictureSlidesLab.ViewModel
             }
 
             Logger.Log("Step by step preview begins");
-            var targetVariationSelectedIndex = StylesVariationListSelectedId.Number;
-            var targetVariant = _styleVariants[_previousVariantsCategory][targetVariationSelectedIndex];
-            foreach (var option in _styleOptions)
+            int targetVariationSelectedIndex = StylesVariationListSelectedId.Number;
+            StyleVariant targetVariant = _styleVariants[_previousVariantsCategory][targetVariationSelectedIndex];
+            foreach (StyleOption option in _styleOptions)
             {
                 targetVariant.Apply(option);
             }
             
-            var currentVariantsCategory = CurrentVariantCategory.Text;
+            string currentVariantsCategory = CurrentVariantCategory.Text;
             if (currentVariantsCategory != PictureSlidesLabText.VariantCategoryFontColor
                 && _previousVariantsCategory != PictureSlidesLabText.VariantCategoryFontColor)
             {
                 // apply font color variant,
                 // because default styles may contain special font color settings, but not in variants
-                var fontColorVariant = new StyleVariant(new Dictionary<string, object>
+                StyleVariant fontColorVariant = new StyleVariant(new Dictionary<string, object>
                 {
                     {"FontColor", _styleOptions[targetVariationSelectedIndex].FontColor}
                 });
-                foreach (var option in _styleOptions)
+                foreach (StyleOption option in _styleOptions)
                 {
                     fontColorVariant.Apply(option);
                 }
             }
 
-            var nextCategoryVariants = _styleVariants[currentVariantsCategory];
+            List<StyleVariant> nextCategoryVariants = _styleVariants[currentVariantsCategory];
             if (currentVariantsCategory == PictureSlidesLabText.VariantCategoryFontFamily)
             {
-                var isFontInVariation = false;
-                var currentFontFamily = _styleOptions[targetVariationSelectedIndex].FontFamily;
-                foreach (var variant in nextCategoryVariants)
+                bool isFontInVariation = false;
+                string currentFontFamily = _styleOptions[targetVariationSelectedIndex].FontFamily;
+                foreach (StyleVariant variant in nextCategoryVariants)
                 {
                     if (currentFontFamily == (string) variant.Get("FontFamily"))
                     {
@@ -502,18 +502,18 @@ namespace PowerPointLabs.PictureSlidesLab.ViewModel
             else if (CurrentVariantCategory.Text == PictureSlidesLabText.VariantCategoryPicture
                      && _isPictureVariationInit)
             {
-                var isPictureSwapped = false;
-                for (var i = 0; i < _8PicturesInPictureVariation.Count; i++)
+                bool isPictureSwapped = false;
+                for (int i = 0; i < _8PicturesInPictureVariation.Count; i++)
                 {
                     // swap the picture to the current selected id in
                     // variation list
-                    var picture = _8PicturesInPictureVariation[i];
+                    ImageItem picture = _8PicturesInPictureVariation[i];
                     if ((ImageSelectionListSelectedItem.ImageItem == null 
                         && picture.ImageFile == StoragePath.NoPicturePlaceholderImgPath) || 
                             (ImageSelectionListSelectedItem.ImageItem != null
                             && picture.ImageFile == ImageSelectionListSelectedItem.ImageItem.ImageFile))
                     {
-                        var tempPic = _8PicturesInPictureVariation[targetVariationSelectedIndex];
+                        ImageItem tempPic = _8PicturesInPictureVariation[targetVariationSelectedIndex];
                         _8PicturesInPictureVariation[targetVariationSelectedIndex]
                             = picture;
                         _8PicturesInPictureVariation[i] = tempPic;
@@ -532,10 +532,10 @@ namespace PowerPointLabs.PictureSlidesLab.ViewModel
             else if (_previousVariantsCategory == PictureSlidesLabText.VariantCategoryPicture)
             {
                 // use the selected picture in the picture variation to preview
-                var targetPicture = _8PicturesInPictureVariation[targetVariationSelectedIndex];
+                ImageItem targetPicture = _8PicturesInPictureVariation[targetVariationSelectedIndex];
                 if (targetPicture.ImageFile != StoragePath.NoPicturePlaceholderImgPath)
                 {
-                    var indexForTargetPicture = ImageSelectionList.IndexOf(targetPicture);
+                    int indexForTargetPicture = ImageSelectionList.IndexOf(targetPicture);
                     if (indexForTargetPicture == -1)
                     {
                         ImageSelectionList.Add(targetPicture);
@@ -554,8 +554,8 @@ namespace PowerPointLabs.PictureSlidesLab.ViewModel
                 }
             }
 
-            var variantIndexWithoutEffect = -1;
-            for (var i = 0; i < nextCategoryVariants.Count; i++)
+            int variantIndexWithoutEffect = -1;
+            for (int i = 0; i < nextCategoryVariants.Count; i++)
             {
                 if (nextCategoryVariants[i].IsNoEffect(_styleOptions[targetVariationSelectedIndex]))
                 {
@@ -568,13 +568,13 @@ namespace PowerPointLabs.PictureSlidesLab.ViewModel
             // selected style
             if (variantIndexWithoutEffect != -1)
             {
-                var temp = nextCategoryVariants[variantIndexWithoutEffect];
+                StyleVariant temp = nextCategoryVariants[variantIndexWithoutEffect];
                 nextCategoryVariants[variantIndexWithoutEffect] =
                     nextCategoryVariants[targetVariationSelectedIndex];
                 nextCategoryVariants[targetVariationSelectedIndex] = temp;
             }
 
-            for (var i = 0; i < nextCategoryVariants.Count && i < _styleOptions.Count; i++)
+            for (int i = 0; i < nextCategoryVariants.Count && i < _styleOptions.Count; i++)
             {
                 nextCategoryVariants[i].Apply(_styleOptions[i]);
             }
@@ -597,7 +597,7 @@ namespace PowerPointLabs.PictureSlidesLab.ViewModel
         public void ApplyStyleInVariationStage(Slide contentSlide, float slideWidth, float slideHeight)
         {
             Logger.Log("Apply style in variation stage begins");
-            var copiedPicture = LoadClipboardPicture();
+            IList<object> copiedPicture = LoadClipboardPicture();
             try
             {
                 Designer.ApplyStyle(
@@ -610,11 +610,11 @@ namespace PowerPointLabs.PictureSlidesLab.ViewModel
                 if (IsInPictureVariation())
                 {
                     // select the picture if possible
-                    var targetPicture = GetSelectedPictureInPictureVariation(
+                    ImageItem targetPicture = GetSelectedPictureInPictureVariation(
                         StylesVariationListSelectedId.Number);
                     if (targetPicture.ImageFile != StoragePath.NoPicturePlaceholderImgPath)
                     {
-                        var indexForTargetPicture = ImageSelectionList.IndexOf(targetPicture);
+                        int indexForTargetPicture = ImageSelectionList.IndexOf(targetPicture);
                         if (indexForTargetPicture == -1)
                         {
                             ImageSelectionList.Add(targetPicture);
@@ -692,9 +692,9 @@ namespace PowerPointLabs.PictureSlidesLab.ViewModel
                 return;
             }
 
-            for (var i = 0; i < _8PicturesInPictureVariation.Count; i++)
+            for (int i = 0; i < _8PicturesInPictureVariation.Count; i++)
             {
-                var imageItem = _8PicturesInPictureVariation[i];
+                ImageItem imageItem = _8PicturesInPictureVariation[i];
                 if (imageItem.ImageFile == StoragePath.NoPicturePlaceholderImgPath)
                 {
                     _8PicturesInPictureVariation[i] = newPicture;
@@ -712,9 +712,9 @@ namespace PowerPointLabs.PictureSlidesLab.ViewModel
                 return;
             }
 
-            for (var i = 0; i < _8PicturesInPictureVariation.Count; i++)
+            for (int i = 0; i < _8PicturesInPictureVariation.Count; i++)
             {
-                var imageItem = _8PicturesInPictureVariation[i];
+                ImageItem imageItem = _8PicturesInPictureVariation[i];
                 if (ImageSelectionList.IndexOf(imageItem) == -1)
                 {
                     _8PicturesInPictureVariation[i] = View.CreateDefaultPictureItem();
@@ -724,7 +724,7 @@ namespace PowerPointLabs.PictureSlidesLab.ViewModel
 
         public void RefreshLast8Pictures()
         {
-            var selectedIdOfVariationList = Math.Max(StylesVariationListSelectedId.Number, 0);
+            int selectedIdOfVariationList = Math.Max(StylesVariationListSelectedId.Number, 0);
             _8PicturesInPictureVariation = GetLast8Pictures(selectedIdOfVariationList);
         }
 
@@ -752,8 +752,8 @@ namespace PowerPointLabs.PictureSlidesLab.ViewModel
 
             try
             {
-                var subPictureList = ImageSelectionList.Skip(Math.Max(1, ImageSelectionList.Count - 8));
-                var result = new List<ImageItem>(subPictureList);
+                IEnumerable<ImageItem> subPictureList = ImageSelectionList.Skip(Math.Max(1, ImageSelectionList.Count - 8));
+                List<ImageItem> result = new List<ImageItem>(subPictureList);
                 while (result.Count < 8)
                 {
                     result.Add(View.CreateDefaultPictureItem());
@@ -765,7 +765,7 @@ namespace PowerPointLabs.PictureSlidesLab.ViewModel
                 }
                 else if (ImageSelectionListSelectedItem.ImageItem == null)
                 {
-                    for (var i = 0; i < result.Count; i++)
+                    for (int i = 0; i < result.Count; i++)
                     {
                         if (result[i].ImageFile == StoragePath.NoPicturePlaceholderImgPath)
                         {
@@ -778,8 +778,8 @@ namespace PowerPointLabs.PictureSlidesLab.ViewModel
                 else if (selectedIdOfVariationList >= 0)
                 // contains selected item, need swap to selected index
                 {
-                    var indexToSwap = result.IndexOf(ImageSelectionListSelectedItem.ImageItem);
-                    var tempItem = result[selectedIdOfVariationList];
+                    int indexToSwap = result.IndexOf(ImageSelectionListSelectedItem.ImageItem);
+                    ImageItem tempItem = result[selectedIdOfVariationList];
                     result[selectedIdOfVariationList] = ImageSelectionListSelectedItem.ImageItem;
                     result[indexToSwap] = tempItem;
                 }
@@ -798,7 +798,7 @@ namespace PowerPointLabs.PictureSlidesLab.ViewModel
             try
             {
                 Logger.Log("Load clipboard begins.");
-                var result = new List<object>();
+                List<object> result = new List<object>();
                 if (Clipboard.ContainsImage())
                 {
                     result.Add(Clipboard.GetImage());
@@ -827,7 +827,7 @@ namespace PowerPointLabs.PictureSlidesLab.ViewModel
             try
             {
                 Logger.Log("Save clipboard begins.");
-                foreach (var copiedObj in copiedObjs)
+                foreach (object copiedObj in copiedObjs)
                 {
                     if (copiedObj == null)
                     {
@@ -867,7 +867,7 @@ namespace PowerPointLabs.PictureSlidesLab.ViewModel
         private void UpdateStylesPreviewImages(ImageItem source, Slide contentSlide, float slideWidth, float slideHeight)
         {
             Logger.Log("UpdateStylesPreviewImages begins");
-            var selectedId = StylesPreviewListSelectedId.Number;
+            int selectedId = StylesPreviewListSelectedId.Number;
             StylesPreviewList.Clear();
 
             if (!IsAbleToUpdateStylesPreviewImages(source, contentSlide))
@@ -875,14 +875,14 @@ namespace PowerPointLabs.PictureSlidesLab.ViewModel
                 return;
             }
 
-            var copiedPicture = LoadClipboardPicture();
+            IList<object> copiedPicture = LoadClipboardPicture();
             try
             {
-                var allStyleOptions = OptionsFactory.GetAllStylesPreviewOptions();
+                List<StyleOption> allStyleOptions = OptionsFactory.GetAllStylesPreviewOptions();
                 Logger.Log("Number of styles: " + allStyleOptions.Count);
-                foreach (var stylesPreviewOption in allStyleOptions)
+                foreach (StyleOption stylesPreviewOption in allStyleOptions)
                 {
-                    var previewInfo = Designer.PreviewApplyStyle(source, 
+                    PreviewInfo previewInfo = Designer.PreviewApplyStyle(source, 
                         contentSlide, slideWidth, slideHeight, stylesPreviewOption);
                     StylesPreviewList.Add(new ImageItem
                     {
@@ -922,7 +922,7 @@ namespace PowerPointLabs.PictureSlidesLab.ViewModel
             _styleVariants = givenVariants ?? VariantsFactory.GetVariants(targetStyle);
 
             VariantsCategory.Clear();
-            foreach (var styleVariant in _styleVariants.Keys)
+            foreach (string styleVariant in _styleVariants.Keys)
             {
                 VariantsCategory.Add(styleVariant);
             }
@@ -930,10 +930,10 @@ namespace PowerPointLabs.PictureSlidesLab.ViewModel
             _previousVariantsCategory = VariantsCategory[0];
 
             // default style options (in preview stage)
-            var defaultStyleOptions = OptionsFactory.GetStylesPreviewOption(targetStyle);
-            var currentVariants = _styleVariants.Values.First();
-            var variantIndexWithoutEffect = -1;
-            for (var i = 0; i < currentVariants.Count; i++)
+            StyleOption defaultStyleOptions = OptionsFactory.GetStylesPreviewOption(targetStyle);
+            List<StyleVariant> currentVariants = _styleVariants.Values.First();
+            int variantIndexWithoutEffect = -1;
+            for (int i = 0; i < currentVariants.Count; i++)
             {
                 if (currentVariants[i].IsNoEffect(defaultStyleOptions))
                 {
@@ -952,18 +952,18 @@ namespace PowerPointLabs.PictureSlidesLab.ViewModel
             if (variantIndexWithoutEffect != -1 && givenOptions == null)
             {
                 // swap style variant
-                var tempVariant = currentVariants[variantIndexWithoutEffect];
+                StyleVariant tempVariant = currentVariants[variantIndexWithoutEffect];
                 currentVariants[variantIndexWithoutEffect] =
                     currentVariants[0];
                 currentVariants[0] = tempVariant;
                 // swap default style options (in variation stage)
-                var tempStyleOpt = _styleOptions[variantIndexWithoutEffect];
+                StyleOption tempStyleOpt = _styleOptions[variantIndexWithoutEffect];
                 _styleOptions[variantIndexWithoutEffect] =
                     _styleOptions[0];
                 _styleOptions[0] = tempStyleOpt;
             }
 
-            for (var i = 0; i < currentVariants.Count && i < _styleOptions.Count; i++)
+            for (int i = 0; i < currentVariants.Count && i < _styleOptions.Count; i++)
             {
                 currentVariants[i].Apply(_styleOptions[i]);
             }
@@ -990,7 +990,7 @@ namespace PowerPointLabs.PictureSlidesLab.ViewModel
             float slideWidth, float slideHeight, bool isMockPreviewImages = false, int selectedId = -1)
         {
             Logger.Log("UpdateStylesVariationImages begins");
-            var copiedPicture = LoadClipboardPicture();
+            IList<object> copiedPicture = LoadClipboardPicture();
             try
             {
                 if (isMockPreviewImages)
@@ -1005,7 +1005,7 @@ namespace PowerPointLabs.PictureSlidesLab.ViewModel
                 }
                 else
                 {
-                    for (var i = 0; i < _styleOptions.Count; i++)
+                    for (int i = 0; i < _styleOptions.Count; i++)
                     {
                         StylesVariationList.Add(
                             GenerateImageItem(source, contentSlide, slideWidth, slideHeight, isMockPreviewImages, i));
@@ -1025,7 +1025,7 @@ namespace PowerPointLabs.PictureSlidesLab.ViewModel
         private ImageItem GenerateImageItem(ImageItem source, Slide contentSlide, float slideWidth, float slideHeight, bool isMockPreviewImages,
             int index)
         {
-            var styleOption = _styleOptions[index];
+            StyleOption styleOption = _styleOptions[index];
             PreviewInfo previewInfo;
             if (isMockPreviewImages)
             {
@@ -1090,7 +1090,7 @@ namespace PowerPointLabs.PictureSlidesLab.ViewModel
         private void InitFontFamilies()
         {
             FontFamilies = new ObservableCollection<string>();
-            foreach (var fontFamily in Fonts.SystemFontFamilies)
+            foreach (System.Windows.Media.FontFamily fontFamily in Fonts.SystemFontFamilies)
             {
                 FontFamilies.Add(fontFamily.Source);
             }
@@ -1106,8 +1106,8 @@ namespace PowerPointLabs.PictureSlidesLab.ViewModel
 
         private void CleanUnusedPersistentData()
         {
-            var imageFilesInUse = new HashSet<string>();
-            foreach (var imageItem in ImageSelectionList)
+            HashSet<string> imageFilesInUse = new HashSet<string>();
+            foreach (ImageItem imageItem in ImageSelectionList)
             {
                 imageFilesInUse.Add(imageItem.ImageFile);
                 imageFilesInUse.Add(imageItem.FullSizeImageFile);
@@ -1152,8 +1152,8 @@ namespace PowerPointLabs.PictureSlidesLab.ViewModel
             }
             else
             {
-                var loadedImageSelectionList = StoragePath.LoadPictures();
-                foreach (var item in loadedImageSelectionList)
+                ObservableCollection<ImageItem> loadedImageSelectionList = StoragePath.LoadPictures();
+                foreach (ImageItem item in loadedImageSelectionList)
                 {
                     if (item.FullSizeImageFile == null && item.BackupFullSizeImageFile != null)
                     {
@@ -1175,8 +1175,8 @@ namespace PowerPointLabs.PictureSlidesLab.ViewModel
 
         private void InitStorage()
         {
-            var isTempPathInit = Util.TempPath.InitTempFolder();
-            var isStoragePathInit = StoragePath.InitPersistentFolder();
+            bool isTempPathInit = Util.TempPath.InitTempFolder();
+            bool isStoragePathInit = StoragePath.InitPersistentFolder();
             if (!isTempPathInit || !isStoragePathInit)
             {
                 View.ShowErrorMessageBox(PictureSlidesLabText.ErrorFailToInitTempFolder);

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/ViewModel/SliderPropHandler/BlurrinessSliderPropHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/ViewModel/SliderPropHandler/BlurrinessSliderPropHandler.cs
@@ -10,8 +10,8 @@ namespace PowerPointLabs.PictureSlidesLab.ViewModel.SliderPropHandler
     {
         public Factory.SliderPropHandlerFactory.SliderProperties GetSliderProperties(StyleOption option)
         {
-            var sliderProperties = new Factory.SliderPropHandlerFactory.SliderProperties();
-            var optValue = option.BlurDegree;
+            Factory.SliderPropHandlerFactory.SliderProperties sliderProperties = new Factory.SliderPropHandlerFactory.SliderProperties();
+            int optValue = option.BlurDegree;
             sliderProperties.Value = (optValue == 0) ? 0 : (optValue - 50) * 2;
             sliderProperties.Maximum = 100;
             sliderProperties.TickFrequency = 2;
@@ -30,7 +30,7 @@ namespace PowerPointLabs.PictureSlidesLab.ViewModel.SliderPropHandler
         {
             variant.Set("OptionName", "Customized");
             variant.Set("IsUseBlurStyle", true);
-            var variantValue = (value == 0) ? 0 : 50 + (value / 2);
+            int variantValue = (value == 0) ? 0 : 50 + (value / 2);
             variant.Set("BlurDegree", variantValue);
         }
     }

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/ViewModel/SliderPropHandler/BrightnessSliderPropHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/ViewModel/SliderPropHandler/BrightnessSliderPropHandler.cs
@@ -10,9 +10,9 @@ namespace PowerPointLabs.PictureSlidesLab.ViewModel.SliderPropHandler
     {
         public Factory.SliderPropHandlerFactory.SliderProperties GetSliderProperties(StyleOption option)
         {
-            var sliderProperties = new Factory.SliderPropHandlerFactory.SliderProperties();
-            var colorValue = option.OverlayColor;
-            var optValue = option.OverlayTransparency;
+            Factory.SliderPropHandlerFactory.SliderProperties sliderProperties = new Factory.SliderPropHandlerFactory.SliderProperties();
+            string colorValue = option.OverlayColor;
+            int optValue = option.OverlayTransparency;
             sliderProperties.Value = (colorValue == "#FFFFFF") ? 200 - optValue : optValue;
             sliderProperties.Maximum = 200;
             sliderProperties.TickFrequency = 1;

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/ViewModel/SliderPropHandler/Factory/SliderPropHandlerFactory.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/ViewModel/SliderPropHandler/Factory/SliderPropHandlerFactory.cs
@@ -18,7 +18,7 @@ namespace PowerPointLabs.PictureSlidesLab.ViewModel.SliderPropHandler.Factory
         {
             if (propHandlerName.Contains(PictureSlidesLabText.TransparencyHasEffect))
             {
-                var transparencyPropHandler = (TransparencySliderPropHandler)ImportedSliderPropHandlers
+                TransparencySliderPropHandler transparencyPropHandler = (TransparencySliderPropHandler)ImportedSliderPropHandlers
                     .Where(propHandler => propHandler.Metadata.PropHandlerName == PictureSlidesLabText.TransparencyHasEffect)
                     .Select(propHandler => propHandler.Value)
                     .FirstOrDefault();

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/ViewModel/SliderPropHandler/TransparencySliderPropHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/ViewModel/SliderPropHandler/TransparencySliderPropHandler.cs
@@ -12,9 +12,9 @@ namespace PowerPointLabs.PictureSlidesLab.ViewModel.SliderPropHandler
 
         public Factory.SliderPropHandlerFactory.SliderProperties GetSliderProperties(StyleOption option)
         {
-            var sliderProperties = new Factory.SliderPropHandlerFactory.SliderProperties();
-            var type = option.GetType();
-            var prop = type.GetProperty(PropName);
+            Factory.SliderPropHandlerFactory.SliderProperties sliderProperties = new Factory.SliderPropHandlerFactory.SliderProperties();
+            System.Type type = option.GetType();
+            System.Reflection.PropertyInfo prop = type.GetProperty(PropName);
             sliderProperties.Value = (int)prop.GetValue(option, null);
             sliderProperties.Maximum = 100;
             sliderProperties.TickFrequency = 1;
@@ -25,8 +25,8 @@ namespace PowerPointLabs.PictureSlidesLab.ViewModel.SliderPropHandler
         public void BindStyleOption(StyleOption option, int value)
         {
             option.OptionName = "Customized";
-            var type = option.GetType();
-            var prop = type.GetProperty(PropName);
+            System.Type type = option.GetType();
+            System.Reflection.PropertyInfo prop = type.GetProperty(PropName);
             prop.SetValue(option, value, null);
         }
 

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Views/AdjustImageWindow.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Views/AdjustImageWindow.xaml.cs
@@ -118,13 +118,13 @@ namespace PowerPointLabs.PictureSlidesLab.Views
                 rect = AutoFit(element);
             }
 
-            var layer = AdornerLayer.GetAdornerLayer(element);
+            AdornerLayer layer = AdornerLayer.GetAdornerLayer(element);
             _croppingAdorner = new CroppingAdorner(element, rect);
             _croppingAdorner.SlideWidth = this.GetCurrentPresentation().SlideWidth;
             _croppingAdorner.SlideHeight = this.GetCurrentPresentation().SlideHeight;
             _croppingAdorner.CropChanged += (sender, args) =>
             {
-                var croppingRect = _croppingAdorner.ClippingRectangle;
+                Rect croppingRect = _croppingAdorner.ClippingRectangle;
                 if (croppingRect.Width*croppingRect.Height < 1)
                 {
                     SaveCropButton.IsEnabled = false;
@@ -160,10 +160,10 @@ namespace PowerPointLabs.PictureSlidesLab.Views
 
         private void CenterWindowOnScreen()
         {
-            var screenWidth = SystemParameters.PrimaryScreenWidth;
-            var screenHeight = SystemParameters.PrimaryScreenHeight;
-            var windowWidth = Width;
-            var windowHeight = Height;
+            double screenWidth = SystemParameters.PrimaryScreenWidth;
+            double screenHeight = SystemParameters.PrimaryScreenHeight;
+            double windowWidth = Width;
+            double windowHeight = Height;
             Left = (screenWidth / 2) - (windowWidth / 2);
             Top = (screenHeight / 2) - (windowHeight / 2);
         }
@@ -180,15 +180,15 @@ namespace PowerPointLabs.PictureSlidesLab.Views
 
         private void SaveCropButton_OnClick(object sender, RoutedEventArgs e)
         {
-            var rect = _croppingAdorner.ClippingRectangle;
-            var xRatio = rect.X/ImageHolder.ActualWidth;
-            var yRatio = rect.Y/ImageHolder.ActualHeight;
-            var widthRatio = rect.Width/ImageHolder.ActualWidth;
-            var heightRatio = rect.Height/ImageHolder.ActualHeight;
+            Rect rect = _croppingAdorner.ClippingRectangle;
+            double xRatio = rect.X/ImageHolder.ActualWidth;
+            double yRatio = rect.Y/ImageHolder.ActualHeight;
+            double widthRatio = rect.Width/ImageHolder.ActualWidth;
+            double heightRatio = rect.Height/ImageHolder.ActualHeight;
             Rect = rect;
 
-            var originalImg = (Bitmap)Bitmap.FromFile(CropResult);
-            var result = CropToShape.KiCut(originalImg, 
+            Bitmap originalImg = (Bitmap)Bitmap.FromFile(CropResult);
+            Bitmap result = CropToShape.KiCut(originalImg, 
                 (float) xRatio*originalImg.Width,
                 (float) yRatio * originalImg.Height,
                 (float) widthRatio * originalImg.Width,
@@ -206,21 +206,21 @@ namespace PowerPointLabs.PictureSlidesLab.Views
 
         private void AutoFitButton_OnClick(object sender, RoutedEventArgs e)
         {
-            var rect = AutoFit();
+            Rect rect = AutoFit();
             _croppingAdorner.ClippingRectangle = rect;
         }
 
         private Rect AutoFit(FrameworkElement element = null)
         {
-            var slideWidth = this.GetCurrentPresentation().SlideWidth;
-            var slideHeight = this.GetCurrentPresentation().SlideHeight;
+            float slideWidth = this.GetCurrentPresentation().SlideWidth;
+            float slideHeight = this.GetCurrentPresentation().SlideHeight;
             element = element ?? _frameworkElement;
 
             Rect rect;
             if (element.ActualWidth / element.ActualHeight
                 < slideWidth/slideHeight)
             {
-                var targetHeight = element.ActualWidth / slideWidth * slideHeight;
+                double targetHeight = element.ActualWidth / slideWidth * slideHeight;
                 rect = new Rect(
                     0,
                     (element.ActualHeight - targetHeight) / 2,
@@ -229,7 +229,7 @@ namespace PowerPointLabs.PictureSlidesLab.Views
             }
             else
             {
-                var targetWidth = element.ActualHeight / slideHeight * slideWidth;
+                double targetWidth = element.ActualHeight / slideHeight * slideWidth;
                 rect = new Rect(
                     (element.ActualWidth - targetWidth) / 2,
                     0,
@@ -271,7 +271,7 @@ namespace PowerPointLabs.PictureSlidesLab.Views
 
         private void RotateFlipImg(RotateFlipType roatateFlipType)
         {
-            var img = (Bitmap)Bitmap.FromFile(CropResult);
+            Bitmap img = (Bitmap)Bitmap.FromFile(CropResult);
             img.RotateFlip(roatateFlipType);
             String rotatedImg = StoragePath.GetPath("rotated-"
                                     + DateTime.Now.GetHashCode() + "-"
@@ -295,7 +295,7 @@ namespace PowerPointLabs.PictureSlidesLab.Views
 
             Dispatcher.Invoke(DispatcherPriority.SystemIdle, new Action(() =>
             {
-                var rect = AutoFit();
+                Rect rect = AutoFit();
                 _croppingAdorner.ClippingRectangle = rect;
             }));
         }

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Views/ImageAdjustment/CroppingAdorner.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Views/ImageAdjustment/CroppingAdorner.cs
@@ -158,7 +158,7 @@ namespace PowerPointLabs.PictureSlidesLab.Views.ImageAdjustment
                 Rect rcInterior = _prCropMask.RectInterior;
                 Rect rcExterior = _prCropMask.RectExterior;
 
-                var dx = args.HorizontalChange;
+                double dx = args.HorizontalChange;
 
                 // boundary: when minimized
                 if (rcInterior.Width - dx < 0)
@@ -166,9 +166,9 @@ namespace PowerPointLabs.PictureSlidesLab.Views.ImageAdjustment
                     dx = rcInterior.Width;
                 }
 
-                var newLeft = rcInterior.Left + dx;
-                var newWidth = rcInterior.Width - dx;
-                var newHeight = newWidth / SlideWidth * SlideHeight;
+                double newLeft = rcInterior.Left + dx;
+                double newWidth = rcInterior.Width - dx;
+                double newHeight = newWidth / SlideWidth * SlideHeight;
 
                 // boundary: when maximized
                 if (newLeft < rcExterior.Left && rcInterior.Top + newHeight > rcExterior.Bottom)
@@ -217,7 +217,7 @@ namespace PowerPointLabs.PictureSlidesLab.Views.ImageAdjustment
         {
             if (sender is CropThumb)
             {
-                var dx = args.HorizontalChange;
+                double dx = args.HorizontalChange;
                 ZoomCroppingRect(dx);
             }
         }
@@ -233,8 +233,8 @@ namespace PowerPointLabs.PictureSlidesLab.Views.ImageAdjustment
                 dx = -rcInterior.Width;
             }
 
-            var newWidth = rcInterior.Width + dx;
-            var newHeight = newWidth / SlideWidth * SlideHeight;
+            double newWidth = rcInterior.Width + dx;
+            double newHeight = newWidth / SlideWidth * SlideHeight;
 
             // boundary: when maximized
             if (rcInterior.Left + newWidth > rcExterior.Right
@@ -278,7 +278,7 @@ namespace PowerPointLabs.PictureSlidesLab.Views.ImageAdjustment
                 Rect rcInterior = _prCropMask.RectInterior;
                 Rect rcExterior = _prCropMask.RectExterior;
 
-                var dy = args.VerticalChange;
+                double dy = args.VerticalChange;
 
                 // boundary: when minimized
 
@@ -287,9 +287,9 @@ namespace PowerPointLabs.PictureSlidesLab.Views.ImageAdjustment
                     dy = rcInterior.Height;
                 }
 
-                var newTop = rcInterior.Top + dy;
-                var newHeight = rcInterior.Height - dy;
-                var newWidth = newHeight / SlideHeight * SlideWidth;
+                double newTop = rcInterior.Top + dy;
+                double newHeight = rcInterior.Height - dy;
+                double newWidth = newHeight / SlideHeight * SlideWidth;
 
                 // boundary: when maximized
                 if (newTop < rcExterior.Top && rcInterior.Left + newWidth > rcExterior.Right)
@@ -341,7 +341,7 @@ namespace PowerPointLabs.PictureSlidesLab.Views.ImageAdjustment
                 Rect rcInterior = _prCropMask.RectInterior;
                 Rect rcExterior = _prCropMask.RectExterior;
 
-                var dx = args.HorizontalChange;
+                double dx = args.HorizontalChange;
 
                 // boundary: when minimized
                 if (rcInterior.Width - dx < 0)
@@ -349,10 +349,10 @@ namespace PowerPointLabs.PictureSlidesLab.Views.ImageAdjustment
                     dx = rcInterior.Width;
                 }
 
-                var newWidth = rcInterior.Width - dx;
-                var newLeft = rcInterior.Right - newWidth;
-                var newHeight = newWidth / SlideWidth * SlideHeight;
-                var newTop = rcInterior.Bottom - newHeight;
+                double newWidth = rcInterior.Width - dx;
+                double newLeft = rcInterior.Right - newWidth;
+                double newHeight = newWidth / SlideWidth * SlideHeight;
+                double newTop = rcInterior.Bottom - newHeight;
 
                 // boundary: when maximized
                 if (newTop < rcExterior.Top && newLeft < rcExterior.Left)
@@ -400,8 +400,8 @@ namespace PowerPointLabs.PictureSlidesLab.Views.ImageAdjustment
         {
             if (sender is CropThumb)
             {
-                var dx = args.HorizontalChange;
-                var dy = args.VerticalChange;
+                double dx = args.HorizontalChange;
+                double dy = args.VerticalChange;
                 MoveCroppingRect(dx, dy);
             }
         }

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Views/PictureSlidesLabWindow.xaml.InterfaceImpl.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Views/PictureSlidesLabWindow.xaml.InterfaceImpl.cs
@@ -91,15 +91,15 @@ namespace PowerPointLabs.PictureSlidesLab.Views
 
         public double GetVariationListBoxScrollOffset()
         {
-            var scrollOffset = 0d;
-            var scrollViewer = ListBoxUtil.FindScrollViewer(StylesVariationListBox);
+            double scrollOffset = 0d;
+            System.Windows.Controls.ScrollViewer scrollViewer = ListBoxUtil.FindScrollViewer(StylesVariationListBox);
             if (scrollViewer != null) { scrollOffset = scrollViewer.VerticalOffset; }
             return scrollOffset;
         }
 
         public void SetVariationListBoxScrollOffset(double offset)
         {
-            var scrollViewer = ListBoxUtil.FindScrollViewer(StylesVariationListBox);
+            System.Windows.Controls.ScrollViewer scrollViewer = ListBoxUtil.FindScrollViewer(StylesVariationListBox);
             if (scrollViewer != null) { scrollViewer.ScrollToVerticalOffset(offset); }
         }
 

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Views/PictureSlidesLabWindow.xaml.LoadStyle.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Views/PictureSlidesLabWindow.xaml.LoadStyle.cs
@@ -68,14 +68,14 @@ namespace PowerPointLabs.PictureSlidesLab.Views
             this.HideMetroDialogAsync(_loadStylesDialog, MetroDialogOptions);
 
             // which is the current slide
-            var currentSlide = this.GetCurrentPresentation().Slides[_loadStylesDialog.SelectedSlide - 1];
+            PowerPointSlide currentSlide = this.GetCurrentPresentation().Slides[_loadStylesDialog.SelectedSlide - 1];
             if (currentSlide == null)
             {
                 return;
             }
 
-            var originalShapeList = currentSlide.GetShapesWithPrefix(ShapeNamePrefix + "_" + EffectName.Original_DO_NOT_REMOVE);
-            var croppedShapeList = currentSlide.GetShapesWithPrefix(ShapeNamePrefix + "_" + EffectName.Cropped_DO_NOT_REMOVE);
+            List<Shape> originalShapeList = currentSlide.GetShapesWithPrefix(ShapeNamePrefix + "_" + EffectName.Original_DO_NOT_REMOVE);
+            List<Shape> croppedShapeList = currentSlide.GetShapesWithPrefix(ShapeNamePrefix + "_" + EffectName.Cropped_DO_NOT_REMOVE);
 
             // if no original shape, show info
             if (originalShapeList.Count == 0)
@@ -84,14 +84,14 @@ namespace PowerPointLabs.PictureSlidesLab.Views
             }
             else
             {
-                var originalImageShape = originalShapeList[0];
-                var isImageStillInListBox = false;
+                Shape originalImageShape = originalShapeList[0];
+                bool isImageStillInListBox = false;
 
                 // if the image source is still in the listbox,
                 // select it as source and also select the target style
-                for (var i = 0; i < ImageSelectionListBox.Items.Count; i++)
+                for (int i = 0; i < ImageSelectionListBox.Items.Count; i++)
                 {
-                    var imageItem = (ImageItem)ImageSelectionListBox.Items[i];
+                    ImageItem imageItem = (ImageItem)ImageSelectionListBox.Items[i];
                     if (imageItem.FullSizeImageFile == originalImageShape.Tags[Service.Effect.Tag.ReloadOriginImg]
                         || imageItem.ContextLink == originalImageShape.Tags[Service.Effect.Tag.ReloadImgContext])
                     {
@@ -106,7 +106,7 @@ namespace PowerPointLabs.PictureSlidesLab.Views
                 // and put into listbox
                 if (!isImageStillInListBox)
                 {
-                    var imageItem = ExtractImageItem(originalImageShape, croppedShapeList);
+                    ImageItem imageItem = ExtractImageItem(originalImageShape, croppedShapeList);
                     ViewModel.ImageSelectionList.Add(imageItem);
                     Dispatcher.BeginInvoke(new Action(() =>
                     {
@@ -123,13 +123,13 @@ namespace PowerPointLabs.PictureSlidesLab.Views
             this.HideMetroDialogAsync(_loadStylesDialog, MetroDialogOptions);
 
             // which is the current slide
-            var currentSlide = this.GetCurrentPresentation().Slides[_loadStylesDialog.SelectedSlide - 1];
+            PowerPointSlide currentSlide = this.GetCurrentPresentation().Slides[_loadStylesDialog.SelectedSlide - 1];
             if (currentSlide == null)
             {
                 return;
             }
 
-            var originalShapeList = currentSlide.GetShapesWithPrefix(ShapeNamePrefix + "_" + EffectName.Original_DO_NOT_REMOVE);
+            List<Shape> originalShapeList = currentSlide.GetShapesWithPrefix(ShapeNamePrefix + "_" + EffectName.Original_DO_NOT_REMOVE);
 
             // if no original shape, show info
             if (originalShapeList.Count == 0)
@@ -147,8 +147,8 @@ namespace PowerPointLabs.PictureSlidesLab.Views
                     UpdatePreviewImages((ImageItem) ImageSelectionListBox.SelectedValue);
                 }
 
-                var originalImageShape = originalShapeList[0];
-                var styleName = originalImageShape.Tags[Service.Effect.Tag.ReloadPrefix + "StyleName"];
+                Shape originalImageShape = originalShapeList[0];
+                string styleName = originalImageShape.Tags[Service.Effect.Tag.ReloadPrefix + "StyleName"];
                 OpenVariationFlyoutForReload(styleName, originalImageShape, canUseDefaultPicture: true);
             }
         }
@@ -166,10 +166,10 @@ namespace PowerPointLabs.PictureSlidesLab.Views
                 return false;
             }
 
-            var isSuccessfullyLoaded = false;
-            var originalShapeList = targetSlide
+            bool isSuccessfullyLoaded = false;
+            List<Shape> originalShapeList = targetSlide
                 .GetShapesWithPrefix(ShapeNamePrefix + "_" + EffectName.Original_DO_NOT_REMOVE);
-            var croppedShapeList = targetSlide
+            List<Shape> croppedShapeList = targetSlide
                 .GetShapesWithPrefix(ShapeNamePrefix + "_" + EffectName.Cropped_DO_NOT_REMOVE);
 
             // if no original shape, show default picture
@@ -185,15 +185,15 @@ namespace PowerPointLabs.PictureSlidesLab.Views
             else if (originalShapeList.Count > 0) // load the style
             {
                 Logger.Log("Original shapes found.");
-                var originalImageShape = originalShapeList[0];
-                var isImageStillInListBox = false;
-                var styleName = originalImageShape.Tags[Service.Effect.Tag.ReloadPrefix + "StyleName"];
+                Shape originalImageShape = originalShapeList[0];
+                bool isImageStillInListBox = false;
+                string styleName = originalImageShape.Tags[Service.Effect.Tag.ReloadPrefix + "StyleName"];
 
                 // if the image source is still in the listbox,
                 // select it as source and also select the target style
-                for (var i = 0; i < ImageSelectionListBox.Items.Count; i++)
+                for (int i = 0; i < ImageSelectionListBox.Items.Count; i++)
                 {
-                    var imageItem = (ImageItem)ImageSelectionListBox.Items[i];
+                    ImageItem imageItem = (ImageItem)ImageSelectionListBox.Items[i];
                     if (imageItem.FullSizeImageFile == originalImageShape.Tags[Service.Effect.Tag.ReloadOriginImg]
                         || imageItem.ContextLink == originalImageShape.Tags[Service.Effect.Tag.ReloadImgContext])
                     {
@@ -211,7 +211,7 @@ namespace PowerPointLabs.PictureSlidesLab.Views
                 // and put into listbox
                 if (!isImageStillInListBox)
                 {
-                    var imageItem = ExtractImageItem(originalImageShape, croppedShapeList);
+                    ImageItem imageItem = ExtractImageItem(originalImageShape, croppedShapeList);
                     ViewModel.ImageSelectionList.Add(imageItem);
 
                     ImageSelectionListBox.SelectedIndex = ImageSelectionListBox.Items.Count - 1;
@@ -242,8 +242,8 @@ namespace PowerPointLabs.PictureSlidesLab.Views
             Dispatcher.BeginInvoke(new Action(() =>
             {
                 StylesPreviewListBox.SelectedIndex = MapStyleNameToStyleIndex(styleName);
-                var listOfStyles = ConstructStylesFromShapeInfo(originalImageShape);
-                var variants = ConstructVariantsFromStyle(listOfStyles[0]);
+                List<StyleOption> listOfStyles = ConstructStylesFromShapeInfo(originalImageShape);
+                Dictionary<string, List<StyleVariant>> variants = ConstructVariantsFromStyle(listOfStyles[0]);
                 Dispatcher.BeginInvoke(new Action(() =>
                 {
                     if (canUseDefaultPicture
@@ -270,15 +270,15 @@ namespace PowerPointLabs.PictureSlidesLab.Views
         private static ImageItem ExtractImageItem(Shape originalImageShape, List<Shape> croppedShapeList)
         {
             // get picture info
-            var fullsizeImageFile = ExtractPictureInfo(originalImageShape);
-            var fullsizeThumbnailFile = ImageUtil.GetThumbnailFromFullSizeImg(fullsizeImageFile);
+            string fullsizeImageFile = ExtractPictureInfo(originalImageShape);
+            string fullsizeThumbnailFile = ImageUtil.GetThumbnailFromFullSizeImg(fullsizeImageFile);
             // get dimensions/cropped picture info
-            var croppedImageFile = ExtractCroppedPicture(croppedShapeList);
-            var croppedThumbnailFile = ImageUtil.GetThumbnailFromFullSizeImg(croppedImageFile);
-            var rect = ExtractDimensionsInfo(originalImageShape);
+            string croppedImageFile = ExtractCroppedPicture(croppedShapeList);
+            string croppedThumbnailFile = ImageUtil.GetThumbnailFromFullSizeImg(croppedImageFile);
+            Rect rect = ExtractDimensionsInfo(originalImageShape);
 
             // then form image item
-            var imageItem = new ImageItem
+            ImageItem imageItem = new ImageItem
             {
                 ImageFile = fullsizeThumbnailFile,
                 FullSizeImageFile = fullsizeImageFile,
@@ -294,7 +294,7 @@ namespace PowerPointLabs.PictureSlidesLab.Views
 
         private static string ExtractPictureInfo(Shape originalImageShape)
         {
-            var fullsizeImageFile =
+            string fullsizeImageFile =
                 StoragePath.GetPath("img-" + DateTime.Now.GetHashCode() +
                                     Guid.NewGuid().ToString().Substring(0, 7) + ".jpg");
             // need to make shape visible so that can export
@@ -307,9 +307,9 @@ namespace PowerPointLabs.PictureSlidesLab.Views
         private static void UpdatePictureDimensionsInfo(List<Shape> croppedShapeList, Shape originalImageShape, 
             ImageItem imageItem)
         {
-            var croppedImageFile = ExtractCroppedPicture(croppedShapeList);
-            var croppedThumbnailFile = ImageUtil.GetThumbnailFromFullSizeImg(croppedImageFile);
-            var rect = ExtractDimensionsInfo(originalImageShape);
+            string croppedImageFile = ExtractCroppedPicture(croppedShapeList);
+            string croppedThumbnailFile = ImageUtil.GetThumbnailFromFullSizeImg(croppedImageFile);
+            Rect rect = ExtractDimensionsInfo(originalImageShape);
             imageItem.CroppedImageFile = croppedImageFile;
             imageItem.CroppedThumbnailImageFile = croppedThumbnailFile;
             imageItem.Rect = rect;
@@ -317,10 +317,10 @@ namespace PowerPointLabs.PictureSlidesLab.Views
 
         private static string ExtractCroppedPicture(List<Shape> croppedShapeList)
         {
-            var croppedImageFile =
+            string croppedImageFile =
                 StoragePath.GetPath("crop-" + DateTime.Now.GetHashCode() +
                                     Guid.NewGuid().ToString().Substring(0, 7) + ".jpg");
-            var croppedImageShape = croppedShapeList.Count > 0 ? croppedShapeList[0] : null;
+            Shape croppedImageShape = croppedShapeList.Count > 0 ? croppedShapeList[0] : null;
             if (croppedImageShape != null)
             {
                 croppedImageShape.Visible = MsoTriState.msoTrue;
@@ -336,7 +336,7 @@ namespace PowerPointLabs.PictureSlidesLab.Views
 
         private static Rect ExtractDimensionsInfo(Shape originalImageShape)
         {
-            var rect = new Rect();
+            Rect rect = new Rect();
             rect.X = double.Parse(originalImageShape.Tags[Service.Effect.Tag.ReloadRectX]);
             rect.Y = double.Parse(originalImageShape.Tags[Service.Effect.Tag.ReloadRectY]);
             rect.Width = double.Parse(originalImageShape.Tags[Service.Effect.Tag.ReloadRectWidth]);
@@ -346,8 +346,8 @@ namespace PowerPointLabs.PictureSlidesLab.Views
 
         private int MapStyleNameToStyleIndex(string styleName)
         {
-            var allOptions = ViewModel.OptionsFactory.GetAllStylesPreviewOptions();
-            for (var i = 0; i < allOptions.Count; i++)
+            List<StyleOption> allOptions = ViewModel.OptionsFactory.GetAllStylesPreviewOptions();
+            for (int i = 0; i < allOptions.Count; i++)
             {
                 if (allOptions[i].StyleName == styleName)
                 {
@@ -359,8 +359,8 @@ namespace PowerPointLabs.PictureSlidesLab.Views
 
         private List<StyleOption> ConstructStylesFromShapeInfo(Shape shape)
         {
-            var result = new List<StyleOption>();
-            for (var i = 0; i < 8; i++)
+            List<StyleOption> result = new List<StyleOption>();
+            for (int i = 0; i < 8; i++)
             {
                 result.Add(ConstructStyleFromShapeInfo(shape));
             }
@@ -369,14 +369,14 @@ namespace PowerPointLabs.PictureSlidesLab.Views
 
         private Dictionary<string, List<StyleVariant>> ConstructVariantsFromStyle(StyleOption opt)
         {
-            var variants = ViewModel.VariantsFactory.GetVariants(opt.StyleName);
+            Dictionary<string, List<StyleVariant>> variants = ViewModel.VariantsFactory.GetVariants(opt.StyleName);
             // replace each category/aspect's variant
             // with the new variant from the given style options
-            foreach (var pair in variants)
+            foreach (KeyValuePair<string, List<StyleVariant>> pair in variants)
             {
-                var firstVariant = pair.Value[0];
-                var newFirstVariant = firstVariant.Copy(opt);
-                for (var i = 0; i < pair.Value.Count; i++)
+                StyleVariant firstVariant = pair.Value[0];
+                StyleVariant newFirstVariant = firstVariant.Copy(opt);
+                for (int i = 0; i < pair.Value.Count; i++)
                 {
                     // try to swap out the 'no-effect' style options
                     if (pair.Value[i].IsNoEffect(opt))
@@ -392,23 +392,23 @@ namespace PowerPointLabs.PictureSlidesLab.Views
 
         private StyleOption ConstructStyleFromShapeInfo(Shape shape)
         {
-            var opt = new StyleOption();
-            var props = opt.GetType().GetProperties();
-            foreach (var propertyInfo in props)
+            StyleOption opt = new StyleOption();
+            PropertyInfo[] props = opt.GetType().GetProperties();
+            foreach (PropertyInfo propertyInfo in props)
             {
-                var valueInStr = shape.Tags[Service.Effect.Tag.ReloadPrefix + propertyInfo.Name];
+                string valueInStr = shape.Tags[Service.Effect.Tag.ReloadPrefix + propertyInfo.Name];
                 if (propertyInfo.PropertyType == typeof(string))
                 {
                     propertyInfo.SetValue(opt, valueInStr, null);
                 }
                 else if (propertyInfo.PropertyType == typeof(int))
                 {
-                    var valueInInt = int.Parse(valueInStr);
+                    int valueInInt = int.Parse(valueInStr);
                     propertyInfo.SetValue(opt, valueInInt, null);
                 }
                 else if (propertyInfo.PropertyType == typeof(bool))
                 {
-                    var valueInBool = bool.Parse(valueInStr);
+                    bool valueInBool = bool.Parse(valueInStr);
                     propertyInfo.SetValue(opt, valueInBool, null);
                 }
             }

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Views/PictureSlidesLabWindow.xaml.VariationStageControls.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Views/PictureSlidesLabWindow.xaml.VariationStageControls.cs
@@ -41,13 +41,13 @@ namespace PowerPointLabs.PictureSlidesLab.Views
         /// <param name="e"></param>
         private void VariantsColorPanel_OnMouseLeftButtonUp(object sender, MouseButtonEventArgs e)
         {
-            var panel = sender as Border;
+            Border panel = sender as Border;
             if (panel == null)
             {
                 return;
             }
 
-            var colorDialog = new ColorDialog
+            ColorDialog colorDialog = new ColorDialog
             {
                 Color = GetColor(panel.Background as SolidColorBrush),
                 FullOpen = true
@@ -84,10 +84,10 @@ namespace PowerPointLabs.PictureSlidesLab.Views
 
         private void VariantsSlider_OnValueChangedFinal(object sender, EventArgs e)
         {
-            var type = e.GetType();
+            Type type = e.GetType();
             if (type.Equals(typeof(System.Windows.Input.KeyEventArgs)))
             {
-                var eventArgs = (System.Windows.Input.KeyEventArgs)e;
+                System.Windows.Input.KeyEventArgs eventArgs = (System.Windows.Input.KeyEventArgs)e;
                 if (eventArgs.Key != Key.Left && eventArgs.Key != Key.Right)
                 {
                     return;
@@ -118,9 +118,9 @@ namespace PowerPointLabs.PictureSlidesLab.Views
                 return;
             }
 
-            var selectedItem = StylesVariationListBox.SelectedValue as ImageItem;
+            ImageItem selectedItem = StylesVariationListBox.SelectedValue as ImageItem;
 
-            var currentCategory = (string) VariantsComboBox.SelectedValue;
+            string currentCategory = (string) VariantsComboBox.SelectedValue;
             if (currentCategory == PictureSlidesLabText.VariantCategoryFontFamily
                 && selectedItem != null
                 && selectedItem.Tooltip != PictureSlidesLabText.NoEffect)
@@ -141,9 +141,9 @@ namespace PowerPointLabs.PictureSlidesLab.Views
                 return;
             }
 
-            var selectedItem = StylesVariationListBox.SelectedValue as ImageItem;
+            ImageItem selectedItem = StylesVariationListBox.SelectedValue as ImageItem;
 
-            var currentCategory = (string) VariantsComboBox.SelectedValue;
+            string currentCategory = (string) VariantsComboBox.SelectedValue;
             if (currentCategory.Contains(PictureSlidesLabText.ColorHasEffect)
                  && selectedItem != null
                  && selectedItem.Tooltip != PictureSlidesLabText.NoEffect)
@@ -164,9 +164,9 @@ namespace PowerPointLabs.PictureSlidesLab.Views
                 return;
             }
 
-            var selectedItem = StylesVariationListBox.SelectedValue as ImageItem;
+            ImageItem selectedItem = StylesVariationListBox.SelectedValue as ImageItem;
 
-            var currentCategory = (string)VariantsComboBox.SelectedValue;
+            string currentCategory = (string)VariantsComboBox.SelectedValue;
             if (IsSliderSupported(currentCategory)
                  && selectedItem != null
                  && selectedItem.Tooltip != PictureSlidesLabText.NoEffect)
@@ -187,7 +187,7 @@ namespace PowerPointLabs.PictureSlidesLab.Views
                 return;
             }
 
-            var currentCategory = (string) VariantsComboBox.SelectedValue;
+            string currentCategory = (string) VariantsComboBox.SelectedValue;
             if (currentCategory == PictureSlidesLabText.VariantCategoryPicture)
             {
                 PictureAspectRefreshButton.Visibility = Visibility.Visible;

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Views/PictureSlidesLabWindow.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Views/PictureSlidesLabWindow.xaml.cs
@@ -149,7 +149,7 @@ namespace PowerPointLabs.PictureSlidesLab.Views
                 Logger.Log("PSL init styling begins");
                 // load back the style from the current slide, or
                 // select the first picture to preview styles
-                var isSuccessfullyLoaded = LoadStyleAndImage(this.GetCurrentSlide(),
+                bool isSuccessfullyLoaded = LoadStyleAndImage(this.GetCurrentSlide(),
                     isLoadingWithDefaultPicture: false);
                 if (ViewModel.ImageSelectionList.Count >= 2 && !isSuccessfullyLoaded)
                 {
@@ -263,7 +263,7 @@ namespace PowerPointLabs.PictureSlidesLab.Views
                 Logger.Log("Drop enter");
                 if (args.Data.GetDataPresent("FileDrop"))
                 {
-                    var filenames = (args.Data.GetData("FileDrop") as string[]);
+                    string[] filenames = (args.Data.GetData("FileDrop") as string[]);
                     if (filenames == null || filenames.Length == 0)
                     {
                         return;
@@ -276,7 +276,7 @@ namespace PowerPointLabs.PictureSlidesLab.Views
                 }
                 else if (args.Data.GetDataPresent("Text"))
                 {
-                    var imageUrl = args.Data.GetData("Text") as string;
+                    string imageUrl = args.Data.GetData("Text") as string;
                     ViewModel.AddImageSelectionListItem(imageUrl,
                         this.GetCurrentSlide().GetNativeSlide(),
                         this.GetCurrentPresentation().SlideWidth,
@@ -319,8 +319,8 @@ namespace PowerPointLabs.PictureSlidesLab.Views
         {
             try
             {
-                var pastedPicture = Clipboard.GetImage();
-                var pastedFiles = Clipboard.GetFileDropList();
+                System.Drawing.Image pastedPicture = Clipboard.GetImage();
+                StringCollection pastedFiles = Clipboard.GetFileDropList();
 
                 if (pastedPicture == null &&
                     (pastedFiles == null || pastedFiles.Count == 0))
@@ -340,7 +340,7 @@ namespace PowerPointLabs.PictureSlidesLab.Views
                 if (pastedPicture != null)
                 {
                     Logger.Log("Pasted enter");
-                    var pastedPictureFile = StoragePath.GetPath("pastedImg-"
+                    string pastedPictureFile = StoragePath.GetPath("pastedImg-"
                                                                 + DateTime.Now.GetHashCode() + "-"
                                                                 + Guid.NewGuid().ToString().Substring(0, 7));
                     pastedPicture.Save(pastedPictureFile);
@@ -467,7 +467,7 @@ namespace PowerPointLabs.PictureSlidesLab.Views
         /// <param name="e"></param>
         private void ListBox_OnKeyDown(object sender, KeyEventArgs e)
         {
-            var listbox = sender as ListBox;
+            ListBox listbox = sender as ListBox;
             if (listbox == null || listbox.Items.Count <= 0)
             {
                 return;
@@ -563,7 +563,7 @@ namespace PowerPointLabs.PictureSlidesLab.Views
         /// <param name="e"></param>
         private void StylesPreviewListBox_OnKeyUp(object sender, KeyEventArgs e)
         {
-            var listbox = sender as ListBox;
+            ListBox listbox = sender as ListBox;
             if (listbox == null || listbox.Items.Count <= 0)
             {
                 return;
@@ -643,7 +643,7 @@ namespace PowerPointLabs.PictureSlidesLab.Views
         /// <param name="e"></param>
         private void ImageSelectionListBox_OnPreviewMouseDown(object sender, MouseButtonEventArgs e)
         {
-            var item = ItemsControl.ContainerFromElement((ItemsControl) sender, (DependencyObject) e.OriginalSource) 
+            ListBoxItem item = ItemsControl.ContainerFromElement((ItemsControl) sender, (DependencyObject) e.OriginalSource) 
                 as ListBoxItem;
             if (item == null || item.Content == null)
             {
@@ -653,9 +653,9 @@ namespace PowerPointLabs.PictureSlidesLab.Views
             if (e.RightButton == MouseButtonState.Pressed)
             {
                 _clickedImageSelectionItemIndex = -1;
-                for (var i = 0; i < ImageSelectionListBox.Items.Count; i++)
+                for (int i = 0; i < ImageSelectionListBox.Items.Count; i++)
                 {
-                    var listBoxItem = ImageSelectionListBox.ItemContainerGenerator.ContainerFromIndex(i) 
+                    ListBoxItem listBoxItem = ImageSelectionListBox.ItemContainerGenerator.ContainerFromIndex(i) 
                         as ListBoxItem;
                     if (listBoxItem == null)
                     {
@@ -673,11 +673,11 @@ namespace PowerPointLabs.PictureSlidesLab.Views
             else if (e.LeftButton == MouseButtonState.Pressed)
             {
                 Logger.Log("begin import pictures");
-                var imageItem = item.Content as ImageItem;
+                ImageItem imageItem = item.Content as ImageItem;
                 if (imageItem != null
                     && imageItem.ImageFile == StoragePath.ChoosePicturesImgPath)
                 {
-                    var openFileDialog = new OpenFileDialog
+                    OpenFileDialog openFileDialog = new OpenFileDialog
                     {
                         Multiselect = true,
                         Filter = @"Image File|*.png;*.jpg;*.jpeg;*.bmp;*.gif;"
@@ -722,7 +722,7 @@ namespace PowerPointLabs.PictureSlidesLab.Views
                 return;
             }
 
-            var selectedImage = (ImageItem)ImageSelectionListBox.Items.GetItemAt(_clickedImageSelectionItemIndex);
+            ImageItem selectedImage = (ImageItem)ImageSelectionListBox.Items.GetItemAt(_clickedImageSelectionItemIndex);
             if (selectedImage == null || selectedImage.ImageFile == StoragePath.LoadingImgPath)
             {
                 return;
@@ -735,7 +735,7 @@ namespace PowerPointLabs.PictureSlidesLab.Views
         {
             if (ViewModel.IsInPictureVariation())
             {
-                var imageItem = ViewModel.GetSelectedPictureInPictureVariation(
+                ImageItem imageItem = ViewModel.GetSelectedPictureInPictureVariation(
                     StylesVariationListBox.SelectedIndex);
                 if (imageItem.ImageFile == StoragePath.NoPicturePlaceholderImgPath
                     || imageItem.ImageFile == StoragePath.LoadingImgPath)
@@ -746,7 +746,7 @@ namespace PowerPointLabs.PictureSlidesLab.Views
             }
             else
             {
-                var selectedImage = (ImageItem)ImageSelectionListBox.SelectedItem;
+                ImageItem selectedImage = (ImageItem)ImageSelectionListBox.SelectedItem;
                 if (selectedImage == null || selectedImage.ImageFile == StoragePath.LoadingImgPath)
                 {
                     return;
@@ -764,7 +764,7 @@ namespace PowerPointLabs.PictureSlidesLab.Views
                 return;
             }
 
-            var selectedImage = (ImageItem)ImageSelectionListBox.Items.GetItemAt(_clickedImageSelectionItemIndex);
+            ImageItem selectedImage = (ImageItem)ImageSelectionListBox.Items.GetItemAt(_clickedImageSelectionItemIndex);
             if (selectedImage == null || selectedImage.ImageFile == StoragePath.LoadingImgPath)
             {
                 return;
@@ -777,7 +777,7 @@ namespace PowerPointLabs.PictureSlidesLab.Views
         {
             if (ViewModel.IsInPictureVariation())
             {
-                var imageItem = ViewModel.GetSelectedPictureInPictureVariation(
+                ImageItem imageItem = ViewModel.GetSelectedPictureInPictureVariation(
                     StylesVariationListBox.SelectedIndex);
                 if (imageItem.ImageFile == StoragePath.NoPicturePlaceholderImgPath
                     || imageItem.ImageFile == StoragePath.LoadingImgPath)
@@ -788,7 +788,7 @@ namespace PowerPointLabs.PictureSlidesLab.Views
             }
             else
             {
-                var selectedImage = (ImageItem)ImageSelectionListBox.SelectedItem;
+                ImageItem selectedImage = (ImageItem)ImageSelectionListBox.SelectedItem;
                 if (selectedImage == null || selectedImage.ImageFile == StoragePath.LoadingImgPath)
                 {
                     return;
@@ -808,7 +808,7 @@ namespace PowerPointLabs.PictureSlidesLab.Views
             if (ViewModel.IsInPictureVariation()
                      && StylesVariationListBox.SelectedIndex >= 0)
             {
-                var selectedImageItem =
+                ImageItem selectedImageItem =
                     ViewModel
                     .GetSelectedPictureInPictureVariation(StylesVariationListBox.SelectedIndex);
                 if (selectedImageItem.ImageFile == StoragePath.NoPicturePlaceholderImgPath
@@ -885,15 +885,15 @@ namespace PowerPointLabs.PictureSlidesLab.Views
 
         private void AddCitationSlideButton_OnClick(object sender, RoutedEventArgs e)
         {
-            var presentation = this.GetCurrentPresentation();
+            Models.PowerPointPresentation presentation = this.GetCurrentPresentation();
             if (presentation.Slides.Any(PictureCitationSlide.IsCitationSlide))
             {
-                var citationSlide = presentation.Slides.Where(PictureCitationSlide.IsCitationSlide).First();
+                Models.PowerPointSlide citationSlide = presentation.Slides.Where(PictureCitationSlide.IsCitationSlide).First();
                 ViewModel.AddPictureCitationSlide(citationSlide.GetNativeSlide(), presentation.Slides);
             }
             else // no citation slide yet, so create one
             {
-                var slide = presentation.Presentation.Slides.Add(presentation.SlideCount + 1, PpSlideLayout.ppLayoutText);
+                Slide slide = presentation.Presentation.Slides.Add(presentation.SlideCount + 1, PpSlideLayout.ppLayoutText);
                 ViewModel.AddPictureCitationSlide(slide, presentation.Slides);
             }
             presentation.AddAckSlide();
@@ -947,7 +947,7 @@ namespace PowerPointLabs.PictureSlidesLab.Views
                 return;
             }
 
-            var selectedImage = (ImageItem) ImageSelectionListBox.Items.GetItemAt(_clickedImageSelectionItemIndex);
+            ImageItem selectedImage = (ImageItem) ImageSelectionListBox.Items.GetItemAt(_clickedImageSelectionItemIndex);
             if (selectedImage == null)
             {
                 return;
@@ -959,7 +959,7 @@ namespace PowerPointLabs.PictureSlidesLab.Views
 
         private void DeleteSelectedImage()
         {
-            var selectedImage = (ImageItem)ImageSelectionListBox.SelectedItem;
+            ImageItem selectedImage = (ImageItem)ImageSelectionListBox.SelectedItem;
             if (selectedImage == null
                 || ImageSelectionListBox.SelectedIndex == 0)
             {
@@ -972,7 +972,7 @@ namespace PowerPointLabs.PictureSlidesLab.Views
 
         private void EditPictureSource(ImageItem source)
         {
-            var metroDialogSettings = new MetroDialogSettings
+            MetroDialogSettings metroDialogSettings = new MetroDialogSettings
             {
                 DefaultText = source.Source
             };
@@ -1120,7 +1120,7 @@ namespace PowerPointLabs.PictureSlidesLab.Views
 
         private static bool IsMouseOverTarget(Visual target, Point point)
         {
-            var bounds = VisualTreeHelper.GetDescendantBounds(target);
+            Rect bounds = VisualTreeHelper.GetDescendantBounds(target);
             return bounds.Contains(point);
         }
 
@@ -1133,10 +1133,10 @@ namespace PowerPointLabs.PictureSlidesLab.Views
                     return;
                 }
 
-                var left2RightToShowTranslate = new TranslateTransform { X = -StylesPreviewGrid.ActualWidth };
+                TranslateTransform left2RightToShowTranslate = new TranslateTransform { X = -StylesPreviewGrid.ActualWidth };
                 StyleVariationsFlyout.RenderTransform = left2RightToShowTranslate;
                 StyleVariationsFlyout.Visibility = Visibility.Visible;
-                var left2RightToShowAnimation = new DoubleAnimation(-StylesPreviewGrid.ActualWidth, 0,
+                DoubleAnimation left2RightToShowAnimation = new DoubleAnimation(-StylesPreviewGrid.ActualWidth, 0,
                     TimeSpan.FromMilliseconds(350))
                 {
                     EasingFunction = new SineEase { EasingMode = EasingMode.EaseInOut },
@@ -1155,9 +1155,9 @@ namespace PowerPointLabs.PictureSlidesLab.Views
                 return;
             }
 
-            var right2LeftToHideTranslate = new TranslateTransform();
+            TranslateTransform right2LeftToHideTranslate = new TranslateTransform();
             StyleVariationsFlyout.RenderTransform = right2LeftToHideTranslate;
-            var right2LeftToHideAnimation = new DoubleAnimation(0, -StyleVariationsFlyout.ActualWidth,
+            DoubleAnimation right2LeftToHideAnimation = new DoubleAnimation(0, -StyleVariationsFlyout.ActualWidth,
                 TimeSpan.FromMilliseconds(350))
             {
                 EasingFunction = new SineEase { EasingMode = EasingMode.EaseInOut },
@@ -1201,7 +1201,7 @@ namespace PowerPointLabs.PictureSlidesLab.Views
                     // when it's to load the design for a default picture,
                     // and it's at the variation stage,
                     // directly jump to picture variation to select picture
-                    var picVariationIndex = ViewModel.VariantsCategory.IndexOf(
+                    int picVariationIndex = ViewModel.VariantsCategory.IndexOf(
                         PictureSlidesLabText.VariantCategoryPicture);
                     if (VariantsComboBox.SelectedIndex != picVariationIndex)
                     {
@@ -1285,7 +1285,7 @@ namespace PowerPointLabs.PictureSlidesLab.Views
         /// <param name="time">time in ms</param>
         private void SetTimeout(Action action, int time)
         {
-            var timer = new DispatcherTimer(DispatcherPriority.Render)
+            DispatcherTimer timer = new DispatcherTimer(DispatcherPriority.Render)
             {
                 Interval = new TimeSpan(0, 0, 0, 0, time) // in ms
             };
@@ -1319,7 +1319,7 @@ namespace PowerPointLabs.PictureSlidesLab.Views
                     return true;
                 }
 
-                var propertyInfo = typeof(Window).GetProperty("IsDisposed", 
+                System.Reflection.PropertyInfo propertyInfo = typeof(Window).GetProperty("IsDisposed", 
                     System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
                 return (bool) propertyInfo.GetValue(this, null);
             }

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Views/QuickDropDialog.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Views/QuickDropDialog.xaml.cs
@@ -28,7 +28,7 @@ namespace PowerPointLabs.PictureSlidesLab.Views
         {
             get
             {
-                var propertyInfo = typeof(Window).GetProperty("IsDisposed",
+                System.Reflection.PropertyInfo propertyInfo = typeof(Window).GetProperty("IsDisposed",
                     System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
                 return (bool) propertyInfo.GetValue(this, null);
             }

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Views/SettingsFlyout.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Views/SettingsFlyout.xaml.cs
@@ -62,13 +62,13 @@ namespace PowerPointLabs.PictureSlidesLab.Views
 
         private void ColorPanel_OnMouseLeftButtonUp(object sender, MouseButtonEventArgs e)
         {
-            var panel = sender as Border;
+            Border panel = sender as Border;
             if (panel == null)
             {
                 return;
             }
 
-            var colorDialog = new ColorDialog
+            ColorDialog colorDialog = new ColorDialog
             {
                 Color = GetColor(panel.Background as SolidColorBrush),
                 FullOpen = true
@@ -78,8 +78,8 @@ namespace PowerPointLabs.PictureSlidesLab.Views
                 return;
             }
 
-            var hexString = StringUtil.GetHexValue(colorDialog.Color);
-            var settings = DataContext as Settings;
+            string hexString = StringUtil.GetHexValue(colorDialog.Color);
+            Settings settings = DataContext as Settings;
             if (settings == null)
             {
                 return;

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Views/SlideSelectionDialog.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Views/SlideSelectionDialog.xaml.cs
@@ -67,11 +67,11 @@ namespace PowerPointLabs.PictureSlidesLab.Views
             {
                 SlideList.Clear();
             }));
-            var currentSlide = this.GetCurrentSlide();
+            PowerPointSlide currentSlide = this.GetCurrentSlide();
             if (currentSlide.Index - 2 >= 0)
             {
                 _prevSlideIndex = currentSlide.Index - 2;
-                var prevSlide = this.GetCurrentPresentation().Slides[currentSlide.Index - 2];
+                PowerPointSlide prevSlide = this.GetCurrentPresentation().Slides[currentSlide.Index - 2];
                 AddSlideThumbnail(prevSlide);
             }
             else
@@ -84,7 +84,7 @@ namespace PowerPointLabs.PictureSlidesLab.Views
             if (currentSlide.Index < this.GetCurrentPresentation().SlideCount)
             {
                 _nextSlideIndex = currentSlide.Index;
-                var nextSlide = this.GetCurrentPresentation().Slides[currentSlide.Index];
+                PowerPointSlide nextSlide = this.GetCurrentPresentation().Slides[currentSlide.Index];
                 AddSlideThumbnail(nextSlide);
             }
             else
@@ -127,7 +127,7 @@ namespace PowerPointLabs.PictureSlidesLab.Views
 
         private void SelectCurrentSlide()
         {
-            foreach (var slide in SlideList)
+            foreach (ImageItem slide in SlideList)
             {
                 if (slide.Tooltip.Contains("Current"))
                 {
@@ -143,7 +143,7 @@ namespace PowerPointLabs.PictureSlidesLab.Views
                 return;
             }
 
-            var thumbnailPath = TempPath.GetPath("slide-" + DateTime.Now.GetHashCode() + slide.Index);
+            string thumbnailPath = TempPath.GetPath("slide-" + DateTime.Now.GetHashCode() + slide.Index);
             slide.GetNativeSlide().Export(thumbnailPath, "JPG", GetPreviewWidth(), PreviewHeight);
 
             ImageItem imageItem;
@@ -216,7 +216,7 @@ namespace PowerPointLabs.PictureSlidesLab.Views
             {
                 GotoSlideButton.IsEnabled = true;
                 // obtain selected slide
-                var selectedItem = (ImageItem) SlideListBox.SelectedItem;
+                ImageItem selectedItem = (ImageItem) SlideListBox.SelectedItem;
                 if (selectedItem.Tooltip.Contains("Current"))
                 {
                     SelectedSlide = Int32.Parse(selectedItem.Tooltip.Substring(16));   
@@ -230,7 +230,7 @@ namespace PowerPointLabs.PictureSlidesLab.Views
 
         private void PrevButton_OnClick(object sender, RoutedEventArgs e)
         {
-            var selectedIndex = SlideListBox.SelectedIndex;
+            int selectedIndex = SlideListBox.SelectedIndex;
             if (selectedIndex - 1 >= 0)
             {
                 SlideListBox.SelectedIndex = selectedIndex - 1;
@@ -244,18 +244,18 @@ namespace PowerPointLabs.PictureSlidesLab.Views
 
         private void LoadPreviousSlides(bool isToSelectPrevSlide = true)
         {
-            var newPrevSlideIndex = _prevSlideIndex;
+            int newPrevSlideIndex = _prevSlideIndex;
 
             if (_prevSlideIndex - 3 >= 0)
             {
                 newPrevSlideIndex = _prevSlideIndex - 3;
-                var prevSlide = this.GetCurrentPresentation().Slides[_prevSlideIndex - 3];
+                PowerPointSlide prevSlide = this.GetCurrentPresentation().Slides[_prevSlideIndex - 3];
                 AddSlideThumbnail(prevSlide, 0);
             }
 
             if (_prevSlideIndex - 2 >= 0)
             {
-                var prevSlide = this.GetCurrentPresentation().Slides[_prevSlideIndex - 2];
+                PowerPointSlide prevSlide = this.GetCurrentPresentation().Slides[_prevSlideIndex - 2];
                 if (_prevSlideIndex - 3 >= 0)
                 {
                     AddSlideThumbnail(prevSlide, 1);
@@ -269,7 +269,7 @@ namespace PowerPointLabs.PictureSlidesLab.Views
 
             if (_prevSlideIndex - 1 >= 0)
             {
-                var prevSlide = this.GetCurrentPresentation().Slides[_prevSlideIndex - 1];
+                PowerPointSlide prevSlide = this.GetCurrentPresentation().Slides[_prevSlideIndex - 1];
                 if (_prevSlideIndex - 3 >= 0)
                 {
                     AddSlideThumbnail(prevSlide, 2);
@@ -295,7 +295,7 @@ namespace PowerPointLabs.PictureSlidesLab.Views
 
         private void NextButton_OnClick(object sender, RoutedEventArgs e)
         {
-            var selectedIndex = SlideListBox.SelectedIndex;
+            int selectedIndex = SlideListBox.SelectedIndex;
             if (selectedIndex + 1 < SlideListBox.Items.Count)
             {
                 SlideListBox.SelectedIndex = selectedIndex + 1;
@@ -309,25 +309,25 @@ namespace PowerPointLabs.PictureSlidesLab.Views
 
         private void LoadNextSlides(bool isToSelectNextSlide = true)
         {
-            var newNextSlideIndex = _nextSlideIndex;
+            int newNextSlideIndex = _nextSlideIndex;
 
             if (_nextSlideIndex + 1 < this.GetCurrentPresentation().SlideCount)
             {
-                var nextSlide = this.GetCurrentPresentation().Slides[_nextSlideIndex + 1];
+                PowerPointSlide nextSlide = this.GetCurrentPresentation().Slides[_nextSlideIndex + 1];
                 newNextSlideIndex = _nextSlideIndex + 1;
                 AddSlideThumbnail(nextSlide);
             }
 
             if (_nextSlideIndex + 2 < this.GetCurrentPresentation().SlideCount)
             {
-                var nextSlide = this.GetCurrentPresentation().Slides[_nextSlideIndex + 2];
+                PowerPointSlide nextSlide = this.GetCurrentPresentation().Slides[_nextSlideIndex + 2];
                 newNextSlideIndex = _nextSlideIndex + 2;
                 AddSlideThumbnail(nextSlide);
             }
 
             if (_nextSlideIndex + 3 < this.GetCurrentPresentation().SlideCount)
             {
-                var nextSlide = this.GetCurrentPresentation().Slides[_nextSlideIndex + 3];
+                PowerPointSlide nextSlide = this.GetCurrentPresentation().Slides[_nextSlideIndex + 3];
                 newNextSlideIndex = _nextSlideIndex + 3;
                 AddSlideThumbnail(nextSlide);
             }
@@ -342,7 +342,7 @@ namespace PowerPointLabs.PictureSlidesLab.Views
 
         private void SlideListBox_OnMouseDoubleClick(object sender, MouseButtonEventArgs e)
         {
-            var item = ItemsControl.ContainerFromElement((ItemsControl)sender, (DependencyObject)e.OriginalSource)
+            ListBoxItem item = ItemsControl.ContainerFromElement((ItemsControl)sender, (DependencyObject)e.OriginalSource)
                 as ListBoxItem;
             if (item == null || item.Content == null)
             {

--- a/PowerPointLabs/PowerPointLabs/PositionsLab/PositionsLabMain.cs
+++ b/PowerPointLabs/PowerPointLabs/PositionsLab/PositionsLabMain.cs
@@ -82,13 +82,13 @@ namespace PowerPointLabs.PositionsLab
         #region Align
         public static void AlignLeft(ShapeRange toAlign)
         {
-            var selectedShapes = new List<PPShape>();
+            List<PPShape> selectedShapes = new List<PPShape>();
 
             switch (PositionsLabSettings.AlignReference)
             {
                 case PositionsLabSettings.AlignReferenceObject.Slide:
                     selectedShapes = ConvertShapeRangeToPPShapeList(toAlign);
-                    foreach (var s in selectedShapes)
+                    foreach (PPShape s in selectedShapes)
                     {
                         s.IncrementLeft(-s.VisualLeft);
                     }
@@ -100,11 +100,11 @@ namespace PowerPointLabs.PositionsLab
                     }
 
                     selectedShapes = ConvertShapeRangeToPPShapeList(toAlign);
-                    var refShape = selectedShapes[0];
+                    PPShape refShape = selectedShapes[0];
 
-                    for (var i = 1; i < selectedShapes.Count; i++)
+                    for (int i = 1; i < selectedShapes.Count; i++)
                     {
-                        var s = selectedShapes[i];
+                        PPShape s = selectedShapes[i];
                         s.IncrementLeft(refShape.VisualLeft - s.VisualLeft);
                     }
                     break;
@@ -127,13 +127,13 @@ namespace PowerPointLabs.PositionsLab
         public static void AlignRight(ShapeRange toAlign, float slideWidth)
         {
 
-            var selectedShapes = new List<PPShape>();
+            List<PPShape> selectedShapes = new List<PPShape>();
 
             switch (PositionsLabSettings.AlignReference)
             {
                 case PositionsLabSettings.AlignReferenceObject.Slide:
                     selectedShapes = ConvertShapeRangeToPPShapeList(toAlign);
-                    foreach (var s in selectedShapes)
+                    foreach (PPShape s in selectedShapes)
                     {
                         s.IncrementLeft(slideWidth - s.VisualLeft - s.AbsoluteWidth);
                     }
@@ -145,13 +145,13 @@ namespace PowerPointLabs.PositionsLab
                     }
 
                     selectedShapes = ConvertShapeRangeToPPShapeList(toAlign);
-                    var refShape = selectedShapes[0];
-                    var rightMostRefPoint = refShape.VisualLeft + refShape.AbsoluteWidth;
+                    PPShape refShape = selectedShapes[0];
+                    float rightMostRefPoint = refShape.VisualLeft + refShape.AbsoluteWidth;
 
-                    for (var i = 1; i < selectedShapes.Count; i++)
+                    for (int i = 1; i < selectedShapes.Count; i++)
                     {
-                        var s = selectedShapes[i];
-                        var rightMostPoint = s.VisualLeft + s.AbsoluteWidth;
+                        PPShape s = selectedShapes[i];
+                        float rightMostPoint = s.VisualLeft + s.AbsoluteWidth;
                         s.IncrementLeft(rightMostRefPoint - rightMostPoint);
                     }
                     break;
@@ -172,13 +172,13 @@ namespace PowerPointLabs.PositionsLab
 
         public static void AlignTop(ShapeRange toAlign)   
         {
-            var selectedShapes = new List<PPShape>();
+            List<PPShape> selectedShapes = new List<PPShape>();
 
             switch (PositionsLabSettings.AlignReference)
             {
                 case PositionsLabSettings.AlignReferenceObject.Slide:
                     selectedShapes = ConvertShapeRangeToPPShapeList(toAlign);
-                    foreach (var s in selectedShapes)
+                    foreach (PPShape s in selectedShapes)
                     {
                         s.IncrementTop(-s.VisualTop);
                     }
@@ -190,11 +190,11 @@ namespace PowerPointLabs.PositionsLab
                     }
 
                     selectedShapes = ConvertShapeRangeToPPShapeList(toAlign);
-                    var refShape = selectedShapes[0];
+                    PPShape refShape = selectedShapes[0];
 
-                    for (var i = 1; i < selectedShapes.Count; i++)
+                    for (int i = 1; i < selectedShapes.Count; i++)
                     {
-                        var s = selectedShapes[i];
+                        PPShape s = selectedShapes[i];
                         s.IncrementTop(refShape.VisualTop - s.VisualTop);
                     }
                     break;
@@ -215,13 +215,13 @@ namespace PowerPointLabs.PositionsLab
 
         public static void AlignBottom(ShapeRange toAlign, float slideHeight)
         {
-            var selectedShapes = new List<PPShape>();
+            List<PPShape> selectedShapes = new List<PPShape>();
 
             switch (PositionsLabSettings.AlignReference)
             {
                 case PositionsLabSettings.AlignReferenceObject.Slide:
                     selectedShapes = ConvertShapeRangeToPPShapeList(toAlign);
-                    foreach (var s in selectedShapes)
+                    foreach (PPShape s in selectedShapes)
                     {
                         s.IncrementTop(slideHeight - s.VisualTop - s.AbsoluteHeight);
                     }
@@ -233,13 +233,13 @@ namespace PowerPointLabs.PositionsLab
                     }
 
                     selectedShapes = ConvertShapeRangeToPPShapeList(toAlign);
-                    var refShape = selectedShapes[0];
-                    var lowestRefPoint = refShape.VisualTop + refShape.AbsoluteHeight;
+                    PPShape refShape = selectedShapes[0];
+                    float lowestRefPoint = refShape.VisualTop + refShape.AbsoluteHeight;
 
-                    for (var i = 1; i < selectedShapes.Count; i++)
+                    for (int i = 1; i < selectedShapes.Count; i++)
                     {
-                        var s = selectedShapes[i];
-                        var lowestPoint = s.VisualTop + s.AbsoluteHeight;
+                        PPShape s = selectedShapes[i];
+                        float lowestPoint = s.VisualTop + s.AbsoluteHeight;
                         s.IncrementTop(lowestRefPoint - lowestPoint);
                     }
                     break;
@@ -260,13 +260,13 @@ namespace PowerPointLabs.PositionsLab
 
         public static void AlignHorizontalCenter(ShapeRange toAlign, float slideHeight)
         {
-            var selectedShapes = new List<PPShape>();
+            List<PPShape> selectedShapes = new List<PPShape>();
 
             switch (PositionsLabSettings.AlignReference)
             {
                 case PositionsLabSettings.AlignReferenceObject.Slide:
                     selectedShapes = ConvertShapeRangeToPPShapeList(toAlign);
-                    foreach (var s in selectedShapes)
+                    foreach (PPShape s in selectedShapes)
                     {
                         s.IncrementTop(slideHeight / 2 - s.VisualTop - s.AbsoluteHeight / 2);
                     }
@@ -278,11 +278,11 @@ namespace PowerPointLabs.PositionsLab
                     }
 
                     selectedShapes = ConvertShapeRangeToPPShapeList(toAlign);
-                    var refShape = selectedShapes[0];
+                    PPShape refShape = selectedShapes[0];
 
-                    for (var i = 1; i < selectedShapes.Count; i++)
+                    for (int i = 1; i < selectedShapes.Count; i++)
                     {
-                        var s = selectedShapes[i];
+                        PPShape s = selectedShapes[i];
                         s.IncrementTop(refShape.VisualCenter.Y - s.VisualCenter.Y);
                     }
                     break;
@@ -303,13 +303,13 @@ namespace PowerPointLabs.PositionsLab
 
         public static void AlignVerticalCenter(ShapeRange toAlign, float slideWidth)
         {
-            var selectedShapes = new List<PPShape>();
+            List<PPShape> selectedShapes = new List<PPShape>();
 
             switch (PositionsLabSettings.AlignReference)
             {
                 case PositionsLabSettings.AlignReferenceObject.Slide:
                     selectedShapes = ConvertShapeRangeToPPShapeList(toAlign);
-                    foreach (var s in selectedShapes)
+                    foreach (PPShape s in selectedShapes)
                     {
                         s.IncrementLeft(slideWidth / 2 - s.VisualLeft - s.AbsoluteWidth / 2);
                     }
@@ -321,11 +321,11 @@ namespace PowerPointLabs.PositionsLab
                     }
 
                     selectedShapes = ConvertShapeRangeToPPShapeList(toAlign);
-                    var refShape = selectedShapes[0];
+                    PPShape refShape = selectedShapes[0];
 
-                    for (var i = 1; i < selectedShapes.Count; i++)
+                    for (int i = 1; i < selectedShapes.Count; i++)
                     {
-                        var s = selectedShapes[i];
+                        PPShape s = selectedShapes[i];
                         s.IncrementLeft(refShape.VisualCenter.X - s.VisualCenter.X);
                     }
                     break;
@@ -346,13 +346,13 @@ namespace PowerPointLabs.PositionsLab
 
         public static void AlignCenter(ShapeRange toAlign, float slideHeight, float slideWidth)
         {
-            var selectedShapes = new List<PPShape>();
+            List<PPShape> selectedShapes = new List<PPShape>();
 
             switch (PositionsLabSettings.AlignReference)
             {
                 case PositionsLabSettings.AlignReferenceObject.Slide:
                     selectedShapes = ConvertShapeRangeToPPShapeList(toAlign);
-                    foreach (var s in selectedShapes)
+                    foreach (PPShape s in selectedShapes)
                     {
                         s.IncrementTop(slideHeight / 2 - s.VisualTop - s.AbsoluteHeight / 2);
                         s.IncrementLeft(slideWidth / 2 - s.VisualLeft - s.AbsoluteWidth / 2);
@@ -365,11 +365,11 @@ namespace PowerPointLabs.PositionsLab
                     }
 
                     selectedShapes = ConvertShapeRangeToPPShapeList(toAlign);
-                    var refShape = selectedShapes[0];
+                    PPShape refShape = selectedShapes[0];
 
-                    for (var i = 1; i < selectedShapes.Count; i++)
+                    for (int i = 1; i < selectedShapes.Count; i++)
                     {
-                        var s = selectedShapes[i];
+                        PPShape s = selectedShapes[i];
                         s.IncrementTop(refShape.VisualCenter.Y - s.VisualCenter.Y);
                         s.IncrementLeft(refShape.VisualCenter.X - s.VisualCenter.X);
                     }
@@ -398,16 +398,16 @@ namespace PowerPointLabs.PositionsLab
                 throw new Exception(PositionsLabText.ErrorFewerThanThreeSelection);
             }
                     
-            var origin = ShapeUtil.GetCenterPoint(selectedShapes[1]);
-            var refPoint = ShapeUtil.GetCenterPoint(selectedShapes[2]);
-            var distance = DistanceBetweenTwoPoints(origin, refPoint);
+            Drawing.PointF origin = ShapeUtil.GetCenterPoint(selectedShapes[1]);
+            Drawing.PointF refPoint = ShapeUtil.GetCenterPoint(selectedShapes[2]);
+            double distance = DistanceBetweenTwoPoints(origin, refPoint);
 
-            for (var i = 3; i <= selectedShapes.Count; i++)
+            for (int i = 3; i <= selectedShapes.Count; i++)
             {
-                var shape = selectedShapes[i];
-                var point = ShapeUtil.GetCenterPoint(shape);
-                var currentDistance = DistanceBetweenTwoPoints(origin, point);
-                var proportion = (currentDistance - distance) / currentDistance;
+                Shape shape = selectedShapes[i];
+                Drawing.PointF point = ShapeUtil.GetCenterPoint(shape);
+                double currentDistance = DistanceBetweenTwoPoints(origin, point);
+                double proportion = (currentDistance - distance) / currentDistance;
 
                 shape.IncrementLeft((float)((origin.X - point.X) * proportion));
                 shape.IncrementTop((float)((origin.Y - point.Y) * proportion));
@@ -424,16 +424,16 @@ namespace PowerPointLabs.PositionsLab
                 throw new Exception(PositionsLabText.ErrorFewerThanTwoSelection);
             }
 
-            var refShape = selectedShapes[0];
-            var sortedShapes = ShapeUtil.SortShapesByLeft(selectedShapes);
-            var refShapeIndex = sortedShapes.IndexOf(refShape);
+            PPShape refShape = selectedShapes[0];
+            List<PPShape> sortedShapes = ShapeUtil.SortShapesByLeft(selectedShapes);
+            int refShapeIndex = sortedShapes.IndexOf(refShape);
 
-            var mostLeft = refShape.VisualLeft;
+            float mostLeft = refShape.VisualLeft;
             //For all shapes left of refShape, adjoin them from closest to refShape
-            for (var i = refShapeIndex - 1; i >= 0; i--)
+            for (int i = refShapeIndex - 1; i >= 0; i--)
             {
-                var neighbour = sortedShapes[i];
-                var rightOfNeighbour = neighbour.VisualLeft + neighbour.AbsoluteWidth;
+                PPShape neighbour = sortedShapes[i];
+                float rightOfNeighbour = neighbour.VisualLeft + neighbour.AbsoluteWidth;
                 neighbour.IncrementLeft(mostLeft - rightOfNeighbour);
                 if (AlignShapesToBeAdjoined)
                 {
@@ -443,11 +443,11 @@ namespace PowerPointLabs.PositionsLab
                 mostLeft = mostLeft - neighbour.AbsoluteWidth;
             }
 
-            var mostRight = refShape.VisualLeft + refShape.AbsoluteWidth;
+            float mostRight = refShape.VisualLeft + refShape.AbsoluteWidth;
             //For all shapes right of refShape, adjoin them from closest to refShape
-            for (var i = refShapeIndex + 1; i < sortedShapes.Count; i++)
+            for (int i = refShapeIndex + 1; i < sortedShapes.Count; i++)
             {
-                var neighbour = sortedShapes[i];
+                PPShape neighbour = sortedShapes[i];
                 neighbour.IncrementLeft(mostRight - neighbour.VisualLeft);
                 if (AlignShapesToBeAdjoined)
                 {
@@ -465,16 +465,16 @@ namespace PowerPointLabs.PositionsLab
                 throw new Exception(PositionsLabText.ErrorFewerThanTwoSelection);
             }
 
-            var refShape = selectedShapes[0];
-            var sortedShapes = ShapeUtil.SortShapesByTop(selectedShapes);
-            var refShapeIndex = sortedShapes.IndexOf(refShape);
+            PPShape refShape = selectedShapes[0];
+            List<PPShape> sortedShapes = ShapeUtil.SortShapesByTop(selectedShapes);
+            int refShapeIndex = sortedShapes.IndexOf(refShape);
 
-            var mostTop = refShape.VisualTop;
+            float mostTop = refShape.VisualTop;
             //For all shapes above refShape, adjoin them from closest to refShape
-            for (var i = refShapeIndex - 1; i >= 0; i--)
+            for (int i = refShapeIndex - 1; i >= 0; i--)
             {
-                var neighbour = sortedShapes[i];
-                var bottomOfNeighbour = neighbour.VisualTop + neighbour.AbsoluteHeight;
+                PPShape neighbour = sortedShapes[i];
+                float bottomOfNeighbour = neighbour.VisualTop + neighbour.AbsoluteHeight;
                 if (AlignShapesToBeAdjoined)
                 {
                     neighbour.IncrementLeft(refShape.VisualCenter.X - neighbour.VisualCenter.X);
@@ -484,11 +484,11 @@ namespace PowerPointLabs.PositionsLab
                 mostTop = mostTop - neighbour.AbsoluteHeight;
             }
 
-            var lowest = refShape.VisualTop + refShape.AbsoluteHeight;
+            float lowest = refShape.VisualTop + refShape.AbsoluteHeight;
             //For all shapes right of refShape, adjoin them from closest to refShape
-            for (var i = refShapeIndex + 1; i < sortedShapes.Count; i++)
+            for (int i = refShapeIndex + 1; i < sortedShapes.Count; i++)
             {
-                var neighbour = sortedShapes[i];
+                PPShape neighbour = sortedShapes[i];
                 if (AlignShapesToBeAdjoined)
                 {
                     neighbour.IncrementLeft(refShape.VisualCenter.X - neighbour.VisualCenter.X);
@@ -526,7 +526,7 @@ namespace PowerPointLabs.PositionsLab
                 referenceWidth = slideWidth;
                 shapesToDistribute = ShapeUtil.SortShapesByLeft(selectedShapes);
 
-                foreach (var s in shapesToDistribute)
+                foreach (PPShape s in shapesToDistribute)
                 {
                     totalShapeWidth += s.AbsoluteWidth;
                 }
@@ -541,9 +541,9 @@ namespace PowerPointLabs.PositionsLab
                     spaceBetweenShapes = (referenceWidth - totalShapeWidth) / (shapesToDistribute.Count + 1);
                 }
 
-                for (var i = 0; i < shapesToDistribute.Count; i++)
+                for (int i = 0; i < shapesToDistribute.Count; i++)
                 {
-                    var currShape = shapesToDistribute[i];
+                    PPShape currShape = shapesToDistribute[i];
 
                     // Check if need leading and trailing space
                     if (i == 0)
@@ -578,15 +578,15 @@ namespace PowerPointLabs.PositionsLab
                 referenceWidth = slideWidth;
                 shapesToDistribute = ShapeUtil.SortShapesByLeft(selectedShapes);
 
-                foreach (var s in shapesToDistribute)
+                foreach (PPShape s in shapesToDistribute)
                 {
                     totalShapeWidth += s.AbsoluteWidth;
                 }
 
                 if (totalShapeWidth > referenceWidth)
                 {
-                    var leftMostShape = shapesToDistribute[0];
-                    var rightMostShape = shapesToDistribute[shapesToDistribute.Count - 1];
+                    PPShape leftMostShape = shapesToDistribute[0];
+                    PPShape rightMostShape = shapesToDistribute[shapesToDistribute.Count - 1];
 
                     leftMostShape.IncrementLeft(startingPoint - leftMostShape.VisualLeft);
                     rightMostShape.IncrementLeft(referenceWidth - rightMostShape.VisualLeft - rightMostShape.AbsoluteWidth);
@@ -603,9 +603,9 @@ namespace PowerPointLabs.PositionsLab
                     spaceBetweenShapes = referenceWidth/(shapesToDistribute.Count + 1);
                 }
 
-                for (var i = 0; i < shapesToDistribute.Count; i++)
+                for (int i = 0; i < shapesToDistribute.Count; i++)
                 {
-                    var currShape = shapesToDistribute[i];
+                    PPShape currShape = shapesToDistribute[i];
                     if (i == 0)
                     {
                         currShape.IncrementLeft(startingPoint - currShape.VisualCenter.X + spaceBetweenShapes);
@@ -633,7 +633,7 @@ namespace PowerPointLabs.PositionsLab
                 shapesToDistribute.RemoveAt(0);
                 shapesToDistribute = ShapeUtil.SortShapesByLeft(shapesToDistribute);
 
-                foreach (var s in shapesToDistribute)
+                foreach (PPShape s in shapesToDistribute)
                 {
                     totalShapeWidth += s.AbsoluteWidth;
                 }
@@ -648,9 +648,9 @@ namespace PowerPointLabs.PositionsLab
                     spaceBetweenShapes = (referenceWidth - totalShapeWidth) / (shapesToDistribute.Count + 1);
                 } 
 
-                for (var i =0; i <shapesToDistribute.Count; i++)
+                for (int i =0; i <shapesToDistribute.Count; i++)
                 {
-                    var currShape = shapesToDistribute[i];
+                    PPShape currShape = shapesToDistribute[i];
 
                     // Check if need leading and trailing space
                     if (i==0)
@@ -687,15 +687,15 @@ namespace PowerPointLabs.PositionsLab
                 shapesToDistribute.RemoveAt(0);
                 shapesToDistribute = ShapeUtil.SortShapesByLeft(shapesToDistribute);
 
-                foreach (var s in shapesToDistribute)
+                foreach (PPShape s in shapesToDistribute)
                 {
                     totalShapeWidth += s.AbsoluteWidth;
                 }
 
                 if (totalShapeWidth > referenceWidth)
                 {
-                    var leftMostShape = shapesToDistribute[0];
-                    var rightMostShape = shapesToDistribute[shapesToDistribute.Count - 1];
+                    PPShape leftMostShape = shapesToDistribute[0];
+                    PPShape rightMostShape = shapesToDistribute[shapesToDistribute.Count - 1];
 
                     leftMostShape.IncrementLeft(startingPoint - leftMostShape.VisualLeft);
                     rightMostShape.IncrementLeft(startingPoint + referenceWidth - rightMostShape.VisualLeft - rightMostShape.AbsoluteWidth);
@@ -712,9 +712,9 @@ namespace PowerPointLabs.PositionsLab
                     spaceBetweenShapes = referenceWidth / (shapesToDistribute.Count + 1);
                 }
 
-                for (var i = 0; i < shapesToDistribute.Count; i++)
+                for (int i = 0; i < shapesToDistribute.Count; i++)
                 {
-                    var currShape = shapesToDistribute[i];
+                    PPShape currShape = shapesToDistribute[i];
                     if (i == 0)
                     {
                         currShape.IncrementLeft(startingPoint - currShape.VisualCenter.X + spaceBetweenShapes);
@@ -740,7 +740,7 @@ namespace PowerPointLabs.PositionsLab
 
                 if (shapesToDistribute[0].VisualLeft > shapesToDistribute[1].VisualLeft)
                 {
-                    var temp = shapesToDistribute[0];
+                    PPShape temp = shapesToDistribute[0];
                     shapesToDistribute[0] = shapesToDistribute[1];
                     shapesToDistribute[1] = temp;
                 }
@@ -748,7 +748,7 @@ namespace PowerPointLabs.PositionsLab
                 startingPoint = shapesToDistribute[0].VisualLeft + shapesToDistribute[0].AbsoluteWidth;
                 referenceWidth = shapesToDistribute[1].VisualLeft + shapesToDistribute[1].AbsoluteWidth - shapesToDistribute[0].VisualLeft;
 
-                foreach (var s in shapesToDistribute)
+                foreach (PPShape s in shapesToDistribute)
                 {
                     totalShapeWidth += s.AbsoluteWidth;
                 }
@@ -758,9 +758,9 @@ namespace PowerPointLabs.PositionsLab
                 shapesToDistribute.RemoveAt(0);
                 shapesToDistribute = ShapeUtil.SortShapesByLeft(shapesToDistribute);
 
-                for (var i = 0; i < shapesToDistribute.Count; i++)
+                for (int i = 0; i < shapesToDistribute.Count; i++)
                 {
-                    var currShape = shapesToDistribute[i];
+                    PPShape currShape = shapesToDistribute[i];
                     if (i==0)
                     {
                         currShape.IncrementLeft(startingPoint - currShape.VisualLeft + spaceBetweenShapes);
@@ -786,7 +786,7 @@ namespace PowerPointLabs.PositionsLab
 
                 if (shapesToDistribute[0].VisualLeft > shapesToDistribute[1].VisualLeft)
                 {
-                    var temp = shapesToDistribute[0];
+                    PPShape temp = shapesToDistribute[0];
                     shapesToDistribute[0] = shapesToDistribute[1];
                     shapesToDistribute[1] = temp;
                 }
@@ -794,7 +794,7 @@ namespace PowerPointLabs.PositionsLab
                 startingPoint = shapesToDistribute[0].VisualCenter.X;
                 referenceWidth = shapesToDistribute[1].VisualCenter.X -shapesToDistribute[0].VisualCenter.X;
 
-                foreach (var s in shapesToDistribute)
+                foreach (PPShape s in shapesToDistribute)
                 {
                     totalShapeWidth += s.AbsoluteWidth;
                 }
@@ -805,9 +805,9 @@ namespace PowerPointLabs.PositionsLab
 
                 shapesToDistribute = ShapeUtil.SortShapesByLeft(shapesToDistribute);
 
-                for (var i = 0; i < shapesToDistribute.Count; i++)
+                for (int i = 0; i < shapesToDistribute.Count; i++)
                 {
-                    var currShape = shapesToDistribute[i];
+                    PPShape currShape = shapesToDistribute[i];
                     if (i == 0)
                     {
                         currShape.IncrementLeft(startingPoint - currShape.VisualCenter.X + spaceBetweenShapes);
@@ -831,10 +831,10 @@ namespace PowerPointLabs.PositionsLab
 
                 shapesToDistribute = ShapeUtil.SortShapesByLeft(selectedShapes);
                 startingPoint = shapesToDistribute[0].VisualLeft + shapesToDistribute[0].AbsoluteWidth;
-                var rightMostShape = shapesToDistribute[shapesToDistribute.Count - 1];
+                PPShape rightMostShape = shapesToDistribute[shapesToDistribute.Count - 1];
                 referenceWidth = rightMostShape.VisualLeft + rightMostShape.AbsoluteWidth - shapesToDistribute[0].VisualLeft;
 
-                foreach (var s in shapesToDistribute)
+                foreach (PPShape s in shapesToDistribute)
                 {
                     totalShapeWidth += s.AbsoluteWidth;
                 }
@@ -843,9 +843,9 @@ namespace PowerPointLabs.PositionsLab
                 shapesToDistribute.RemoveAt(shapesToDistribute.Count - 1);
                 shapesToDistribute.RemoveAt(0);
 
-                for (var i = 0; i < shapesToDistribute.Count; i++)
+                for (int i = 0; i < shapesToDistribute.Count; i++)
                 {
-                    var currShape = shapesToDistribute[i];
+                    PPShape currShape = shapesToDistribute[i];
                     if (i == 0)
                     {
                         currShape.IncrementLeft(startingPoint - currShape.VisualLeft + spaceBetweenShapes);
@@ -871,7 +871,7 @@ namespace PowerPointLabs.PositionsLab
                 startingPoint = shapesToDistribute[0].VisualCenter.X;
                 referenceWidth = shapesToDistribute[shapesToDistribute.Count-1].VisualCenter.X - shapesToDistribute[0].VisualCenter.X;
 
-                foreach (var s in shapesToDistribute)
+                foreach (PPShape s in shapesToDistribute)
                 {
                     totalShapeWidth += s.AbsoluteWidth;
                 }
@@ -880,9 +880,9 @@ namespace PowerPointLabs.PositionsLab
                 shapesToDistribute.RemoveAt(shapesToDistribute.Count - 1);
                 shapesToDistribute.RemoveAt(0);
 
-                for (var i = 0; i < shapesToDistribute.Count; i++)
+                for (int i = 0; i < shapesToDistribute.Count; i++)
                 {
-                    var currShape = shapesToDistribute[i];
+                    PPShape currShape = shapesToDistribute[i];
                     if (i == 0)
                     {
                         currShape.IncrementLeft(startingPoint - currShape.VisualCenter.X + spaceBetweenShapes);
@@ -921,7 +921,7 @@ namespace PowerPointLabs.PositionsLab
                 startingPoint = 0;
                 referenceHeight = slideHeight;
                 shapesToDistribute = ShapeUtil.SortShapesByTop(selectedShapes);
-                foreach (var s in shapesToDistribute)
+                foreach (PPShape s in shapesToDistribute)
                 {
                     totalShapeHeight += s.AbsoluteHeight;
                 }
@@ -936,9 +936,9 @@ namespace PowerPointLabs.PositionsLab
                     spaceBetweenShapes = (referenceHeight - totalShapeHeight) / (shapesToDistribute.Count + 1);
                 }
 
-                for (var i = 0; i < shapesToDistribute.Count; i++)
+                for (int i = 0; i < shapesToDistribute.Count; i++)
                 {
-                    var currShape = shapesToDistribute[i];
+                    PPShape currShape = shapesToDistribute[i];
 
                     // Check if need leading and trailing space
                     if (i == 0)
@@ -973,15 +973,15 @@ namespace PowerPointLabs.PositionsLab
                 referenceHeight = slideHeight;
                 shapesToDistribute = ShapeUtil.SortShapesByTop(selectedShapes);
 
-                foreach (var s in shapesToDistribute)
+                foreach (PPShape s in shapesToDistribute)
                 {
                     totalShapeHeight += s.AbsoluteHeight;
                 }
 
                 if (totalShapeHeight > referenceHeight)
                 {
-                    var topMostShape = shapesToDistribute[0];
-                    var bottomMostShape = shapesToDistribute[shapesToDistribute.Count - 1];
+                    PPShape topMostShape = shapesToDistribute[0];
+                    PPShape bottomMostShape = shapesToDistribute[shapesToDistribute.Count - 1];
 
                     topMostShape.IncrementTop(startingPoint - topMostShape.VisualTop);
                     bottomMostShape.IncrementTop(referenceHeight - bottomMostShape.VisualTop - bottomMostShape.AbsoluteHeight);
@@ -998,9 +998,9 @@ namespace PowerPointLabs.PositionsLab
                     spaceBetweenShapes = referenceHeight / (shapesToDistribute.Count + 1);
                 }
 
-                for (var i = 0; i < shapesToDistribute.Count; i++)
+                for (int i = 0; i < shapesToDistribute.Count; i++)
                 {
-                    var currShape = shapesToDistribute[i];
+                    PPShape currShape = shapesToDistribute[i];
                     if (i == 0)
                     {
                         currShape.IncrementTop(startingPoint - currShape.VisualCenter.Y + spaceBetweenShapes);
@@ -1028,7 +1028,7 @@ namespace PowerPointLabs.PositionsLab
                 shapesToDistribute.RemoveAt(0);
                 shapesToDistribute = ShapeUtil.SortShapesByTop(shapesToDistribute);
 
-                foreach (var s in shapesToDistribute)
+                foreach (PPShape s in shapesToDistribute)
                 {
                     totalShapeHeight += s.AbsoluteHeight;
                 }
@@ -1043,9 +1043,9 @@ namespace PowerPointLabs.PositionsLab
                     spaceBetweenShapes = (referenceHeight - totalShapeHeight) / (shapesToDistribute.Count + 1);
                 }
 
-                for (var i = 0; i < shapesToDistribute.Count; i++)
+                for (int i = 0; i < shapesToDistribute.Count; i++)
                 {
-                    var currShape = shapesToDistribute[i];
+                    PPShape currShape = shapesToDistribute[i];
 
                     // Check if need leading and trailing space
                     if (i == 0)
@@ -1082,15 +1082,15 @@ namespace PowerPointLabs.PositionsLab
                 shapesToDistribute.RemoveAt(0);
                 shapesToDistribute = ShapeUtil.SortShapesByTop(shapesToDistribute);
 
-                foreach (var s in shapesToDistribute)
+                foreach (PPShape s in shapesToDistribute)
                 {
                     totalShapeHeight += s.AbsoluteHeight;
                 }
 
                 if (totalShapeHeight > referenceHeight)
                 {
-                    var topMostShape = shapesToDistribute[0];
-                    var bottomMostShape = shapesToDistribute[shapesToDistribute.Count - 1];
+                    PPShape topMostShape = shapesToDistribute[0];
+                    PPShape bottomMostShape = shapesToDistribute[shapesToDistribute.Count - 1];
 
                     topMostShape.IncrementTop(startingPoint - topMostShape.VisualTop);
                     bottomMostShape.IncrementTop(startingPoint + referenceHeight - bottomMostShape.VisualTop - bottomMostShape.AbsoluteHeight);
@@ -1107,9 +1107,9 @@ namespace PowerPointLabs.PositionsLab
                     spaceBetweenShapes = referenceHeight / (shapesToDistribute.Count + 1);
                 }
 
-                for (var i = 0; i < shapesToDistribute.Count; i++)
+                for (int i = 0; i < shapesToDistribute.Count; i++)
                 {
-                    var currShape = shapesToDistribute[i];
+                    PPShape currShape = shapesToDistribute[i];
                     if (i == 0)
                     {
                         currShape.IncrementTop(startingPoint - currShape.VisualCenter.Y + spaceBetweenShapes);
@@ -1135,7 +1135,7 @@ namespace PowerPointLabs.PositionsLab
 
                 if (shapesToDistribute[0].VisualTop > shapesToDistribute[1].VisualTop)
                 {
-                    var temp = shapesToDistribute[0];
+                    PPShape temp = shapesToDistribute[0];
                     shapesToDistribute[0] = shapesToDistribute[1];
                     shapesToDistribute[1] = temp;
                 }
@@ -1143,7 +1143,7 @@ namespace PowerPointLabs.PositionsLab
                 startingPoint = shapesToDistribute[0].VisualTop + shapesToDistribute[0].AbsoluteHeight;
                 referenceHeight = shapesToDistribute[1].VisualTop + shapesToDistribute[1].AbsoluteHeight - shapesToDistribute[0].VisualTop;
 
-                foreach (var s in shapesToDistribute)
+                foreach (PPShape s in shapesToDistribute)
                 {
                     totalShapeHeight += s.AbsoluteHeight;
                 }
@@ -1153,9 +1153,9 @@ namespace PowerPointLabs.PositionsLab
                 shapesToDistribute.RemoveAt(0);
                 shapesToDistribute = ShapeUtil.SortShapesByTop(shapesToDistribute);
 
-                for (var i = 0; i < shapesToDistribute.Count; i++)
+                for (int i = 0; i < shapesToDistribute.Count; i++)
                 {
-                    var currShape = shapesToDistribute[i];
+                    PPShape currShape = shapesToDistribute[i];
                     if (i == 0)
                     {
                         currShape.IncrementTop(startingPoint - currShape.VisualTop + spaceBetweenShapes);
@@ -1181,7 +1181,7 @@ namespace PowerPointLabs.PositionsLab
 
                 if (shapesToDistribute[0].VisualTop > shapesToDistribute[1].VisualTop)
                 {
-                    var temp = shapesToDistribute[0];
+                    PPShape temp = shapesToDistribute[0];
                     shapesToDistribute[0] = shapesToDistribute[1];
                     shapesToDistribute[1] = temp;
                 }
@@ -1189,7 +1189,7 @@ namespace PowerPointLabs.PositionsLab
                 startingPoint = shapesToDistribute[0].VisualCenter.Y;
                 referenceHeight = shapesToDistribute[1].VisualCenter.Y - shapesToDistribute[0].VisualCenter.Y;
 
-                foreach (var s in shapesToDistribute)
+                foreach (PPShape s in shapesToDistribute)
                 {
                     totalShapeHeight += s.AbsoluteHeight;
                 }
@@ -1200,9 +1200,9 @@ namespace PowerPointLabs.PositionsLab
 
                 shapesToDistribute = ShapeUtil.SortShapesByTop(shapesToDistribute);
 
-                for (var i = 0; i < shapesToDistribute.Count; i++)
+                for (int i = 0; i < shapesToDistribute.Count; i++)
                 {
-                    var currShape = shapesToDistribute[i];
+                    PPShape currShape = shapesToDistribute[i];
                     if (i == 0)
                     {
                         currShape.IncrementTop(startingPoint - currShape.VisualCenter.Y + spaceBetweenShapes);
@@ -1226,10 +1226,10 @@ namespace PowerPointLabs.PositionsLab
 
                 shapesToDistribute = ShapeUtil.SortShapesByTop(selectedShapes);
                 startingPoint = shapesToDistribute[0].VisualTop + shapesToDistribute[0].AbsoluteHeight;
-                var bottomMostShape = shapesToDistribute[shapesToDistribute.Count - 1];
+                PPShape bottomMostShape = shapesToDistribute[shapesToDistribute.Count - 1];
                 referenceHeight = bottomMostShape.VisualTop + bottomMostShape.AbsoluteHeight - shapesToDistribute[0].VisualTop;
 
-                foreach (var s in shapesToDistribute)
+                foreach (PPShape s in shapesToDistribute)
                 {
                     totalShapeHeight += s.AbsoluteHeight;
                 }
@@ -1238,9 +1238,9 @@ namespace PowerPointLabs.PositionsLab
                 shapesToDistribute.RemoveAt(shapesToDistribute.Count - 1);
                 shapesToDistribute.RemoveAt(0);
 
-                for (var i = 0; i < shapesToDistribute.Count; i++)
+                for (int i = 0; i < shapesToDistribute.Count; i++)
                 {
-                    var currShape = shapesToDistribute[i];
+                    PPShape currShape = shapesToDistribute[i];
                     if (i == 0)
                     {
                         currShape.IncrementTop(startingPoint - currShape.VisualTop + spaceBetweenShapes);
@@ -1266,7 +1266,7 @@ namespace PowerPointLabs.PositionsLab
                 startingPoint = shapesToDistribute[0].VisualCenter.Y;
                 referenceHeight = shapesToDistribute[shapesToDistribute.Count - 1].VisualCenter.Y - shapesToDistribute[0].VisualCenter.Y;
 
-                foreach (var s in shapesToDistribute)
+                foreach (PPShape s in shapesToDistribute)
                 {
                     totalShapeHeight += s.AbsoluteHeight;
                 }
@@ -1275,9 +1275,9 @@ namespace PowerPointLabs.PositionsLab
                 shapesToDistribute.RemoveAt(shapesToDistribute.Count - 1);
                 shapesToDistribute.RemoveAt(0);
 
-                for (var i = 0; i < shapesToDistribute.Count; i++)
+                for (int i = 0; i < shapesToDistribute.Count; i++)
                 {
-                    var currShape = shapesToDistribute[i];
+                    PPShape currShape = shapesToDistribute[i];
                     if (i == 0)
                     {
                         currShape.IncrementTop(startingPoint - currShape.VisualCenter.Y + spaceBetweenShapes);
@@ -1319,23 +1319,23 @@ namespace PowerPointLabs.PositionsLab
             bool isObjectCenter = PositionsLabSettings.DistributeSpaceReference == PositionsLabSettings.DistributeSpaceReferenceObject.ObjectCenter;
             bool isObjectBoundary = PositionsLabSettings.DistributeSpaceReference == PositionsLabSettings.DistributeSpaceReferenceObject.ObjectBoundary;
 
-            var colLengthGivenFullRows = (int) Math.Ceiling((double) selectedShapes.Count/rowLength);
+            int colLengthGivenFullRows = (int) Math.Ceiling((double) selectedShapes.Count/rowLength);
             if (colLength <= colLengthGivenFullRows)
             {
                 if (isFirstTwoShapes && isObjectCenter)
                 {
-                    var startAnchorCenter = selectedShapes[0].VisualCenter;
-                    var endAnchorCenter = selectedShapes[1].VisualCenter;
-                    var rowWidth = endAnchorCenter.X - startAnchorCenter.X;
-                    var colHeight = endAnchorCenter.Y - startAnchorCenter.Y;
+                    Drawing.PointF startAnchorCenter = selectedShapes[0].VisualCenter;
+                    Drawing.PointF endAnchorCenter = selectedShapes[1].VisualCenter;
+                    float rowWidth = endAnchorCenter.X - startAnchorCenter.X;
+                    float colHeight = endAnchorCenter.Y - startAnchorCenter.Y;
                     DistributeGridByRowWithAnchors(selectedShapes, rowLength, colLength, rowWidth, colHeight);
                 }
                 else if (isFirstTwoShapes && isObjectBoundary)
                 {
-                    var startAnchor = selectedShapes[0];
-                    var endAnchor = selectedShapes[1];
-                    var rowWidth = endAnchor.VisualLeft + endAnchor.AbsoluteWidth - startAnchor.VisualLeft;
-                    var colHeight = endAnchor.VisualTop + endAnchor.AbsoluteHeight - startAnchor.VisualTop;
+                    PPShape startAnchor = selectedShapes[0];
+                    PPShape endAnchor = selectedShapes[1];
+                    float rowWidth = endAnchor.VisualLeft + endAnchor.AbsoluteWidth - startAnchor.VisualLeft;
+                    float colHeight = endAnchor.VisualTop + endAnchor.AbsoluteHeight - startAnchor.VisualTop;
                     DistributeGridByRowWithAnchorsByEdge(selectedShapes, rowLength, colLength, rowWidth, colHeight);
                 }
                 else if (isFirstShape && isObjectCenter)
@@ -1351,18 +1351,18 @@ namespace PowerPointLabs.PositionsLab
             {
                 if (isFirstTwoShapes && isObjectCenter)
                 {
-                    var startAnchorCenter = selectedShapes[0].VisualCenter;
-                    var endAnchorCenter = selectedShapes[1].VisualCenter;
-                    var rowWidth = endAnchorCenter.X - startAnchorCenter.X;
-                    var colHeight = endAnchorCenter.Y - startAnchorCenter.Y;
+                    Drawing.PointF startAnchorCenter = selectedShapes[0].VisualCenter;
+                    Drawing.PointF endAnchorCenter = selectedShapes[1].VisualCenter;
+                    float rowWidth = endAnchorCenter.X - startAnchorCenter.X;
+                    float colHeight = endAnchorCenter.Y - startAnchorCenter.Y;
                     DistributeGridByColWithAnchors(selectedShapes, rowLength, colLength, rowWidth, colHeight);
                 }
                 else if (isFirstTwoShapes && isObjectBoundary)
                 {
-                    var startAnchor = selectedShapes[0];
-                    var endAnchor = selectedShapes[1];
-                    var rowWidth = endAnchor.VisualLeft + endAnchor.AbsoluteWidth - startAnchor.VisualLeft;
-                    var colHeight = endAnchor.VisualTop + endAnchor.AbsoluteHeight - startAnchor.VisualTop;
+                    PPShape startAnchor = selectedShapes[0];
+                    PPShape endAnchor = selectedShapes[1];
+                    float rowWidth = endAnchor.VisualLeft + endAnchor.AbsoluteWidth - startAnchor.VisualLeft;
+                    float colHeight = endAnchor.VisualTop + endAnchor.AbsoluteHeight - startAnchor.VisualTop;
                     DistributeGridByColWithAnchorsByEdge(selectedShapes, rowLength, colLength, rowWidth, colHeight);
                 }
                 else if (isFirstShape && isObjectCenter)
@@ -1378,21 +1378,21 @@ namespace PowerPointLabs.PositionsLab
 
         public static void DistributeGridByRow(List<PPShape> selectedShapes, int rowLength, int colLength)
         {
-            var refPoint = selectedShapes[0].VisualCenter;
+            Drawing.PointF refPoint = selectedShapes[0].VisualCenter;
 
-            var numShapes = selectedShapes.Count;
+            int numShapes = selectedShapes.Count;
 
-            var numIndicesToSkip = IndicesToSkip(numShapes, rowLength, PositionsLabSettings.DistributeGridAlignment);
+            int numIndicesToSkip = IndicesToSkip(numShapes, rowLength, PositionsLabSettings.DistributeGridAlignment);
 
-            var rowDifferences = GetLongestWidthsOfRowsByRow(selectedShapes, rowLength, numIndicesToSkip);
-            var colDifferences = GetLongestHeightsOfColsByRow(selectedShapes, rowLength, colLength);
+            float[] rowDifferences = GetLongestWidthsOfRowsByRow(selectedShapes, rowLength, numIndicesToSkip);
+            float[] colDifferences = GetLongestHeightsOfColsByRow(selectedShapes, rowLength, colLength);
 
-            var posX = refPoint.X;
-            var posY = refPoint.Y;
-            var remainder = numShapes%rowLength;
-            var differenceIndex = 0;
+            float posX = refPoint.X;
+            float posY = refPoint.Y;
+            int remainder = numShapes%rowLength;
+            int differenceIndex = 0;
 
-            for (var i = 0; i < numShapes; i++)
+            for (int i = 0; i < numShapes; i++)
             {
                 //Start of new row
                 if (i%rowLength == 0 && i != 0)
@@ -1413,7 +1413,7 @@ namespace PowerPointLabs.PositionsLab
                                                     PositionsLabSettings.GridMarginRight);
                 }
 
-                var currentShape = selectedShapes[i];
+                PPShape currentShape = selectedShapes[i];
                 currentShape.IncrementLeft(posX - currentShape.VisualCenter.X);
                 currentShape.IncrementTop(posY - currentShape.VisualCenter.Y);
 
@@ -1426,21 +1426,21 @@ namespace PowerPointLabs.PositionsLab
 
         public static void DistributeGridByCol(List<PPShape> selectedShapes, int rowLength, int colLength)
         {
-            var refPoint = selectedShapes[0].VisualCenter;
+            Drawing.PointF refPoint = selectedShapes[0].VisualCenter;
 
-            var numShapes = selectedShapes.Count;
+            int numShapes = selectedShapes.Count;
 
-            var numIndicesToSkip = IndicesToSkip(numShapes, colLength, PositionsLabSettings.DistributeGridAlignment);
+            int numIndicesToSkip = IndicesToSkip(numShapes, colLength, PositionsLabSettings.DistributeGridAlignment);
 
-            var rowDifferences = GetLongestWidthsOfRowsByCol(selectedShapes, rowLength, colLength, numIndicesToSkip);
-            var colDifferences = GetLongestHeightsOfColsByCol(selectedShapes, rowLength, colLength, numIndicesToSkip);
+            float[] rowDifferences = GetLongestWidthsOfRowsByCol(selectedShapes, rowLength, colLength, numIndicesToSkip);
+            float[] colDifferences = GetLongestHeightsOfColsByCol(selectedShapes, rowLength, colLength, numIndicesToSkip);
 
-            var posX = refPoint.X;
-            var posY = refPoint.Y;
-            var remainder = colLength - (rowLength*colLength - numShapes);
-            var augmentedShapeIndex = 0;
+            float posX = refPoint.X;
+            float posY = refPoint.Y;
+            int remainder = colLength - (rowLength*colLength - numShapes);
+            int augmentedShapeIndex = 0;
 
-            for (var i = 0; i < numShapes; i++)
+            for (int i = 0; i < numShapes; i++)
             {
                 //If last index and need to skip, skip index 
                 if (numIndicesToSkip > 0 && IsLastIndexOfRow(augmentedShapeIndex, rowLength))
@@ -1470,8 +1470,8 @@ namespace PowerPointLabs.PositionsLab
                                                 PositionsLabSettings.GridMarginBottom);
                 }
 
-                var currentShape = selectedShapes[i];
-                var center = currentShape.VisualCenter;
+                PPShape currentShape = selectedShapes[i];
+                Drawing.PointF center = currentShape.VisualCenter;
                 currentShape.IncrementLeft(posX - center.X);
                 currentShape.IncrementTop(posY - center.Y);
 
@@ -1489,17 +1489,17 @@ namespace PowerPointLabs.PositionsLab
                 throw new Exception(PositionsLabText.ErrorFewerThanTwoSelection);
             }
 
-            var startingAnchor = selectedShapes[0].VisualCenter;
-            var endingAnchor = selectedShapes[1].VisualCenter;
+            Drawing.PointF startingAnchor = selectedShapes[0].VisualCenter;
+            Drawing.PointF endingAnchor = selectedShapes[1].VisualCenter;
 
-            var endAnchor = selectedShapes[1];
+            PPShape endAnchor = selectedShapes[1];
             selectedShapes.RemoveAt(1);
             selectedShapes.Add(endAnchor);
 
-            var rowDifference = rowWidth / (rowLength - 1);
-            var colDifference = colHeight / (colLength - 1);
+            float rowDifference = rowWidth / (rowLength - 1);
+            float colDifference = colHeight / (colLength - 1);
 
-            var gridSpaces = new float[selectedShapes.Count, 2];
+            float[,] gridSpaces = new float[selectedShapes.Count, 2];
 
             for (int i = 0; i < selectedShapes.Count; i++)
             {
@@ -1512,19 +1512,19 @@ namespace PowerPointLabs.PositionsLab
 
         public static void DistributeGridByRow(List<PPShape> selectedShapes, int rowLength, int colLength, float[,] gridSpaces, int start, int end)
         {
-            var numShapes = selectedShapes.Count;
-            var numIndicesToSkip = IndicesToSkip(numShapes, rowLength, PositionsLabSettings.DistributeGridAlignment);
+            int numShapes = selectedShapes.Count;
+            int numIndicesToSkip = IndicesToSkip(numShapes, rowLength, PositionsLabSettings.DistributeGridAlignment);
 
-            var startingAnchor = selectedShapes[0].VisualCenter;
+            Drawing.PointF startingAnchor = selectedShapes[0].VisualCenter;
 
-            var rowDifferences = GetLongestWidthsOfRowsByCol(selectedShapes, rowLength, colLength, numIndicesToSkip);
-            var colDifferences = GetLongestHeightsOfColsByCol(selectedShapes, rowLength, colLength, numIndicesToSkip);
+            float[] rowDifferences = GetLongestWidthsOfRowsByCol(selectedShapes, rowLength, colLength, numIndicesToSkip);
+            float[] colDifferences = GetLongestHeightsOfColsByCol(selectedShapes, rowLength, colLength, numIndicesToSkip);
 
-            var posX = startingAnchor.X;
-            var posY = startingAnchor.Y;
-            var remainder = numShapes % rowLength;
+            float posX = startingAnchor.X;
+            float posY = startingAnchor.Y;
+            int remainder = numShapes % rowLength;
 
-            for (var i = start; i < end; i++)
+            for (int i = start; i < end; i++)
             {
                 //Start of new row
                 if (i % rowLength == 0 && i != 0)
@@ -1539,7 +1539,7 @@ namespace PowerPointLabs.PositionsLab
                     posX += numIndicesToSkip * gridSpaces[i, 0];
                 }
 
-                var currentShape = selectedShapes[i];
+                PPShape currentShape = selectedShapes[i];
                 currentShape.IncrementLeft(posX - currentShape.VisualCenter.X);
                 currentShape.IncrementTop(posY - currentShape.VisualCenter.Y);
 
@@ -1554,31 +1554,31 @@ namespace PowerPointLabs.PositionsLab
                 throw new Exception(PositionsLabText.ErrorFewerThanTwoSelection);
             }
 
-            var numShapes = selectedShapes.Count;
+            int numShapes = selectedShapes.Count;
 
-            var startAnchor = selectedShapes[0];
-            var endAnchor = selectedShapes[1];
+            PPShape startAnchor = selectedShapes[0];
+            PPShape endAnchor = selectedShapes[1];
             selectedShapes.RemoveAt(1);
             selectedShapes.Add(endAnchor);
 
-            var startingAnchor = selectedShapes[0].VisualCenter;
+            Drawing.PointF startingAnchor = selectedShapes[0].VisualCenter;
 
-            var longestRow = rowWidth;
-            var longestCol = colHeight;
+            float longestRow = rowWidth;
+            float longestCol = colHeight;
 
-            var colDifferences = GetLongestHeightsOfColsByRow(selectedShapes, rowLength, colLength);
+            float[] colDifferences = GetLongestHeightsOfColsByRow(selectedShapes, rowLength, colLength);
 
             for (int i = 0; i < colDifferences.Length; i++)
             {
                 longestCol -= colDifferences[i];
             }
 
-            var posX = startingAnchor.X;
-            var posY = startAnchor.VisualTop + colDifferences[0] / 2;
-            var rowDifference = longestRow;
-            var colDifference = longestCol / (colDifferences.Length - 1);
+            float posX = startingAnchor.X;
+            float posY = startAnchor.VisualTop + colDifferences[0] / 2;
+            float rowDifference = longestRow;
+            float colDifference = longestCol / (colDifferences.Length - 1);
 
-            for (var i = 0; i < numShapes - 1; i++)
+            for (int i = 0; i < numShapes - 1; i++)
             {
                 //Start of new row
                 if (i % rowLength == 0)
@@ -1605,7 +1605,7 @@ namespace PowerPointLabs.PositionsLab
                     }
                 }
 
-                var currentShape = selectedShapes[i];
+                PPShape currentShape = selectedShapes[i];
                 currentShape.IncrementLeft(posX - currentShape.VisualCenter.X);
 
                 if (i / rowLength == 0)
@@ -1626,19 +1626,19 @@ namespace PowerPointLabs.PositionsLab
 
         public static void DistributeGridByRowByEdge(List<PPShape> selectedShapes, int rowLength, int colLength)
         {
-            var numShapes = selectedShapes.Count;
+            int numShapes = selectedShapes.Count;
 
-            var startingAnchor = selectedShapes[0].VisualCenter;
+            Drawing.PointF startingAnchor = selectedShapes[0].VisualCenter;
 
-            var posX = startingAnchor.X;
-            var posY = startingAnchor.Y;
+            float posX = startingAnchor.X;
+            float posY = startingAnchor.Y;
 
-            var longestRow = GetLongestRowWidthByRow(selectedShapes, rowLength);
-            var colDifferences = GetLongestHeightsOfColsByRow(selectedShapes, rowLength, colLength);
+            float longestRow = GetLongestRowWidthByRow(selectedShapes, rowLength);
+            float[] colDifferences = GetLongestHeightsOfColsByRow(selectedShapes, rowLength, colLength);
 
-            var rowDifference = longestRow;
+            float rowDifference = longestRow;
 
-            for (var i = 0; i < numShapes; i++)
+            for (int i = 0; i < numShapes; i++)
             {
                 //Start of new row
                 if (i % rowLength == 0)
@@ -1666,7 +1666,7 @@ namespace PowerPointLabs.PositionsLab
                     }
                 }
 
-                var currentShape = selectedShapes[i];
+                PPShape currentShape = selectedShapes[i];
                 currentShape.IncrementLeft(posX - currentShape.VisualCenter.X);
                 currentShape.IncrementTop(posY - currentShape.VisualCenter.Y);
 
@@ -1684,17 +1684,17 @@ namespace PowerPointLabs.PositionsLab
                 throw new Exception(PositionsLabText.ErrorFewerThanTwoSelection);
             }
 
-            var startingAnchor = selectedShapes[0].VisualCenter;
-            var endingAnchor = selectedShapes[1].VisualCenter;
+            Drawing.PointF startingAnchor = selectedShapes[0].VisualCenter;
+            Drawing.PointF endingAnchor = selectedShapes[1].VisualCenter;
 
-            var rowDifference = rowWidth / (rowLength - 1);
-            var colDifference = colHeight / (colLength - 1);
+            float rowDifference = rowWidth / (rowLength - 1);
+            float colDifference = colHeight / (colLength - 1);
 
-            var endAnchor = selectedShapes[1];
+            PPShape endAnchor = selectedShapes[1];
             selectedShapes.RemoveAt(1);
             selectedShapes.Add(endAnchor);
 
-            var gridSpaces = new float[selectedShapes.Count, 2];
+            float[,] gridSpaces = new float[selectedShapes.Count, 2];
 
             for (int i = 0; i < selectedShapes.Count; i++)
             {
@@ -1707,18 +1707,18 @@ namespace PowerPointLabs.PositionsLab
 
         public static void DistributeGridByCol(List<PPShape> selectedShapes, int rowLength, int colLength, float[,] gridSpaces, int start, int end)
         {
-            var numShapes = selectedShapes.Count;
+            int numShapes = selectedShapes.Count;
 
-            var numIndicesToSkip = IndicesToSkip(numShapes, colLength, PositionsLabSettings.DistributeGridAlignment);
+            int numIndicesToSkip = IndicesToSkip(numShapes, colLength, PositionsLabSettings.DistributeGridAlignment);
 
-            var startingAnchor = selectedShapes[0].VisualCenter;
+            Drawing.PointF startingAnchor = selectedShapes[0].VisualCenter;
 
-            var posX = startingAnchor.X;
-            var posY = startingAnchor.Y;
-            var remainder = colLength - (rowLength * colLength - numShapes);
-            var augmentedShapeIndex = 0;
+            float posX = startingAnchor.X;
+            float posY = startingAnchor.Y;
+            int remainder = colLength - (rowLength * colLength - numShapes);
+            int augmentedShapeIndex = 0;
 
-            for (var i = start; i < end; i++)
+            for (int i = start; i < end; i++)
             {
                 //If last index and need to skip, skip index 
                 if (numIndicesToSkip > 0 && IsLastIndexOfRow(augmentedShapeIndex, rowLength))
@@ -1746,8 +1746,8 @@ namespace PowerPointLabs.PositionsLab
                     posY += gridSpaces[i, 1];
                 }
 
-                var currentShape = selectedShapes[i];
-                var center = currentShape.VisualCenter;
+                PPShape currentShape = selectedShapes[i];
+                Drawing.PointF center = currentShape.VisualCenter;
                 currentShape.IncrementLeft(posX - center.X);
                 currentShape.IncrementTop(posY - center.Y);
 
@@ -1758,19 +1758,19 @@ namespace PowerPointLabs.PositionsLab
 
         public static void DistributeGridByColByEdge(List<PPShape> selectedShapes, int rowLength, int colLength)
         {
-            var numShapes = selectedShapes.Count;
-            var startingAnchor = selectedShapes[0].VisualCenter;
+            int numShapes = selectedShapes.Count;
+            Drawing.PointF startingAnchor = selectedShapes[0].VisualCenter;
 
-            var posX = startingAnchor.X;
-            var posY = startingAnchor.Y;
-            var remainder = colLength - (rowLength * colLength - numShapes);
-            var augmentedShapeIndex = 0;
+            float posX = startingAnchor.X;
+            float posY = startingAnchor.Y;
+            int remainder = colLength - (rowLength * colLength - numShapes);
+            int augmentedShapeIndex = 0;
 
-            var longestRow = GetLongestRowWidthByCol(selectedShapes, rowLength, colLength);
-            var colDifferences = GetLongestHeightsOfColsByCol(selectedShapes, rowLength, colLength, 0);
-            var rowDifference = longestRow;
+            float longestRow = GetLongestRowWidthByCol(selectedShapes, rowLength, colLength);
+            float[] colDifferences = GetLongestHeightsOfColsByCol(selectedShapes, rowLength, colLength, 0);
+            float rowDifference = longestRow;
 
-            for (var i = 0; i < numShapes; i++)
+            for (int i = 0; i < numShapes; i++)
             {
                 //If last index and no more remainder, skip the rest
                 if (IsLastIndexOfRow(augmentedShapeIndex, rowLength))
@@ -1818,8 +1818,8 @@ namespace PowerPointLabs.PositionsLab
                     }
                 }
 
-                var currentShape = selectedShapes[i];
-                var center = currentShape.VisualCenter;
+                PPShape currentShape = selectedShapes[i];
+                Drawing.PointF center = currentShape.VisualCenter;
                 currentShape.IncrementLeft(posX - center.X);
                 currentShape.IncrementTop(posY - center.Y);
 
@@ -1838,33 +1838,33 @@ namespace PowerPointLabs.PositionsLab
                 throw new Exception(PositionsLabText.ErrorFewerThanTwoSelection);
             }
 
-            var numShapes = selectedShapes.Count;
+            int numShapes = selectedShapes.Count;
 
-            var startAnchor = selectedShapes[0];
-            var endAnchor = selectedShapes[1];
+            PPShape startAnchor = selectedShapes[0];
+            PPShape endAnchor = selectedShapes[1];
             selectedShapes.RemoveAt(1);
             selectedShapes.Add(endAnchor);
 
-            var startingAnchor = selectedShapes[0].VisualCenter;
+            Drawing.PointF startingAnchor = selectedShapes[0].VisualCenter;
 
-            var longestRow = rowWidth;
-            var longestCol = colHeight;
+            float longestRow = rowWidth;
+            float longestCol = colHeight;
 
-            var colDifferences = GetLongestHeightsOfColsByCol(selectedShapes, rowLength, colLength, 0);
+            float[] colDifferences = GetLongestHeightsOfColsByCol(selectedShapes, rowLength, colLength, 0);
 
             for (int i = 0; i < colDifferences.Length; i++)
             {
                 longestCol -= colDifferences[i];
             }
 
-            var posX = startingAnchor.X;
-            var posY = startAnchor.VisualTop + colDifferences[0] / 2;
-            var rowDifference = longestRow;
-            var colDifference = longestCol / (colDifferences.Length - 1);
-            var remainder = colLength - (rowLength * colLength - numShapes);
-            var augmentedShapeIndex = 0;
+            float posX = startingAnchor.X;
+            float posY = startAnchor.VisualTop + colDifferences[0] / 2;
+            float rowDifference = longestRow;
+            float colDifference = longestCol / (colDifferences.Length - 1);
+            int remainder = colLength - (rowLength * colLength - numShapes);
+            int augmentedShapeIndex = 0;
 
-            for (var i = 0; i < numShapes - 1; i++)
+            for (int i = 0; i < numShapes - 1; i++)
             {
                 //If last index and no more remainder, skip the rest
                 if (IsLastIndexOfRow(augmentedShapeIndex, rowLength))
@@ -1910,8 +1910,8 @@ namespace PowerPointLabs.PositionsLab
                     }
                 }
 
-                var currentShape = selectedShapes[i];
-                var center = currentShape.VisualCenter;
+                PPShape currentShape = selectedShapes[i];
+                Drawing.PointF center = currentShape.VisualCenter;
                 currentShape.IncrementLeft(posX - center.X);
 
                 if (augmentedShapeIndex / rowLength == 0)
@@ -1950,9 +1950,9 @@ namespace PowerPointLabs.PositionsLab
 
                 origin = ShapeUtil.GetCenterPoint(selectedShapes[1]);
 
-                var boundaryAngles = GetShapeBoundaryAngles(origin, selectedShapes[2]);
+                float[] boundaryAngles = GetShapeBoundaryAngles(origin, selectedShapes[2]);
                 startingAngle = boundaryAngles[1];
-                var endingAngle = boundaryAngles[0];
+                float endingAngle = boundaryAngles[0];
 
                 if (startingAngle == 0 && boundaryAngles[1] == 360)
                 {
@@ -1965,7 +1965,7 @@ namespace PowerPointLabs.PositionsLab
                     referenceAngle += 360;
                 }
 
-                var offset = endingAngle - startingAngle;
+                float offset = endingAngle - startingAngle;
                 if (offset > 0)
                 {
                     offset -= 360;
@@ -1995,10 +1995,10 @@ namespace PowerPointLabs.PositionsLab
                 }
 
                 origin = ShapeUtil.GetCenterPoint(selectedShapes[1]);
-                var startingShapeBoundaryAngles = GetShapeBoundaryAngles(origin, selectedShapes[2]);
-                var endingShapeBoundaryAngles = GetShapeBoundaryAngles(origin, selectedShapes[3]);
+                float[] startingShapeBoundaryAngles = GetShapeBoundaryAngles(origin, selectedShapes[2]);
+                float[] endingShapeBoundaryAngles = GetShapeBoundaryAngles(origin, selectedShapes[3]);
                 startingAngle = startingShapeBoundaryAngles[0];
-                var endingAngle = endingShapeBoundaryAngles[1];
+                float endingAngle = endingShapeBoundaryAngles[1];
 
                 if ((startingAngle == 0 && startingShapeBoundaryAngles[1] == 360)
                     || (endingShapeBoundaryAngles[0] == 0 && endingAngle == 360))
@@ -2006,13 +2006,13 @@ namespace PowerPointLabs.PositionsLab
                     throw new Exception(PositionsLabText.ErrorFunctionNotSupportedForOverlapRefShapeCenter);
                 }
 
-                var startingShapeAngle = startingShapeBoundaryAngles[1] - startingAngle;
+                float startingShapeAngle = startingShapeBoundaryAngles[1] - startingAngle;
                 if (startingShapeAngle < 0)
                 {
                     startingShapeAngle += 360;
                 }
 
-                var endingShapeAngle = endingAngle - endingShapeBoundaryAngles[0];
+                float endingShapeAngle = endingAngle - endingShapeBoundaryAngles[0];
                 if (endingShapeAngle < 0)
                 {
                     endingShapeAngle += 360;
@@ -2036,7 +2036,7 @@ namespace PowerPointLabs.PositionsLab
 
                 origin = ShapeUtil.GetCenterPoint(selectedShapes[1]);
                 startingAngle = (float)AngleBetweenTwoPoints(origin, GetVisualCenter(selectedShapes[2]));
-                var endingAngle = (float)AngleBetweenTwoPoints(origin, GetVisualCenter(selectedShapes[3]));
+                float endingAngle = (float)AngleBetweenTwoPoints(origin, GetVisualCenter(selectedShapes[3]));
 
                 referenceAngle = endingAngle - startingAngle;
                 if (referenceAngle < 0)
@@ -2051,27 +2051,27 @@ namespace PowerPointLabs.PositionsLab
         public static void DistributeShapesWithinAngleForCenter(ShapeRange selectedShapes, Drawing.PointF origin, float startingAngle,
             float referenceAngle, int startingIndex)
         {
-            var shapeAngleInfos = new List<ShapeAngleInfo>();
+            List<ShapeAngleInfo> shapeAngleInfos = new List<ShapeAngleInfo>();
 
             for (int i = startingIndex; i <= selectedShapes.Count; i++)
             {
-                var angle = (float)AngleBetweenTwoPoints(origin, ShapeUtil.GetCenterPoint(selectedShapes[i]));
-                var angleFromStart = (angle + (360 - startingAngle)) % 360;
+                float angle = (float)AngleBetweenTwoPoints(origin, ShapeUtil.GetCenterPoint(selectedShapes[i]));
+                float angleFromStart = (angle + (360 - startingAngle)) % 360;
 
-                var shapeAngleInfo = new ShapeAngleInfo(selectedShapes[i], angleFromStart);
+                ShapeAngleInfo shapeAngleInfo = new ShapeAngleInfo(selectedShapes[i], angleFromStart);
                 shapeAngleInfos.Add(shapeAngleInfo);
             }
 
             shapeAngleInfos = shapeAngleInfos.OrderBy(x => x.Angle).ToList();
 
-            var angleBetweenShapes = referenceAngle / (shapeAngleInfos.Count + 1);
-            var endingAngle = 0f;
+            float angleBetweenShapes = referenceAngle / (shapeAngleInfos.Count + 1);
+            float endingAngle = 0f;
 
-            foreach (var shapeAngleInfo in shapeAngleInfos)
+            foreach (ShapeAngleInfo shapeAngleInfo in shapeAngleInfos)
             {
                 endingAngle += angleBetweenShapes;
 
-                var rotationAngle = endingAngle - shapeAngleInfo.Angle;
+                float rotationAngle = endingAngle - shapeAngleInfo.Angle;
                 Rotate(shapeAngleInfo.Shape, origin, rotationAngle, PositionsLabSettings.DistributeShapeOrientation);
             }
         }
@@ -2079,29 +2079,29 @@ namespace PowerPointLabs.PositionsLab
         public static void DistributeShapesWithinAngleForBoundary(ShapeRange selectedShapes, Drawing.PointF origin, float startingAngle,
              float referenceAngle, int startingIndex, float startingShapeAngle = 0, float endingShapeAngle = 0, float offset = 0)
         {
-            var shapeAngleInfos = new List<ShapeAngleInfo>();
+            List<ShapeAngleInfo> shapeAngleInfos = new List<ShapeAngleInfo>();
 
-            var boundaryShapeAngle = startingShapeAngle + endingShapeAngle;
+            float boundaryShapeAngle = startingShapeAngle + endingShapeAngle;
             if (boundaryShapeAngle >= referenceAngle)
             {
                 boundaryShapeAngle = 0;
             }
 
-            var count = 0;
-            var isStable = false;
+            int count = 0;
+            bool isStable = false;
             while (!isStable && count < 20)
             {
-                var totalShapeAngle = boundaryShapeAngle;
+                float totalShapeAngle = boundaryShapeAngle;
 
                 if (count == 0)
                 {
                     for (int i = startingIndex; i <= selectedShapes.Count; i++)
                     {
                         float shapeAngle;
-                        var angle = GetShapeAngleInfo(selectedShapes[i], origin, startingAngle, totalShapeAngle, out shapeAngle);
+                        float angle = GetShapeAngleInfo(selectedShapes[i], origin, startingAngle, totalShapeAngle, out shapeAngle);
                         totalShapeAngle += shapeAngle;
 
-                        var shapeAngleInfo = new ShapeAngleInfo(selectedShapes[i], angle, shapeAngle);
+                        ShapeAngleInfo shapeAngleInfo = new ShapeAngleInfo(selectedShapes[i], angle, shapeAngle);
                         shapeAngleInfos.Add(shapeAngleInfo);
                     }
 
@@ -2109,10 +2109,10 @@ namespace PowerPointLabs.PositionsLab
                 }
                 else
                 {
-                    foreach (var shapeAngleInfo in shapeAngleInfos)
+                    foreach (ShapeAngleInfo shapeAngleInfo in shapeAngleInfos)
                     {
                         float shapeAngle;
-                        var angle = GetShapeAngleInfo(shapeAngleInfo.Shape, origin, startingAngle, totalShapeAngle, out shapeAngle);
+                        float angle = GetShapeAngleInfo(shapeAngleInfo.Shape, origin, startingAngle, totalShapeAngle, out shapeAngle);
                         totalShapeAngle += shapeAngle;
 
                         shapeAngleInfo.Angle = angle;
@@ -2120,14 +2120,14 @@ namespace PowerPointLabs.PositionsLab
                     }
                 }
 
-                var angleBetweenShapes = (referenceAngle - totalShapeAngle) / (shapeAngleInfos.Count + 1);
-                var endingAngle = (boundaryShapeAngle == 0) ? angleBetweenShapes : startingShapeAngle + angleBetweenShapes;
+                float angleBetweenShapes = (referenceAngle - totalShapeAngle) / (shapeAngleInfos.Count + 1);
+                float endingAngle = (boundaryShapeAngle == 0) ? angleBetweenShapes : startingShapeAngle + angleBetweenShapes;
 
                 isStable = true;
 
-                foreach (var shapeAngleInfo in shapeAngleInfos)
+                foreach (ShapeAngleInfo shapeAngleInfo in shapeAngleInfos)
                 {
-                    var rotationAngle = (endingAngle - shapeAngleInfo.Angle) % 360;
+                    float rotationAngle = (endingAngle - shapeAngleInfo.Angle) % 360;
                     if (rotationAngle > threshold || rotationAngle < -threshold)
                     {
                         isStable = false;
@@ -2144,7 +2144,7 @@ namespace PowerPointLabs.PositionsLab
         private static float GetShapeAngleInfo(Shape shape, Drawing.PointF origin, float startingAngle, float totalShapeAngle,
             out float shapeAngle)
         {
-            var boundaryAnglesFromStart = GetShapeBoundaryAngles(origin, shape);
+            float[] boundaryAnglesFromStart = GetShapeBoundaryAngles(origin, shape);
             if (boundaryAnglesFromStart[0] == 0 && boundaryAnglesFromStart[1] == 360)
             {
                 throw new Exception(PositionsLabText.ErrorFunctionNotSupportedForOverlapRefShapeCenter);
@@ -2173,7 +2173,7 @@ namespace PowerPointLabs.PositionsLab
                 throw new Exception(PositionsLabText.ErrorFewerThanTwoSelection);
             }
 
-            var sortedShapes = selectedShapes;
+            List<PPShape> sortedShapes = selectedShapes;
 
             if (!PositionsLabSettings.IsSwapByClickOrder)
             {
@@ -2191,24 +2191,24 @@ namespace PowerPointLabs.PositionsLab
                 prevSelectedShapes.Clear();
             }
 
-            var firstPos = GetSwapReferencePoint(sortedShapes[0], PositionsLabSettings.SwapReferencePoint);
+            Drawing.PointF firstPos = GetSwapReferencePoint(sortedShapes[0], PositionsLabSettings.SwapReferencePoint);
 
-            var shapeNames = new List<string>();
+            List<string> shapeNames = new List<string>();
 
-            for (var i = 0; i < sortedShapes.Count; i++)
+            for (int i = 0; i < sortedShapes.Count; i++)
             {
-                var currentShape = sortedShapes[i];
+                PPShape currentShape = sortedShapes[i];
                 if (i < sortedShapes.Count - 1)
                 {
-                    var currentPos = GetSwapReferencePoint(currentShape, PositionsLabSettings.SwapReferencePoint);
-                    var nextPos = GetSwapReferencePoint(sortedShapes[i + 1], PositionsLabSettings.SwapReferencePoint);
+                    Drawing.PointF currentPos = GetSwapReferencePoint(currentShape, PositionsLabSettings.SwapReferencePoint);
+                    Drawing.PointF nextPos = GetSwapReferencePoint(sortedShapes[i + 1], PositionsLabSettings.SwapReferencePoint);
                     currentShape.IncrementLeft(nextPos.X - currentPos.X);
                     currentShape.IncrementTop(nextPos.Y - currentPos.Y);
                     ShapeUtil.SwapZOrder(currentShape._shape, sortedShapes[i + 1]._shape);
                 }
                 else
                 {
-                    var currentPos = GetSwapReferencePoint(currentShape, PositionsLabSettings.SwapReferencePoint);
+                    Drawing.PointF currentPos = GetSwapReferencePoint(currentShape, PositionsLabSettings.SwapReferencePoint);
                     currentShape.IncrementLeft(firstPos.X - currentPos.X);
                     currentShape.IncrementTop(firstPos.Y - currentPos.Y);
                 }
@@ -2233,8 +2233,8 @@ namespace PowerPointLabs.PositionsLab
         
         public static void Rotate(Shape shape, Drawing.PointF origin, float angle, PositionsLabSettings.RadialShapeOrientationObject shapeOrientation)
         {
-            var unrotatedCenter = ShapeUtil.GetCenterPoint(shape);
-            var rotatedCenter = CommonUtil.RotatePoint(unrotatedCenter, origin, angle);
+            Drawing.PointF unrotatedCenter = ShapeUtil.GetCenterPoint(shape);
+            Drawing.PointF rotatedCenter = CommonUtil.RotatePoint(unrotatedCenter, origin, angle);
 
             shape.Left += (rotatedCenter.X - unrotatedCenter.X);
             shape.Top += (rotatedCenter.Y - unrotatedCenter.Y);
@@ -2251,7 +2251,7 @@ namespace PowerPointLabs.PositionsLab
 
         public static void SnapVertical(IList<Shape> selectedShapes)
         {
-            foreach (var s in selectedShapes)
+            foreach (Shape s in selectedShapes)
             {
                 SnapShapeVertical(s);
             }
@@ -2259,7 +2259,7 @@ namespace PowerPointLabs.PositionsLab
 
         public static void SnapHorizontal(IList<Shape> selectedShapes)
         {
-            foreach (var s in selectedShapes)
+            foreach (Shape s in selectedShapes)
             {
                 SnapShapeHorizontal(s);
             }
@@ -2272,17 +2272,17 @@ namespace PowerPointLabs.PositionsLab
                 throw new Exception(PositionsLabText.ErrorFewerThanTwoSelection);
             }
 
-            var refShapeCenter = ShapeUtil.GetCenterPoint(shapes[0]);
-            var isAllSameDir = true;
-            var lastDir = -1;
+            Drawing.PointF refShapeCenter = ShapeUtil.GetCenterPoint(shapes[0]);
+            bool isAllSameDir = true;
+            int lastDir = -1;
 
-            for (var i = 1; i < shapes.Count; i++)
+            for (int i = 1; i < shapes.Count; i++)
             {
-                var shape = shapes[i];
-                var shapeCenter = ShapeUtil.GetCenterPoint(shape);
-                var angle = (float) AngleBetweenTwoPoints(refShapeCenter, shapeCenter);
+                Shape shape = shapes[i];
+                Drawing.PointF shapeCenter = ShapeUtil.GetCenterPoint(shape);
+                float angle = (float) AngleBetweenTwoPoints(refShapeCenter, shapeCenter);
 
-                var dir = GetDirectionWrtRefShape(shape, angle);
+                int dir = GetDirectionWrtRefShape(shape, angle);
 
                 if (i == 1)
                 {
@@ -2305,14 +2305,14 @@ namespace PowerPointLabs.PositionsLab
                 lastDir++;
             }
 
-            for (var i = 1; i < shapes.Count; i++)
+            for (int i = 1; i < shapes.Count; i++)
             {
-                var shape = shapes[i];
-                var shapeCenter = ShapeUtil.GetCenterPoint(shape);
-                var angle = (float) AngleBetweenTwoPoints(refShapeCenter, shapeCenter);
+                Shape shape = shapes[i];
+                Drawing.PointF shapeCenter = ShapeUtil.GetCenterPoint(shape);
+                float angle = (float) AngleBetweenTwoPoints(refShapeCenter, shapeCenter);
 
                 float defaultUpAngle = 0;
-                var hasDefaultDirection = shapeDefaultUpAngle.TryGetValue(shape.AutoShapeType, out defaultUpAngle);
+                bool hasDefaultDirection = shapeDefaultUpAngle.TryGetValue(shape.AutoShapeType, out defaultUpAngle);
 
                 if (!hasDefaultDirection)
                 {
@@ -2356,7 +2356,7 @@ namespace PowerPointLabs.PositionsLab
 
         private static void SnapTo0Or180(Shape shape)
         {
-            var rotation = shape.Rotation;
+            float rotation = shape.Rotation;
 
             if (rotation >= 90 && rotation < 270)
             {
@@ -2370,7 +2370,7 @@ namespace PowerPointLabs.PositionsLab
 
         private static void SnapTo90Or270(Shape shape)
         {
-            var rotation = shape.Rotation;
+            float rotation = shape.Rotation;
 
             if (rotation >= 0 && rotation < 180)
             {
@@ -2384,12 +2384,12 @@ namespace PowerPointLabs.PositionsLab
 
         private static bool IsVertical(Shape shape)
         {
-            var shapeIsVertical = shape.Height > shape.Width;
+            bool shapeIsVertical = shape.Height > shape.Width;
 
             if (NearlyEqual(shape.Height, shape.Width, Epsilon))
             {
                 float defaultUpAngle = 0;
-                var hasDefaultDirection = shapeDefaultUpAngle.TryGetValue(shape.AutoShapeType, out defaultUpAngle);
+                bool hasDefaultDirection = shapeDefaultUpAngle.TryGetValue(shape.AutoShapeType, out defaultUpAngle);
                 if (hasDefaultDirection)
                 {
                     if (NearlyEqual(defaultUpAngle, 0.0f, Epsilon) || NearlyEqual(defaultUpAngle, 180.0f, Epsilon))
@@ -2413,10 +2413,10 @@ namespace PowerPointLabs.PositionsLab
                 throw new Exception(PositionsLabText.ErrorNoSelection);
             }
 
-            for (var i = 1; i <= selectedShapes.Count; i++)
+            for (int i = 1; i <= selectedShapes.Count; i++)
             {
-                var currentShape = selectedShapes[i];
-                var currentRotation = currentShape.Rotation;
+                Shape currentShape = selectedShapes[i];
+                float currentRotation = currentShape.Rotation;
                 currentShape.Flip(MsoFlipCmd.msoFlipHorizontal);
                 currentShape.Rotation = currentRotation;
             }
@@ -2429,10 +2429,10 @@ namespace PowerPointLabs.PositionsLab
                 throw new Exception(PositionsLabText.ErrorNoSelection);
             }
 
-            for (var i = 1; i <= selectedShapes.Count; i++)
+            for (int i = 1; i <= selectedShapes.Count; i++)
             {
-                var currentShape = selectedShapes[i];
-                var currentRotation = currentShape.Rotation;
+                Shape currentShape = selectedShapes[i];
+                float currentRotation = currentShape.Rotation;
                 currentShape.Flip(MsoFlipCmd.msoFlipVertical);
                 currentShape.Rotation = currentRotation;
             }
@@ -2446,7 +2446,7 @@ namespace PowerPointLabs.PositionsLab
 
         public static double AngleBetweenTwoPoints(Drawing.PointF refPoint, Drawing.PointF pt)
         {
-            var angle = Math.Atan((pt.Y - refPoint.Y)/(pt.X - refPoint.X))*180/Math.PI;
+            double angle = Math.Atan((pt.Y - refPoint.Y)/(pt.X - refPoint.X))*180/Math.PI;
 
             if (pt.X - refPoint.X >= 0)
             {
@@ -2462,15 +2462,15 @@ namespace PowerPointLabs.PositionsLab
 
         public static double DistanceBetweenTwoPoints(Drawing.PointF refPoint, Drawing.PointF pt)
         {
-            var distance = Math.Sqrt(Math.Pow(pt.X - refPoint.X, 2) + Math.Pow(refPoint.Y - pt.Y, 2));
+            double distance = Math.Sqrt(Math.Pow(pt.X - refPoint.X, 2) + Math.Pow(refPoint.Y - pt.Y, 2));
             return distance;
         }
 
         public static bool NearlyEqual(float a, float b, float epsilon)
         {
-            var absA = Math.Abs(a);
-            var absB = Math.Abs(b);
-            var diff = Math.Abs(a - b);
+            float absA = Math.Abs(a);
+            float absB = Math.Abs(b);
+            float diff = Math.Abs(a - b);
 
             if (a == b)
             {
@@ -2490,7 +2490,7 @@ namespace PowerPointLabs.PositionsLab
         private static int GetDirectionWrtRefShape(Shape shape, float angleFromRefShape)
         {
             float defaultUpAngle;
-            var hasDefaultDirection = shapeDefaultUpAngle.TryGetValue(shape.AutoShapeType, out defaultUpAngle);
+            bool hasDefaultDirection = shapeDefaultUpAngle.TryGetValue(shape.AutoShapeType, out defaultUpAngle);
 
             if (!hasDefaultDirection)
             {
@@ -2504,16 +2504,16 @@ namespace PowerPointLabs.PositionsLab
                 }
             }
 
-            var angle = AddAngles(angleFromRefShape, defaultUpAngle);
-            var diff = SubtractAngles(shape.Rotation, angle);
-            var phaseInFloat = diff/90;
+            float angle = AddAngles(angleFromRefShape, defaultUpAngle);
+            float diff = SubtractAngles(shape.Rotation, angle);
+            float phaseInFloat = diff/90;
 
             if (!NearlyEqual(phaseInFloat, (float) Math.Round(phaseInFloat), Epsilon))
             {
                 return None;
             }
 
-            var phase = (int) Math.Round(phaseInFloat);
+            int phase = (int) Math.Round(phaseInFloat);
 
             return phase % 4;
         }
@@ -2530,7 +2530,7 @@ namespace PowerPointLabs.PositionsLab
 
         public static float SubtractAngles(float a, float b)
         {
-            var diff = a - b;
+            float diff = a - b;
             if (diff < 0)
             {
                 return 360 + diff;
@@ -2541,13 +2541,13 @@ namespace PowerPointLabs.PositionsLab
 
         public static float[] GetLongestWidthsOfRowsByRow(List<PPShape> shapes, int rowLength, int numIndicesToSkip)
         {
-            var longestWidths = new float[rowLength];
-            var numShapes = shapes.Count;
-            var remainder = numShapes%rowLength;
+            float[] longestWidths = new float[rowLength];
+            int numShapes = shapes.Count;
+            int remainder = numShapes%rowLength;
 
-            for (var i = 0; i < numShapes; i++)
+            for (int i = 0; i < numShapes; i++)
             {
-                var longestRowIndex = i%rowLength;
+                int longestRowIndex = i%rowLength;
                 if (numShapes - i == remainder - 1)
                 {
                     longestRowIndex += numIndicesToSkip;
@@ -2571,9 +2571,9 @@ namespace PowerPointLabs.PositionsLab
             float gridMarginLeft = PositionsLabSettings.GridMarginLeft;
             float gridMarginRight = PositionsLabSettings.GridMarginRight;
 
-            for (var i = 0; i < numShapes; i++)
+            for (int i = 0; i < numShapes; i++)
             {
-                var rowIndex = i % rowLength;
+                int rowIndex = i % rowLength;
 
                 if (rowIndex == 0)
                 {
@@ -2596,11 +2596,11 @@ namespace PowerPointLabs.PositionsLab
 
         public static float[] GetLongestHeightsOfColsByRow(List<PPShape> shapes, int rowLength, int colLength)
         {
-            var longestHeights = new float[colLength];
+            float[] longestHeights = new float[colLength];
 
-            for (var i = 0; i < shapes.Count; i++)
+            for (int i = 0; i < shapes.Count; i++)
             {
-                var longestHeightIndex = i/rowLength;
+                int longestHeightIndex = i/rowLength;
                 if (longestHeights[longestHeightIndex] < shapes[i].AbsoluteHeight)
                 {
                     longestHeights[longestHeightIndex] = shapes[i].AbsoluteHeight;
@@ -2612,12 +2612,12 @@ namespace PowerPointLabs.PositionsLab
 
         public static float[] GetLongestWidthsOfRowsByCol(List<PPShape> shapes, int rowLength, int colLength, int numIndicesToSkip)
         {
-            var longestWidths = new float[rowLength];
-            var numShapes = shapes.Count;
-            var augmentedShapeIndex = 0;
-            var remainder = colLength - (rowLength*colLength - numShapes);
+            float[] longestWidths = new float[rowLength];
+            int numShapes = shapes.Count;
+            int augmentedShapeIndex = 0;
+            int remainder = colLength - (rowLength*colLength - numShapes);
 
-            for (var i = 0; i < numShapes; i++)
+            for (int i = 0; i < numShapes; i++)
             {
                 //If last index and need to skip, skip index 
                 if (numIndicesToSkip > 0 && IsLastIndexOfRow(augmentedShapeIndex, rowLength))
@@ -2639,7 +2639,7 @@ namespace PowerPointLabs.PositionsLab
                     }
                 }
 
-                var longestWidthsArrayIndex = augmentedShapeIndex%rowLength;
+                int longestWidthsArrayIndex = augmentedShapeIndex%rowLength;
 
                 if (longestWidths[longestWidthsArrayIndex] < shapes[i].AbsoluteWidth)
                 {
@@ -2664,7 +2664,7 @@ namespace PowerPointLabs.PositionsLab
             float gridMarginLeft = PositionsLabSettings.GridMarginLeft;
             float gridMarginRight = PositionsLabSettings.GridMarginRight;
 
-            for (var i = 0; i < numShapes; i++)
+            for (int i = 0; i < numShapes; i++)
             {
                 //If last index and no more remainder, skip the rest
                 if (IsLastIndexOfRow(augmentedShapeIndex, rowLength))
@@ -2705,12 +2705,12 @@ namespace PowerPointLabs.PositionsLab
 
         public static float[] GetLongestHeightsOfColsByCol(List<PPShape> shapes, int rowLength, int colLength, int numIndicesToSkip)
         {
-            var longestHeights = new float[colLength];
-            var numShapes = shapes.Count;
-            var augmentedShapeIndex = 0;
-            var remainder = colLength - (rowLength*colLength - numShapes);
+            float[] longestHeights = new float[colLength];
+            int numShapes = shapes.Count;
+            int augmentedShapeIndex = 0;
+            int remainder = colLength - (rowLength*colLength - numShapes);
 
-            for (var i = 0; i < numShapes; i++)
+            for (int i = 0; i < numShapes; i++)
             {
                 //If last index and need to skip, skip index 
                 if (numIndicesToSkip > 0 && IsLastIndexOfRow(augmentedShapeIndex, rowLength))
@@ -2732,7 +2732,7 @@ namespace PowerPointLabs.PositionsLab
                     }
                 }
 
-                var longestHeightArrayIndex = augmentedShapeIndex/rowLength;
+                int longestHeightArrayIndex = augmentedShapeIndex/rowLength;
 
                 if (longestHeights[longestHeightArrayIndex] < shapes[i].AbsoluteHeight)
                 {
@@ -2757,7 +2757,7 @@ namespace PowerPointLabs.PositionsLab
 
         public static int IndicesToSkip(int totalSelectedShapes, int rowLength, PositionsLabSettings.GridAlignment alignment)
         {
-            var numOfShapesInLastRow = totalSelectedShapes%rowLength;
+            int numOfShapesInLastRow = totalSelectedShapes%rowLength;
 
             if (alignment == PositionsLabSettings.GridAlignment.AlignLeft || 
                 alignment == PositionsLabSettings.GridAlignment.None || 
@@ -2773,7 +2773,7 @@ namespace PowerPointLabs.PositionsLab
 
             if (alignment == PositionsLabSettings.GridAlignment.AlignCenter)
             {
-                var difference = rowLength - numOfShapesInLastRow;
+                int difference = rowLength - numOfShapesInLastRow;
                 return difference/2;
             }
 
@@ -2787,8 +2787,8 @@ namespace PowerPointLabs.PositionsLab
                 return -1;
             }
 
-            var start = 0;
-            var end = 0;
+            int start = 0;
+            int end = 0;
 
             if (index1 < index2)
             {
@@ -2803,7 +2803,7 @@ namespace PowerPointLabs.PositionsLab
 
             float difference = 0;
 
-            for (var i = start; i < end; i++)
+            for (int i = start; i < end; i++)
             {
                 difference += (differences[i] / 2 + margin1 + margin2 + differences[i + 1] / 2);
             }
@@ -2813,30 +2813,30 @@ namespace PowerPointLabs.PositionsLab
 
         private static float[] GetShapeBoundaryAngles(Drawing.PointF origin, Shape shape)
         {
-            var ppShape = new PPShape(shape, false);
-            var points = ppShape.Points;
-            var pointAngles = new List<float>();
+            PPShape ppShape = new PPShape(shape, false);
+            List<Drawing.PointF> points = ppShape.Points;
+            List<float> pointAngles = new List<float>();
 
-            foreach (var point in points)
+            foreach (Drawing.PointF point in points)
             {
-                var angle = (float)AngleBetweenTwoPoints(origin, point);
+                float angle = (float)AngleBetweenTwoPoints(origin, point);
                 pointAngles.Add(angle);
             }
 
-            var isSpanAcross0Degrees = false;
-            var hasTurningPoint = false;
+            bool isSpanAcross0Degrees = false;
+            bool hasTurningPoint = false;
             bool isCurrentClockwise;
-            var isPreviousClockwise = pointAngles[0] - pointAngles[pointAngles.Count - 1] >= 0;
-            var turningPointAngles = new List<float>();
+            bool isPreviousClockwise = pointAngles[0] - pointAngles[pointAngles.Count - 1] >= 0;
+            List<float> turningPointAngles = new List<float>();
 
-            var boundaryAngles = new float[2];
+            float[] boundaryAngles = new float[2];
             boundaryAngles[0] = pointAngles[0];
             boundaryAngles[1] = pointAngles[0];
 
             for (int i = 1; i < pointAngles.Count; i++)
             {
-                var previousAngle = pointAngles[i - 1];
-                var currentAngle = pointAngles[i];
+                float previousAngle = pointAngles[i - 1];
+                float currentAngle = pointAngles[i];
                 isCurrentClockwise = currentAngle - previousAngle >= 0;
 
                 if (Math.Abs(currentAngle - previousAngle) > 180)
@@ -2886,12 +2886,12 @@ namespace PowerPointLabs.PositionsLab
 
         private static Drawing.PointF GetVisualCenter(Shape shape)
         {
-            var duplicateShape = shape.Duplicate()[1];
+            Shape duplicateShape = shape.Duplicate()[1];
             duplicateShape.Left = shape.Left;
             duplicateShape.Top = shape.Top;
 
-            var duplicatePPShape = new PPShape(duplicateShape);
-            var visualCenter = duplicatePPShape.VisualCenter;
+            PPShape duplicatePPShape = new PPShape(duplicateShape);
+            Drawing.PointF visualCenter = duplicatePPShape.VisualCenter;
             duplicateShape.Delete();
 
             return visualCenter;
@@ -2908,7 +2908,7 @@ namespace PowerPointLabs.PositionsLab
 
                 for (int i = 0; i < selectedShapes.Count; i++)
                 {
-                    var shapePos = selectedShapes[i].VisualCenter;
+                    Drawing.PointF shapePos = selectedShapes[i].VisualCenter;
                     Drawing.PointF prevShapePos = new Drawing.PointF();
                     if (!prevSelectedShapes.TryGetValue(selectedShapes[i].Name, out prevShapePos))
                     {
@@ -2939,7 +2939,7 @@ namespace PowerPointLabs.PositionsLab
             prevSelectedShapes.Clear();
             for (int i = 0; i < selectedShapes.Count; i++)
             {
-                var shapePos = selectedShapes[i].VisualCenter;
+                Drawing.PointF shapePos = selectedShapes[i].VisualCenter;
                 prevSelectedShapes.Add(selectedShapes[i].Name, shapePos);
             }
         }
@@ -2966,10 +2966,10 @@ namespace PowerPointLabs.PositionsLab
 
         private static List<PPShape> ConvertShapeRangeToPPShapeList(ShapeRange toAlign)
         {
-            var selectedShapes = new List<PPShape>();
-            for (var i = 1; i <= toAlign.Count; i++)
+            List<PPShape> selectedShapes = new List<PPShape>();
+            for (int i = 1; i <= toAlign.Count; i++)
             {
-                var s = toAlign[i];
+                Shape s = toAlign[i];
                 if (s.Type.Equals(Office.MsoShapeType.msoPicture))
                 {
                     selectedShapes.Add(new PPShape(toAlign[i], false));

--- a/PowerPointLabs/PowerPointLabs/PositionsLab/PositionsPaneWPF.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/PositionsLab/PositionsPaneWPF.xaml.cs
@@ -338,7 +338,7 @@ namespace PowerPointLabs.PositionsLab
         {
             //Remove dragging control of user
             this.GetCurrentSelection().Unselect();
-            System.Drawing.PointF p = System.Windows.Forms.Control.MousePosition;
+            System.Drawing.Point p = System.Windows.Forms.Control.MousePosition;
 
             float prevAngle = (float)PositionsLabMain.AngleBetweenTwoPoints(ConvertSlidePointToScreenPoint(ShapeUtil.GetCenterPoint(_refPoint)), _prevMousePos);
             float angle = (float)PositionsLabMain.AngleBetweenTwoPoints(ConvertSlidePointToScreenPoint(ShapeUtil.GetCenterPoint(_refPoint)), p) - prevAngle;

--- a/PowerPointLabs/PowerPointLabs/PositionsLab/PositionsPaneWPF.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/PositionsLab/PositionsPaneWPF.xaml.cs
@@ -69,7 +69,7 @@ namespace PowerPointLabs.PositionsLab
         
         private void InitializeHotKeys()
         {
-            var buttonActionMapping = new Dictionary<ToggleButton, Action<bool, bool>>();
+            Dictionary<ToggleButton, Action<bool, bool>> buttonActionMapping = new Dictionary<ToggleButton, Action<bool, bool>>();
             buttonActionMapping.Add(rotationButton, RotateSlightly);
             buttonActionMapping.Add(duplicateRotationButton, RotateSlightly);
 
@@ -90,16 +90,16 @@ namespace PowerPointLabs.PositionsLab
         {
             return () =>
             {
-                var positionsPane = this.GetTaskPane(typeof(PositionsPane));
+                Microsoft.Office.Tools.CustomTaskPane positionsPane = this.GetTaskPane(typeof(PositionsPane));
                 if (positionsPane == null || !positionsPane.Visible)
                 {
                     return false;
                 }
 
-                foreach (var mapping in buttonActionMapping)
+                foreach (KeyValuePair<ToggleButton, Action<bool, bool>> mapping in buttonActionMapping)
                 {
-                    var button = mapping.Key;
-                    var action = mapping.Value;
+                    ToggleButton button = mapping.Key;
+                    Action<bool, bool> action = mapping.Value;
 
                     if ((bool)button.IsChecked)
                     {
@@ -114,14 +114,14 @@ namespace PowerPointLabs.PositionsLab
         
         private void RotateSlightly(bool isClockwise, bool isLarge)
         {
-            var origin = ShapeUtil.GetCenterPoint(_refPoint);
-            var angle = (isClockwise) ? 1f : -1f;
+            System.Drawing.PointF origin = ShapeUtil.GetCenterPoint(_refPoint);
+            float angle = (isClockwise) ? 1f : -1f;
             if (isLarge)
             {
                 angle *= CtrlProportion;
             }
 
-            foreach (var currentShape in _shapesToBeRotated)
+            foreach (Shape currentShape in _shapesToBeRotated)
             {
                 PositionsLabMain.Rotate(currentShape, origin, angle, PositionsLabSettings.ReorientShapeOrientation);
             }
@@ -137,7 +137,7 @@ namespace PowerPointLabs.PositionsLab
 
         private void AlignRightButton_Click(object sender, RoutedEventArgs e)
         {
-            var slideWidth = this.GetCurrentPresentation().SlideWidth;
+            float slideWidth = this.GetCurrentPresentation().SlideWidth;
             Action<ShapeRange, float> positionsAction = (shapes, width) => PositionsLabMain.AlignRight(shapes, width);
             ExecutePositionsAction(positionsAction, slideWidth, false);
         }
@@ -150,29 +150,29 @@ namespace PowerPointLabs.PositionsLab
 
         private void AlignBottomButton_Click(object sender, RoutedEventArgs e)
         {
-            var slideHeight = this.GetCurrentPresentation().SlideHeight;
+            float slideHeight = this.GetCurrentPresentation().SlideHeight;
             Action<ShapeRange, float> positionsAction = (shapes, height) => PositionsLabMain.AlignBottom(shapes, height);
             ExecutePositionsAction(positionsAction, slideHeight, false);
         }
 
         private void AlignHorizontalCenterButton_Click(object sender, RoutedEventArgs e)
         {
-            var slideHeight = this.GetCurrentPresentation().SlideHeight;
+            float slideHeight = this.GetCurrentPresentation().SlideHeight;
             Action<ShapeRange, float> positionsAction = (shapes, height) => PositionsLabMain.AlignHorizontalCenter(shapes, height);
             ExecutePositionsAction(positionsAction, slideHeight, false);
         }
 
         private void AlignVerticalCenterButton_Click(object sender, RoutedEventArgs e)
         {
-            var slideWidth = this.GetCurrentPresentation().SlideWidth;
+            float slideWidth = this.GetCurrentPresentation().SlideWidth;
             Action<ShapeRange, float> positionsAction = (shapes, width) => PositionsLabMain.AlignVerticalCenter(shapes, width);
             ExecutePositionsAction(positionsAction, slideWidth, false);
         }
 
         private void AlignCenterButton_Click(object sender, RoutedEventArgs e)
         {
-            var slideHeight = this.GetCurrentPresentation().SlideHeight;
-            var slideWidth = this.GetCurrentPresentation().SlideWidth;
+            float slideHeight = this.GetCurrentPresentation().SlideHeight;
+            float slideWidth = this.GetCurrentPresentation().SlideWidth;
             Action<ShapeRange, float, float> positionsAction = (shapes, height, width) => PositionsLabMain.AlignCenter(shapes, height, width);
             ExecutePositionsAction(positionsAction, slideHeight, slideWidth, false);
         }
@@ -216,22 +216,22 @@ namespace PowerPointLabs.PositionsLab
         #region Distribute
         private void DistributeHorizontalButton_Click(object sender, RoutedEventArgs e)
         {
-            var slideWidth = this.GetCurrentPresentation().SlideWidth;
+            float slideWidth = this.GetCurrentPresentation().SlideWidth;
             Action<List<PPShape>, float> positionsAction = (shapes, width) => PositionsLabMain.DistributeHorizontal(shapes, width);
             ExecutePositionsAction(positionsAction, slideWidth, false);
         }
 
         private void DistributeVerticalButton_Click(object sender, RoutedEventArgs e)
         {
-            var slideHeight = this.GetCurrentPresentation().SlideHeight;
+            float slideHeight = this.GetCurrentPresentation().SlideHeight;
             Action<List<PPShape>, float> positionsAction = (shapes, height) => PositionsLabMain.DistributeVertical(shapes, height);
             ExecutePositionsAction(positionsAction, slideHeight, false);
         }
 
         private void DistributeCenterButton_Click(object sender, RoutedEventArgs e)
         {
-            var slideWidth = this.GetCurrentPresentation().SlideWidth;
-            var slideHeight = this.GetCurrentPresentation().SlideHeight;
+            float slideWidth = this.GetCurrentPresentation().SlideWidth;
+            float slideHeight = this.GetCurrentPresentation().SlideHeight;
             Action<List<PPShape>, float, float> positionsAction = (shapes, width, height) => PositionsLabMain.DistributeCenter(shapes, width, height);
             ExecutePositionsAction(positionsAction, slideWidth, slideHeight, false);
         }
@@ -246,10 +246,10 @@ namespace PowerPointLabs.PositionsLab
 
             try
             {
-                var selectedShapes = this.GetCurrentSelection().ShapeRange;
-                var numShapesSelected = selectedShapes.Count;
-                var colLength = (int)Math.Ceiling(Math.Sqrt(numShapesSelected));
-                var rowLength = (int)Math.Ceiling((double)numShapesSelected / colLength);
+                ShapeRange selectedShapes = this.GetCurrentSelection().ShapeRange;
+                int numShapesSelected = selectedShapes.Count;
+                int colLength = (int)Math.Ceiling(Math.Sqrt(numShapesSelected));
+                int rowLength = (int)Math.Ceiling((double)numShapesSelected / colLength);
 
                 _positionsDistributeGridDialog = new PositionsDistributeGridDialog(numShapesSelected, rowLength, colLength,
                                                                                     PositionsLabSettings.DistributeGridAlignment,
@@ -300,8 +300,8 @@ namespace PowerPointLabs.PositionsLab
 
         private void RotationButton_Click(object sender, RoutedEventArgs e)
         {
-            var noShapesSelected = this.GetCurrentSelection().Type != PpSelectionType.ppSelectionShapes;
-            var button = (ToggleButton)sender;
+            bool noShapesSelected = this.GetCurrentSelection().Type != PpSelectionType.ppSelectionShapes;
+            ToggleButton button = (ToggleButton)sender;
 
             if (noShapesSelected)
             {
@@ -310,7 +310,7 @@ namespace PowerPointLabs.PositionsLab
                 return;
             }
 
-            var selectedShapes = this.GetCurrentSelection().ShapeRange;
+            ShapeRange selectedShapes = this.GetCurrentSelection().ShapeRange;
 
             if (selectedShapes.Count <= 1)
             {
@@ -321,7 +321,7 @@ namespace PowerPointLabs.PositionsLab
 
             ClearAllEventHandlers();
 
-            var currentSlide = this.GetCurrentSlide();
+            Models.PowerPointSlide currentSlide = this.GetCurrentSlide();
 
             _refPoint = selectedShapes[1];
             _shapesToBeRotated = ConvertShapeRangeToShapeList(selectedShapes, 2);
@@ -338,14 +338,14 @@ namespace PowerPointLabs.PositionsLab
         {
             //Remove dragging control of user
             this.GetCurrentSelection().Unselect();
-            var p = System.Windows.Forms.Control.MousePosition;
+            System.Drawing.PointF p = System.Windows.Forms.Control.MousePosition;
 
-            var prevAngle = (float)PositionsLabMain.AngleBetweenTwoPoints(ConvertSlidePointToScreenPoint(ShapeUtil.GetCenterPoint(_refPoint)), _prevMousePos);
-            var angle = (float)PositionsLabMain.AngleBetweenTwoPoints(ConvertSlidePointToScreenPoint(ShapeUtil.GetCenterPoint(_refPoint)), p) - prevAngle;
-            
-            var origin = ShapeUtil.GetCenterPoint(_refPoint);
+            float prevAngle = (float)PositionsLabMain.AngleBetweenTwoPoints(ConvertSlidePointToScreenPoint(ShapeUtil.GetCenterPoint(_refPoint)), _prevMousePos);
+            float angle = (float)PositionsLabMain.AngleBetweenTwoPoints(ConvertSlidePointToScreenPoint(ShapeUtil.GetCenterPoint(_refPoint)), p) - prevAngle;
 
-            foreach (var currentShape in _shapesToBeRotated)
+            System.Drawing.PointF origin = ShapeUtil.GetCenterPoint(_refPoint);
+
+            foreach (Shape currentShape in _shapesToBeRotated)
             {
                 PositionsLabMain.Rotate(currentShape, origin, angle, PositionsLabSettings.ReorientShapeOrientation);
             }
@@ -372,7 +372,7 @@ namespace PowerPointLabs.PositionsLab
         {
             try
             {
-                var button = ((bool)rotationButton.IsChecked) ? rotationButton :
+                ToggleButton button = ((bool)rotationButton.IsChecked) ? rotationButton :
                              ((bool)duplicateRotationButton.IsChecked) ? duplicateRotationButton
                                                                        : null;
 
@@ -382,8 +382,8 @@ namespace PowerPointLabs.PositionsLab
                     return;
                 }
 
-                var p = System.Windows.Forms.Control.MousePosition;
-                var selectedShape = GetShapeDirectlyBelowMousePos(_allShapesInSlide, p);
+                System.Drawing.Point p = System.Windows.Forms.Control.MousePosition;
+                Shape selectedShape = GetShapeDirectlyBelowMousePos(_allShapesInSlide, p);
 
                 if (selectedShape == null)
                 {
@@ -392,8 +392,8 @@ namespace PowerPointLabs.PositionsLab
                     return;
                 }
 
-                var isShapeToBeRotated = _shapesToBeRotated.Contains(selectedShape);
-                var isRefPoint = _refPoint.Id == selectedShape.Id;
+                bool isShapeToBeRotated = _shapesToBeRotated.Contains(selectedShape);
+                bool isRefPoint = _refPoint.Id == selectedShape.Id;
 
                 if (!isShapeToBeRotated && !isRefPoint)
                 {
@@ -412,9 +412,9 @@ namespace PowerPointLabs.PositionsLab
 
                 if (button == duplicateRotationButton)
                 {
-                    foreach (var currentShape in _shapesToBeRotated)
+                    foreach (Shape currentShape in _shapesToBeRotated)
                     {
-                        var duplicatedShape = currentShape.Duplicate()[1];
+                        Shape duplicatedShape = currentShape.Duplicate()[1];
                         duplicatedShape.Left -= 12;
                         duplicatedShape.Top -= 12;
                         ShapeUtil.MoveZToJustBehind(duplicatedShape, currentShape);
@@ -432,7 +432,7 @@ namespace PowerPointLabs.PositionsLab
 
         private void LockAxisButton_Click(object sender, RoutedEventArgs e)
         {
-            var noShapesSelected = this.GetCurrentSelection().Type != PpSelectionType.ppSelectionShapes;
+            bool noShapesSelected = this.GetCurrentSelection().Type != PpSelectionType.ppSelectionShapes;
 
             if (noShapesSelected)
             {
@@ -441,11 +441,11 @@ namespace PowerPointLabs.PositionsLab
                 return;
             }
 
-            var selectedShapes = this.GetCurrentSelection().ShapeRange;
+            ShapeRange selectedShapes = this.GetCurrentSelection().ShapeRange;
 
             ClearAllEventHandlers();
 
-            var currentSlide = this.GetCurrentSlide();
+            Models.PowerPointSlide currentSlide = this.GetCurrentSlide();
 
             _shapesToBeMoved = ConvertShapeRangeToShapeList(selectedShapes, 1);
             _allShapesInSlide = ConvertShapesToShapeList(currentSlide.Shapes);
@@ -459,14 +459,14 @@ namespace PowerPointLabs.PositionsLab
             //Remove dragging control of user
             this.GetCurrentSelection().Unselect();
 
-            var currentMousePos = System.Windows.Forms.Control.MousePosition;
+            System.Drawing.Point currentMousePos = System.Windows.Forms.Control.MousePosition;
 
             float diffX = currentMousePos.X - _initialMousePos.X;
             float diffY = currentMousePos.Y - _initialMousePos.Y;
 
-            for (var i = 0; i < _shapesToBeMoved.Count; i++)
+            for (int i = 0; i < _shapesToBeMoved.Count; i++)
             {
-                var s = _shapesToBeMoved[i];
+                Shape s = _shapesToBeMoved[i];
                 if (Math.Abs(diffX) > Math.Abs(diffY))
                 {
                     s.Left = _initialPos[i, Left] + diffX;
@@ -496,9 +496,9 @@ namespace PowerPointLabs.PositionsLab
                     return;
                 }
 
-                var p = System.Windows.Forms.Control.MousePosition;
-                var currentSlide = this.GetCurrentSlide();
-                var selectedShape = GetShapeDirectlyBelowMousePos(_allShapesInSlide, p);
+                System.Drawing.Point p = System.Windows.Forms.Control.MousePosition;
+                Models.PowerPointSlide currentSlide = this.GetCurrentSlide();
+                Shape selectedShape = GetShapeDirectlyBelowMousePos(_allShapesInSlide, p);
 
                 if (selectedShape == null)
                 {
@@ -507,7 +507,7 @@ namespace PowerPointLabs.PositionsLab
                     return;
                 }
 
-                var isShapeToBeMoved = _shapesToBeMoved.Contains(selectedShape);
+                bool isShapeToBeMoved = _shapesToBeMoved.Contains(selectedShape);
 
                 if (!isShapeToBeMoved)
                 {
@@ -519,9 +519,9 @@ namespace PowerPointLabs.PositionsLab
                 this.StartNewUndoEntry();
 
                 _initialPos = new float[_shapesToBeMoved.Count, 2];
-                for (var i = 0; i < _shapesToBeMoved.Count; i++)
+                for (int i = 0; i < _shapesToBeMoved.Count; i++)
                 {
-                    var s = _shapesToBeMoved[i];
+                    Shape s = _shapesToBeMoved[i];
                     _initialPos[i, Left] = s.Left;
                     _initialPos[i, Top] = s.Top;
                 }
@@ -570,7 +570,7 @@ namespace PowerPointLabs.PositionsLab
 
         private void AlignRightButton_MouseEnter(object sender, System.Windows.Input.MouseEventArgs e)
         {
-            var slideWidth = this.GetCurrentPresentation().SlideWidth;
+            float slideWidth = this.GetCurrentPresentation().SlideWidth;
             Action<ShapeRange, float> positionsAction = (shapes, width) => PositionsLabMain.AlignRight(shapes, width);
             _previewCallBack = delegate
             {
@@ -591,7 +591,7 @@ namespace PowerPointLabs.PositionsLab
 
         private void AlignBottomButton_MouseEnter(object sender, System.Windows.Input.MouseEventArgs e)
         {
-            var slideHeight = this.GetCurrentPresentation().SlideHeight;
+            float slideHeight = this.GetCurrentPresentation().SlideHeight;
             Action<ShapeRange, float> positionsAction = (shapes, height) => PositionsLabMain.AlignBottom(shapes, height);
             _previewCallBack = delegate
             {
@@ -602,7 +602,7 @@ namespace PowerPointLabs.PositionsLab
 
         private void AlignHorizontalCenterButton_MouseEnter(object sender, System.Windows.Input.MouseEventArgs e)
         {
-            var slideHeight = this.GetCurrentPresentation().SlideHeight;
+            float slideHeight = this.GetCurrentPresentation().SlideHeight;
             Action<ShapeRange, float> positionsAction = (shapes, height) => PositionsLabMain.AlignHorizontalCenter(shapes, height);
             _previewCallBack = delegate
             {
@@ -613,7 +613,7 @@ namespace PowerPointLabs.PositionsLab
 
         private void AlignVerticalCenterButton_MouseEnter(object sender, System.Windows.Input.MouseEventArgs e)
         {
-            var slideWidth = this.GetCurrentPresentation().SlideWidth;
+            float slideWidth = this.GetCurrentPresentation().SlideWidth;
             Action<ShapeRange, float> positionsAction = (shapes, width) => PositionsLabMain.AlignVerticalCenter(shapes, width);
             _previewCallBack = delegate
             {
@@ -624,8 +624,8 @@ namespace PowerPointLabs.PositionsLab
 
         private void AlignCenterButton_MouseEnter(object sender, System.Windows.Input.MouseEventArgs e)
         {
-            var slideHeight = this.GetCurrentPresentation().SlideHeight;
-            var slideWidth = this.GetCurrentPresentation().SlideWidth;
+            float slideHeight = this.GetCurrentPresentation().SlideHeight;
+            float slideWidth = this.GetCurrentPresentation().SlideWidth;
             Action<ShapeRange, float, float> positionsAction = (shapes, height, width) => PositionsLabMain.AlignCenter(shapes, height, width);
             _previewCallBack = delegate
             {
@@ -690,7 +690,7 @@ namespace PowerPointLabs.PositionsLab
 
         private void DistributeHorizontalButton_MouseEnter(object sender, System.Windows.Input.MouseEventArgs e)
         {
-            var slideWidth = this.GetCurrentPresentation().SlideWidth;
+            float slideWidth = this.GetCurrentPresentation().SlideWidth;
             Action<List<PPShape>, float> positionsAction = (shapes, width) => PositionsLabMain.DistributeHorizontal(shapes, width);
             _previewCallBack = delegate
             {
@@ -701,7 +701,7 @@ namespace PowerPointLabs.PositionsLab
 
         private void DistributeVerticalButton_MouseEnter(object sender, System.Windows.Input.MouseEventArgs e)
         {
-            var slideHeight = this.GetCurrentPresentation().SlideHeight;
+            float slideHeight = this.GetCurrentPresentation().SlideHeight;
             Action<List<PPShape>, float> positionsAction = (shapes, height) => PositionsLabMain.DistributeVertical(shapes, height);
             _previewCallBack = delegate
             {
@@ -712,8 +712,8 @@ namespace PowerPointLabs.PositionsLab
 
         private void DistributeCenterButton_MouseEnter(object sender, System.Windows.Input.MouseEventArgs e)
         {
-            var slideWidth = this.GetCurrentPresentation().SlideWidth;
-            var slideHeight = this.GetCurrentPresentation().SlideHeight;
+            float slideWidth = this.GetCurrentPresentation().SlideWidth;
+            float slideHeight = this.GetCurrentPresentation().SlideHeight;
             Action<List<PPShape>, float, float> positionsAction = (shapes, width, height) => PositionsLabMain.DistributeCenter(shapes, width, height);
             _previewCallBack = delegate
             {
@@ -791,15 +791,15 @@ namespace PowerPointLabs.PositionsLab
 
         private bool IsPointWithinShape(Shape shape, System.Drawing.Point p)
         {
-            var epsilon = 0.00001f;
+            float epsilon = 0.00001f;
 
-            var centerPoint = ConvertSlidePointToScreenPoint(ShapeUtil.GetCenterPoint(shape));
-            var rotatedMousePos = CommonUtil.RotatePoint(p, centerPoint, -shape.Rotation);
+            System.Drawing.PointF centerPoint = ConvertSlidePointToScreenPoint(ShapeUtil.GetCenterPoint(shape));
+            System.Drawing.PointF rotatedMousePos = CommonUtil.RotatePoint(p, centerPoint, -shape.Rotation);
 
-            var x1 = PointsToScreenPixelsX(shape.Left);
-            var y1 = PointsToScreenPixelsY(shape.Top);
-            var x2 = PointsToScreenPixelsX(shape.Left + shape.Width);
-            var y2 = PointsToScreenPixelsY(shape.Top + shape.Height);
+            float x1 = PointsToScreenPixelsX(shape.Left);
+            float y1 = PointsToScreenPixelsY(shape.Top);
+            float x2 = PointsToScreenPixelsX(shape.Left + shape.Width);
+            float y2 = PointsToScreenPixelsY(shape.Top + shape.Height);
 
             // Expand the bounding box with a standard padding
             // NOTE: PowerPoint transforms the mouse cursor when entering shapes before it actually
@@ -818,7 +818,7 @@ namespace PowerPointLabs.PositionsLab
         {
             Shape aShape = null;
 
-            foreach (var s in shapes)
+            foreach (Shape s in shapes)
             {
                 if (IsPointWithinShape(s, p))
                 {
@@ -834,11 +834,11 @@ namespace PowerPointLabs.PositionsLab
 
         private List<PPShape> ConvertShapeRangeToPPShapeList (ShapeRange range, int index)
         {
-            var shapes = new List<PPShape>();
+            List<PPShape> shapes = new List<PPShape>();
 
-            for (var i = index; i <= range.Count; i++)
+            for (int i = index; i <= range.Count; i++)
             {
-                var s = range[i];
+                Shape s = range[i];
                 if (s.Type.Equals(Office.MsoShapeType.msoPicture))
                 {
                     shapes.Add(new PPShape(range[i], false));
@@ -854,9 +854,9 @@ namespace PowerPointLabs.PositionsLab
 
         private List<Shape> ConvertShapeRangeToShapeList(ShapeRange range, int index)
         {
-            var shapes = new List<Shape>();
+            List<Shape> shapes = new List<Shape>();
 
-            for (var i = index; i <= range.Count; i++)
+            for (int i = index; i <= range.Count; i++)
             {
                 shapes.Add(range[i]);
             }
@@ -866,7 +866,7 @@ namespace PowerPointLabs.PositionsLab
 
         private List<Shape> ConvertShapesToShapeList(Shapes shapes)
         {
-            var listOfShapes = new List<Shape>();
+            List<Shape> listOfShapes = new List<Shape>();
 
             foreach (Shape s in shapes)
             {
@@ -886,7 +886,7 @@ namespace PowerPointLabs.PositionsLab
 
         private void SelectShapes(List<Shape> shapes)
         {
-            foreach (var s in shapes)
+            foreach (Shape s in shapes)
             {
                 s.Select(Office.MsoTriState.msoFalse);
             }
@@ -982,7 +982,7 @@ namespace PowerPointLabs.PositionsLab
                 return;
             }
             
-            var errorMessage = GetErrorMessage(exception.Message);
+            string errorMessage = GetErrorMessage(exception.Message);
             if (!string.Equals(errorMessage, PositionsLabText.ErrorUndefined, StringComparison.Ordinal))
             {
                 MessageBox.Show(content, PositionsLabText.ErrorDialogTitle);
@@ -1037,7 +1037,7 @@ namespace PowerPointLabs.PositionsLab
 
             try
             {
-                var selectedShapes = this.GetCurrentSelection().ShapeRange;
+                ShapeRange selectedShapes = this.GetCurrentSelection().ShapeRange;
 
                 if (isPreview)
                 {
@@ -1058,8 +1058,8 @@ namespace PowerPointLabs.PositionsLab
                 }
                 else if (isConvertPPShape)
                 {
-                    var simulatedPPShapes = ConvertShapeRangeToPPShapeList(simulatedShapes, 1);
-                    var initialPositions = SaveOriginalPositions(simulatedPPShapes);
+                    List<PPShape> simulatedPPShapes = ConvertShapeRangeToPPShapeList(simulatedShapes, 1);
+                    float[,] initialPositions = SaveOriginalPositions(simulatedPPShapes);
 
                     positionsAction.Invoke(simulatedShapes);
 
@@ -1109,7 +1109,7 @@ namespace PowerPointLabs.PositionsLab
 
             try
             {
-                var selectedShapes = this.GetCurrentSelection().ShapeRange;
+                ShapeRange selectedShapes = this.GetCurrentSelection().ShapeRange;
 
                 if (isPreview)
                 {
@@ -1129,8 +1129,8 @@ namespace PowerPointLabs.PositionsLab
                 }
                 else
                 {
-                    var simulatedPPShapes = ConvertShapeRangeToPPShapeList(simulatedShapes, 1);
-                    var initialPositions = SaveOriginalPositions(simulatedPPShapes);
+                    List<PPShape> simulatedPPShapes = ConvertShapeRangeToPPShapeList(simulatedShapes, 1);
+                    float[,] initialPositions = SaveOriginalPositions(simulatedPPShapes);
 
                     positionsAction.Invoke(simulatedShapes, dimension);
 
@@ -1174,7 +1174,7 @@ namespace PowerPointLabs.PositionsLab
 
             try
             {
-                var selectedShapes = this.GetCurrentSelection().ShapeRange;
+                ShapeRange selectedShapes = this.GetCurrentSelection().ShapeRange;
 
                 if (isPreview)
                 {
@@ -1194,8 +1194,8 @@ namespace PowerPointLabs.PositionsLab
                 }
                 else
                 {
-                    var simulatedPPShapes = ConvertShapeRangeToPPShapeList(simulatedShapes, 1);
-                    var initialPositions = SaveOriginalPositions(simulatedPPShapes);
+                    List<PPShape> simulatedPPShapes = ConvertShapeRangeToPPShapeList(simulatedShapes, 1);
+                    float[,] initialPositions = SaveOriginalPositions(simulatedPPShapes);
 
                     positionsAction.Invoke(simulatedShapes, dimension1, dimension2);
 
@@ -1239,7 +1239,7 @@ namespace PowerPointLabs.PositionsLab
 
             try
             {
-                var selectedShapes = this.GetCurrentSelection().ShapeRange;
+                ShapeRange selectedShapes = this.GetCurrentSelection().ShapeRange;
 
                 if (isPreview)
                 {
@@ -1253,8 +1253,8 @@ namespace PowerPointLabs.PositionsLab
                 }
 
                 simulatedShapes = DuplicateShapes(selectedShapes);
-                var simulatedPPShapes = ConvertShapeRangeToPPShapeList(simulatedShapes, 1);
-                var initialPositions = SaveOriginalPositions(simulatedPPShapes);
+                List<PPShape> simulatedPPShapes = ConvertShapeRangeToPPShapeList(simulatedShapes, 1);
+                float[,] initialPositions = SaveOriginalPositions(simulatedPPShapes);
 
                 positionsAction.Invoke(simulatedPPShapes);
 
@@ -1297,7 +1297,7 @@ namespace PowerPointLabs.PositionsLab
 
             try
             {
-                var selectedShapes = this.GetCurrentSelection().ShapeRange;
+                ShapeRange selectedShapes = this.GetCurrentSelection().ShapeRange;
 
                 if (isPreview)
                 {
@@ -1319,8 +1319,8 @@ namespace PowerPointLabs.PositionsLab
                     ShapeUtil.SwapZOrder(simulatedPPShape._shape, selectedShapes[i]);
                 }
 
-                var simulatedPPShapes = ConvertShapeRangeToPPShapeList(simulatedShapes, 1);
-                var initialPositions = SaveOriginalPositions(simulatedPPShapes);
+                List<PPShape> simulatedPPShapes = ConvertShapeRangeToPPShapeList(simulatedShapes, 1);
+                float[,] initialPositions = SaveOriginalPositions(simulatedPPShapes);
 
                 positionsAction.Invoke(simulatedPPShapes, booleanVal);
 
@@ -1363,7 +1363,7 @@ namespace PowerPointLabs.PositionsLab
 
             try
             {
-                var selectedShapes = this.GetCurrentSelection().ShapeRange;
+                ShapeRange selectedShapes = this.GetCurrentSelection().ShapeRange;
 
                 if (isPreview)
                 {
@@ -1377,8 +1377,8 @@ namespace PowerPointLabs.PositionsLab
                 }
 
                 simulatedShapes = DuplicateShapes(selectedShapes);
-                var simulatedPPShapes = ConvertShapeRangeToPPShapeList(simulatedShapes, 1);
-                var initialPositions = SaveOriginalPositions(simulatedPPShapes);
+                List<PPShape> simulatedPPShapes = ConvertShapeRangeToPPShapeList(simulatedShapes, 1);
+                float[,] initialPositions = SaveOriginalPositions(simulatedPPShapes);
 
                 positionsAction.Invoke(simulatedPPShapes, dimension);
 
@@ -1421,7 +1421,7 @@ namespace PowerPointLabs.PositionsLab
 
             try
             {
-                var selectedShapes = this.GetCurrentSelection().ShapeRange;
+                ShapeRange selectedShapes = this.GetCurrentSelection().ShapeRange;
 
                 if (isPreview)
                 {
@@ -1435,8 +1435,8 @@ namespace PowerPointLabs.PositionsLab
                 }
 
                 simulatedShapes = DuplicateShapes(selectedShapes);
-                var simulatedPPShapes = ConvertShapeRangeToPPShapeList(simulatedShapes, 1);
-                var initialPositions = SaveOriginalPositions(simulatedPPShapes);
+                List<PPShape> simulatedPPShapes = ConvertShapeRangeToPPShapeList(simulatedShapes, 1);
+                float[,] initialPositions = SaveOriginalPositions(simulatedPPShapes);
 
                 positionsAction.Invoke(simulatedPPShapes, dimension1, dimension2);
 
@@ -1477,7 +1477,7 @@ namespace PowerPointLabs.PositionsLab
 
             try
             {
-                var selectedShapes = this.GetCurrentSelection().ShapeRange;
+                ShapeRange selectedShapes = this.GetCurrentSelection().ShapeRange;
 
                 if (isPreview)
                 {
@@ -1514,9 +1514,9 @@ namespace PowerPointLabs.PositionsLab
             try
             {
                 this.StartNewUndoEntry();
-                var selectedShapes = this.GetCurrentSelection().ShapeRange;
+                ShapeRange selectedShapes = this.GetCurrentSelection().ShapeRange;
                 simulatedShapes = DuplicateShapes(selectedShapes);
-                var simulatedPPShapes = ConvertShapeRangeToPPShapeList(simulatedShapes, 1);
+                List<PPShape> simulatedPPShapes = ConvertShapeRangeToPPShapeList(simulatedShapes, 1);
 
                 PositionsLabMain.DistributeGrid(simulatedPPShapes, rowLength, colLength);
 
@@ -1555,12 +1555,12 @@ namespace PowerPointLabs.PositionsLab
         {
             if (_previewIsExecuted)
             {
-                var selectedShapes = this.GetCurrentSelection().ShapeRange;
+                ShapeRange selectedShapes = this.GetCurrentSelection().ShapeRange;
 
                 foreach (Shape s in selectedShapes)
                 {
                     PositionShapeProperties properties;
-                    var isPresent = allShapePos.TryGetValue(s.Id, out properties);
+                    bool isPresent = allShapePos.TryGetValue(s.Id, out properties);
 
                     if (isPresent)
                     {
@@ -1603,8 +1603,8 @@ namespace PowerPointLabs.PositionsLab
         {
             for (int i = 1; i <= selected.Count; i++)
             {
-                var selectedShape = selected[i];
-                var simulatedShape = simulatedShapes[i];
+                Shape selectedShape = selected[i];
+                Shape simulatedShape = simulatedShapes[i];
 
                 selectedShape.IncrementLeft(ShapeUtil.GetCenterPoint(simulatedShape).X - ShapeUtil.GetCenterPoint(selectedShape).X);
                 selectedShape.IncrementTop(ShapeUtil.GetCenterPoint(simulatedShape).Y - ShapeUtil.GetCenterPoint(selectedShape).Y);
@@ -1616,8 +1616,8 @@ namespace PowerPointLabs.PositionsLab
         {
             for (int i = 1; i <= selected.Count; i++)
             {
-                var selectedShape = selected[i];
-                var simulatedShape = simulatedShapes[i];
+                Shape selectedShape = selected[i];
+                Shape simulatedShape = simulatedShapes[i];
 
                 selectedShape.IncrementLeft(ShapeUtil.GetCenterPoint(simulatedShape).X - originalPositions[i - 1, Left]);
                 selectedShape.IncrementTop(ShapeUtil.GetCenterPoint(simulatedShape).Y - originalPositions[i - 1, Top]);
@@ -1628,8 +1628,8 @@ namespace PowerPointLabs.PositionsLab
         {
             for (int i = 1; i <= selected.Count; i++)
             {
-                var selectedShape = selected[i];
-                var simulatedShape = simulatedShapes[i - 1];
+                Shape selectedShape = selected[i];
+                PPShape simulatedShape = simulatedShapes[i - 1];
 
                 selectedShape.IncrementLeft(simulatedShape.VisualCenter.X - originalPositions[i - 1, Left]);
                 selectedShape.IncrementTop(simulatedShape.VisualCenter.Y - originalPositions[i - 1, Top]);
@@ -1643,8 +1643,8 @@ namespace PowerPointLabs.PositionsLab
 
             for (int i = 0; i < range.Count; i++)
             {
-                var shape = range[i + 1];
-                var duplicated = shape.Duplicate()[1];
+                Shape shape = range[i + 1];
+                Shape duplicated = shape.Duplicate()[1];
                 duplicated.Name = shape.Name + "_Copy";
                 duplicated.Left = shape.Left;
                 duplicated.Top = shape.Top;
@@ -1656,11 +1656,11 @@ namespace PowerPointLabs.PositionsLab
 
         private float[,] SaveOriginalPositions(List<PPShape> shapes)
         {
-            var initialPositions = new float[shapes.Count, 2];
-            for (var i = 0; i < shapes.Count; i++)
+            float[,] initialPositions = new float[shapes.Count, 2];
+            for (int i = 0; i < shapes.Count; i++)
             {
-                var s = shapes[i];
-                var pt = s.VisualCenter;
+                PPShape s = shapes[i];
+                System.Drawing.PointF pt = s.VisualCenter;
                 initialPositions[i, Left] = pt.X;
                 initialPositions[i, Top] = pt.Y;
             }

--- a/PowerPointLabs/PowerPointLabs/PositionsLab/Views/PositionsDistributeGridDialog.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/PositionsLab/Views/PositionsDistributeGridDialog.xaml.cs
@@ -30,7 +30,7 @@ namespace PowerPointLabs.PositionsLab.Views
                 return;
             }
 
-            var errorMessage = GetErrorMessage(exception.Message);
+            string errorMessage = GetErrorMessage(exception.Message);
             if (!string.Equals(errorMessage, PositionsLabText.ErrorUndefined, StringComparison.Ordinal))
             {
                 MessageBox.Show(content, PositionsLabText.ErrorDialogTitle);
@@ -168,8 +168,8 @@ namespace PowerPointLabs.PositionsLab.Views
                 gridAlignment = PositionsLabSettings.GridAlignment.AlignRight;
             }
 
-            var rowValue = rowInput.Value;
-            var colValue = colInput.Value;
+            double? rowValue = rowInput.Value;
+            double? colValue = colInput.Value;
 
             if (!rowValue.HasValue || rowValue.GetValueOrDefault() == 0 ||
                 !colValue.HasValue || colValue.GetValueOrDefault() == 0)

--- a/PowerPointLabs/PowerPointLabs/PostInstall.cs
+++ b/PowerPointLabs/PowerPointLabs/PostInstall.cs
@@ -11,7 +11,7 @@ namespace PowerPointLabs
     {
         public void Execute(AddInPostDeploymentActionArgs args)
         {
-            var sourceFile = "";
+            string sourceFile = "";
             switch (Properties.Settings.Default.ReleaseType)
             {
                 case "dev":

--- a/PowerPointLabs/PowerPointLabs/PowerPointLabs.csproj
+++ b/PowerPointLabs/PowerPointLabs/PowerPointLabs.csproj
@@ -647,6 +647,7 @@
     <Compile Include="Views\ErrorDialogBox.xaml.cs">
       <DependentUpon>ErrorDialogBox.xaml</DependentUpon>
     </Compile>
+    <Compile Include="XMLMisc\Data\AudioGenSpeechData.cs" />
     <Compile Include="ZoomLab\AutoZoom.cs" />
     <Compile Include="ColorPicker\ColorInformationDialog.cs">
       <SubType>Form</SubType>

--- a/PowerPointLabs/PowerPointLabs/ResizeLab/ResizeLabErrorHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ResizeLab/ResizeLabErrorHandler.cs
@@ -45,7 +45,7 @@ namespace PowerPointLabs.ResizeLab
             {
                 return;
             }
-            var errorMsg = string.Format(GetErrorMessage(errorType), optionalParameters);
+            string errorMsg = string.Format(GetErrorMessage(errorType), optionalParameters);
             View.ShowErrorMessageBox(errorMsg);
         }
 

--- a/PowerPointLabs/PowerPointLabs/ResizeLab/ResizeLabMain.AdjustProportionally.cs
+++ b/PowerPointLabs/PowerPointLabs/ResizeLab/ResizeLabMain.AdjustProportionally.cs
@@ -67,8 +67,8 @@ namespace PowerPointLabs.ResizeLab
 
         public void AdjustAreaProportionally(PowerPoint.ShapeRange selectedShapes)
         {
-            var isAspectRatio = selectedShapes.LockAspectRatio;
-            var isLockedRatio = isAspectRatio == MsoTriState.msoTrue;
+            MsoTriState isAspectRatio = selectedShapes.LockAspectRatio;
+            bool isLockedRatio = isAspectRatio == MsoTriState.msoTrue;
 
             selectedShapes.LockAspectRatio = MsoTriState.msoFalse;
             AdjustActualAreaProportionally(selectedShapes, isLockedRatio);
@@ -84,7 +84,7 @@ namespace PowerPointLabs.ResizeLab
         {
             try
             {
-                var referenceWidth = GetReferenceWidth(selectedShapes);
+                float referenceWidth = GetReferenceWidth(selectedShapes);
 
                 if (referenceWidth <= 0 || AdjustProportionallyProportionList?.Count != selectedShapes.Count)
                 {
@@ -93,10 +93,10 @@ namespace PowerPointLabs.ResizeLab
 
                 for (int i = 1; i < AdjustProportionallyProportionList.Count; i++)
                 {
-                    var newWidth = referenceWidth*
+                    float newWidth = referenceWidth*
                                    (AdjustProportionallyProportionList[i] / AdjustProportionallyProportionList[0]);
-                    var shape = new PPShape(selectedShapes[i + 1]);
-                    var anchorPoint = GetVisualAnchorPoint(shape);
+                    PPShape shape = new PPShape(selectedShapes[i + 1]);
+                    System.Drawing.PointF anchorPoint = GetVisualAnchorPoint(shape);
 
                     shape.AbsoluteWidth = newWidth;
                     AlignVisualShape(shape, anchorPoint);
@@ -118,7 +118,7 @@ namespace PowerPointLabs.ResizeLab
         {
             try
             {
-                var referenceHeight = GetReferenceHeight(selectedShapes);
+                float referenceHeight = GetReferenceHeight(selectedShapes);
 
                 if (referenceHeight <= 0 || AdjustProportionallyProportionList?.Count != selectedShapes.Count)
                 {
@@ -127,10 +127,10 @@ namespace PowerPointLabs.ResizeLab
 
                 for (int i = 1; i < AdjustProportionallyProportionList.Count; i++)
                 {
-                    var newHeight = referenceHeight*
+                    float newHeight = referenceHeight*
                                     (AdjustProportionallyProportionList[i] / AdjustProportionallyProportionList[0]);
-                    var shape = new PPShape(selectedShapes[i + 1]);
-                    var anchorPoint = GetVisualAnchorPoint(shape);
+                    PPShape shape = new PPShape(selectedShapes[i + 1]);
+                    System.Drawing.PointF anchorPoint = GetVisualAnchorPoint(shape);
 
                     shape.AbsoluteHeight = newHeight;
                     AlignVisualShape(shape, anchorPoint);
@@ -152,7 +152,7 @@ namespace PowerPointLabs.ResizeLab
         {
             try
             {
-                var referenceWidth = GetReferenceWidth(selectedShapes);
+                float referenceWidth = GetReferenceWidth(selectedShapes);
 
                 if (referenceWidth <= 0 || AdjustProportionallyProportionList?.Count != selectedShapes.Count)
                 {
@@ -161,10 +161,10 @@ namespace PowerPointLabs.ResizeLab
 
                 for (int i = 1; i < AdjustProportionallyProportionList.Count; i++)
                 {
-                    var newWidth = referenceWidth*
+                    float newWidth = referenceWidth*
                                    (AdjustProportionallyProportionList[i] / AdjustProportionallyProportionList[0]);
-                    var shape = new PPShape(selectedShapes[i + 1], false);
-                    var anchorPoint = GetActualAnchorPoint(shape);
+                    PPShape shape = new PPShape(selectedShapes[i + 1], false);
+                    System.Drawing.PointF anchorPoint = GetActualAnchorPoint(shape);
 
                     shape.ShapeWidth = newWidth;
                     AlignActualShape(shape, anchorPoint);
@@ -186,7 +186,7 @@ namespace PowerPointLabs.ResizeLab
         {
             try
             {
-                var referenceHeight = GetReferenceHeight(selectedShapes);
+                float referenceHeight = GetReferenceHeight(selectedShapes);
 
                 if (referenceHeight <= 0 || AdjustProportionallyProportionList?.Count != selectedShapes.Count)
                 {
@@ -195,10 +195,10 @@ namespace PowerPointLabs.ResizeLab
 
                 for (int i = 1; i < AdjustProportionallyProportionList.Count; i++)
                 {
-                    var newHeight = referenceHeight*
+                    float newHeight = referenceHeight*
                                     (AdjustProportionallyProportionList[i] / AdjustProportionallyProportionList[0]);
-                    var shape = new PPShape(selectedShapes[i + 1], false);
-                    var anchorPoint = GetActualAnchorPoint(shape);
+                    PPShape shape = new PPShape(selectedShapes[i + 1], false);
+                    System.Drawing.PointF anchorPoint = GetActualAnchorPoint(shape);
 
                     shape.ShapeHeight = newHeight;
                     AlignActualShape(shape, anchorPoint);
@@ -220,10 +220,10 @@ namespace PowerPointLabs.ResizeLab
         {
             try
             {
-                var referenceWidth = selectedShapes[1].Width;
-                var referenceHeight = selectedShapes[1].Height;
-                var referenceArea = (double)referenceWidth * referenceHeight;
-                var referenceRatio = (double)referenceHeight / referenceWidth;
+                float referenceWidth = selectedShapes[1].Width;
+                float referenceHeight = selectedShapes[1].Height;
+                double referenceArea = (double)referenceWidth * referenceHeight;
+                double referenceRatio = (double)referenceHeight / referenceWidth;
 
                 if (referenceWidth <= 0 || referenceHeight <= 0 || AdjustProportionallyProportionList?.Count != selectedShapes.Count)
                 {
@@ -232,10 +232,10 @@ namespace PowerPointLabs.ResizeLab
 
                 for (int i = 1; i < AdjustProportionallyProportionList.Count; i++)
                 {
-                    var shape = new PPShape(selectedShapes[i + 1], false);
-                    var anchorPoint = GetActualAnchorPoint(shape);
+                    PPShape shape = new PPShape(selectedShapes[i + 1], false);
+                    System.Drawing.PointF anchorPoint = GetActualAnchorPoint(shape);
 
-                    var newArea = referenceArea *
+                    double newArea = referenceArea *
                                     (AdjustProportionallyProportionList[i] / AdjustProportionallyProportionList[0]);
 
                     if (isLockedRatio)
@@ -245,8 +245,8 @@ namespace PowerPointLabs.ResizeLab
                         referenceRatio = (double)referenceHeight / referenceWidth;
                     }
 
-                    var newWidth = (float)Math.Sqrt(newArea / referenceRatio);
-                    var newHeight = (float)(newWidth * referenceRatio);
+                    float newWidth = (float)Math.Sqrt(newArea / referenceRatio);
+                    float newHeight = (float)(newWidth * referenceRatio);
                     
                     shape.ShapeWidth = newWidth;
                     shape.ShapeHeight = newHeight;

--- a/PowerPointLabs/PowerPointLabs/ResizeLab/ResizeLabMain.Equalize.cs
+++ b/PowerPointLabs/PowerPointLabs/ResizeLab/ResizeLabMain.Equalize.cs
@@ -68,7 +68,7 @@ namespace PowerPointLabs.ResizeLab
         /// <param name="selectedShapes"></param>
         public void ResizeToSameHeightAndWidth(PowerPoint.ShapeRange selectedShapes)
         {
-            var isAspectRatio = selectedShapes.LockAspectRatio;
+            MsoTriState isAspectRatio = selectedShapes.LockAspectRatio;
 
             selectedShapes.LockAspectRatio = MsoTriState.msoFalse;
             switch (ResizeType)
@@ -92,8 +92,8 @@ namespace PowerPointLabs.ResizeLab
         {
             try
             {
-                var referenceHeight = GetReferenceHeight(selectedShapes);
-                var referenceWidth = GetReferenceWidth(selectedShapes);
+                float referenceHeight = GetReferenceHeight(selectedShapes);
+                float referenceWidth = GetReferenceWidth(selectedShapes);
 
                 if (!IsMoreThanOneShape(selectedShapes, Equalize_MinNoOfShapesRequired, true, Equalize_ErrorParameters) 
                     || (referenceHeight < 0) || (referenceWidth < 0))
@@ -103,8 +103,8 @@ namespace PowerPointLabs.ResizeLab
 
                 for (int i = 1; i <= selectedShapes.Count; i++)
                 {
-                    var shape = new PPShape(selectedShapes[i]);
-                    var anchorPoint = GetVisualAnchorPoint(shape);
+                    PPShape shape = new PPShape(selectedShapes[i]);
+                    PointF anchorPoint = GetVisualAnchorPoint(shape);
 
                     if ((dimension == Dimension.Height) || (dimension == Dimension.HeightAndWidth))
                     {
@@ -129,8 +129,8 @@ namespace PowerPointLabs.ResizeLab
         {
             try
             {
-                var referenceHeight = GetReferenceHeight(selectedShapes);
-                var referenceWidth = GetReferenceWidth(selectedShapes);
+                float referenceHeight = GetReferenceHeight(selectedShapes);
+                float referenceWidth = GetReferenceWidth(selectedShapes);
 
                 if (!IsMoreThanOneShape(selectedShapes, Equalize_MinNoOfShapesRequired, true, Equalize_ErrorParameters)
                     || (referenceHeight < 0) || (referenceWidth < 0))
@@ -140,8 +140,8 @@ namespace PowerPointLabs.ResizeLab
 
                 for (int i = 1; i <= selectedShapes.Count; i++)
                 {
-                    var shape = new PPShape(selectedShapes[i], false);
-                    var anchorPoint = GetActualAnchorPoint(shape);
+                    PPShape shape = new PPShape(selectedShapes[i], false);
+                    PointF anchorPoint = GetActualAnchorPoint(shape);
 
                     if ((dimension == Dimension.Height) || (dimension == Dimension.HeightAndWidth))
                     {

--- a/PowerPointLabs/PowerPointLabs/ResizeLab/ResizeLabMain.FitToSlide.cs
+++ b/PowerPointLabs/PowerPointLabs/ResizeLab/ResizeLabMain.FitToSlide.cs
@@ -92,7 +92,7 @@ namespace PowerPointLabs.ResizeLab
             {
                 for (int i = 1; i <= selectedShapes.Count; i++)
                 {
-                    var shape = new PPShape(selectedShapes[i]);
+                    PPShape shape = new PPShape(selectedShapes[i]);
 
                     if ((dimension == Dimension.Height) || (dimension == Dimension.HeightAndWidth))
                     {
@@ -132,14 +132,14 @@ namespace PowerPointLabs.ResizeLab
             {
                 for (int i = 1; i <= selectedShapes.Count; i++)
                 {
-                    var shape = selectedShapes[i];
-                    var anchorPoint = GetVisualAnchorPoint(new PPShape(shape, false));
+                    PowerPoint.Shape shape = selectedShapes[i];
+                    System.Drawing.PointF anchorPoint = GetVisualAnchorPoint(new PPShape(shape, false));
 
                     if (dimension == Dimension.Height)
                     {
                         FitToSlide.FitToHeight(shape, slideWidth, slideHeight);
 
-                        var ppShape = new PPShape(shape, false);
+                        PPShape ppShape = new PPShape(shape, false);
                         AlignVisualShape(ppShape, anchorPoint);
                         ppShape.VisualTop = 0;
                     }
@@ -147,7 +147,7 @@ namespace PowerPointLabs.ResizeLab
                     {
                         FitToSlide.FitToWidth(shape, slideWidth, slideHeight);
 
-                        var ppShape = new PPShape(shape, false);
+                        PPShape ppShape = new PPShape(shape, false);
                         AlignVisualShape(ppShape, anchorPoint);
                         ppShape.VisualLeft = 0;
                     }

--- a/PowerPointLabs/PowerPointLabs/ResizeLab/ResizeLabMain.Match.cs
+++ b/PowerPointLabs/PowerPointLabs/ResizeLab/ResizeLabMain.Match.cs
@@ -66,13 +66,13 @@ namespace PowerPointLabs.ResizeLab
         {
             try
             {
-                var isAspectRatio = selectedShapes.LockAspectRatio;
+                MsoTriState isAspectRatio = selectedShapes.LockAspectRatio;
                 selectedShapes.LockAspectRatio = MsoTriState.msoFalse;
 
                 for (int i = 1; i <= selectedShapes.Count; i++)
                 {
-                    var shape = new PPShape(selectedShapes[i]);
-                    var anchorPoint = GetVisualAnchorPoint(shape);
+                    PPShape shape = new PPShape(selectedShapes[i]);
+                    System.Drawing.PointF anchorPoint = GetVisualAnchorPoint(shape);
 
                     shape.AbsoluteHeight = shape.AbsoluteWidth;
                     AlignVisualShape(shape, anchorPoint);
@@ -94,13 +94,13 @@ namespace PowerPointLabs.ResizeLab
         {
             try
             {
-                var isAspectRatio = selectedShapes.LockAspectRatio;
+                MsoTriState isAspectRatio = selectedShapes.LockAspectRatio;
                 selectedShapes.LockAspectRatio = MsoTriState.msoFalse;
 
                 for (int i = 1; i <= selectedShapes.Count; i++)
                 {
-                    var shape = new PPShape(selectedShapes[i]);
-                    var anchorPoint = GetVisualAnchorPoint(shape);
+                    PPShape shape = new PPShape(selectedShapes[i]);
+                    System.Drawing.PointF anchorPoint = GetVisualAnchorPoint(shape);
 
                     shape.AbsoluteWidth = shape.AbsoluteHeight;
                     AlignVisualShape(shape, anchorPoint);
@@ -122,13 +122,13 @@ namespace PowerPointLabs.ResizeLab
         {
             try
             {
-                var isAspectRatio = selectedShapes.LockAspectRatio;
+                MsoTriState isAspectRatio = selectedShapes.LockAspectRatio;
                 selectedShapes.LockAspectRatio = MsoTriState.msoFalse;
 
                 for (int i = 1; i <= selectedShapes.Count; i++)
                 {
-                    var shape = new PPShape(selectedShapes[i], false);
-                    var anchorPoint = GetActualAnchorPoint(shape);
+                    PPShape shape = new PPShape(selectedShapes[i], false);
+                    System.Drawing.PointF anchorPoint = GetActualAnchorPoint(shape);
 
                     shape.ShapeHeight = shape.ShapeWidth;
                     AlignActualShape(shape, anchorPoint);
@@ -150,13 +150,13 @@ namespace PowerPointLabs.ResizeLab
         {
             try
             {
-                var isAspectRatio = selectedShapes.LockAspectRatio;
+                MsoTriState isAspectRatio = selectedShapes.LockAspectRatio;
                 selectedShapes.LockAspectRatio = MsoTriState.msoFalse;
 
                 for (int i = 1; i <= selectedShapes.Count; i++)
                 {
-                    var shape = new PPShape(selectedShapes[i], false);
-                    var anchorPoint = GetActualAnchorPoint(shape);
+                    PPShape shape = new PPShape(selectedShapes[i], false);
+                    System.Drawing.PointF anchorPoint = GetActualAnchorPoint(shape);
 
                     shape.ShapeWidth = shape.ShapeHeight;
                     AlignActualShape(shape, anchorPoint);

--- a/PowerPointLabs/PowerPointLabs/ResizeLab/ResizeLabMain.ShrinkStretch.cs
+++ b/PowerPointLabs/PowerPointLabs/ResizeLab/ResizeLabMain.ShrinkStretch.cs
@@ -62,7 +62,7 @@ namespace PowerPointLabs.ResizeLab
         /// <param name="stretchShapes">The shapes to stretch</param>
         public void StretchLeft(PowerPoint.ShapeRange stretchShapes)
         {
-            var appropriateStretch = new GetAppropriateStretchAction((referenceEdge, checkShape) =>
+            GetAppropriateStretchAction appropriateStretch = new GetAppropriateStretchAction((referenceEdge, checkShape) =>
             {
                 // Opposite stretch
                 if (GetRight(checkShape) < referenceEdge)
@@ -71,7 +71,7 @@ namespace PowerPointLabs.ResizeLab
                 }
                 return StretchLeftAction;
             });
-            var defaultReferenceEdge = new GetDefaultReferenceEdge(referenceShape => referenceShape.VisualLeft);
+            GetDefaultReferenceEdge defaultReferenceEdge = new GetDefaultReferenceEdge(referenceShape => referenceShape.VisualLeft);
             Stretch(stretchShapes, appropriateStretch, defaultReferenceEdge, StretchType.Left);
         }
 
@@ -81,7 +81,7 @@ namespace PowerPointLabs.ResizeLab
         /// <param name="stretchShapes">The shapes to stretch</param>
         public void StretchRight(PowerPoint.ShapeRange stretchShapes)
         {
-            var appropriateStretch = new GetAppropriateStretchAction((referenceEdge, checkShape) =>
+            GetAppropriateStretchAction appropriateStretch = new GetAppropriateStretchAction((referenceEdge, checkShape) =>
             {
                 // Opposite stretch
                 if (checkShape.VisualLeft > referenceEdge)
@@ -90,7 +90,7 @@ namespace PowerPointLabs.ResizeLab
                 }
                 return StretchRightAction;
             });
-            var defaultReferenceEdge = new GetDefaultReferenceEdge(referenceShape => referenceShape.VisualLeft + referenceShape.AbsoluteWidth);
+            GetDefaultReferenceEdge defaultReferenceEdge = new GetDefaultReferenceEdge(referenceShape => referenceShape.VisualLeft + referenceShape.AbsoluteWidth);
             Stretch(stretchShapes, appropriateStretch, defaultReferenceEdge, StretchType.Right);
         }
 
@@ -100,7 +100,7 @@ namespace PowerPointLabs.ResizeLab
         /// <param name="stretchShapes">The shapes to stretch</param>
         public void StretchTop(PowerPoint.ShapeRange stretchShapes)
         {
-            var appropriateStretch = new GetAppropriateStretchAction((referenceEdge, checkShape) =>
+            GetAppropriateStretchAction appropriateStretch = new GetAppropriateStretchAction((referenceEdge, checkShape) =>
             {
                 // Opposite stretch
                 if (GetBottom(checkShape) < referenceEdge)
@@ -109,7 +109,7 @@ namespace PowerPointLabs.ResizeLab
                 }
                 return StretchTopAction;
             });
-            var defaultReferenceEdge = new GetDefaultReferenceEdge(referenceShape => referenceShape.VisualTop);
+            GetDefaultReferenceEdge defaultReferenceEdge = new GetDefaultReferenceEdge(referenceShape => referenceShape.VisualTop);
             Stretch(stretchShapes, appropriateStretch, defaultReferenceEdge, StretchType.Top);
         }
 
@@ -119,7 +119,7 @@ namespace PowerPointLabs.ResizeLab
         /// <param name="stretchShapes">The shapes to stretch</param>
         public void StretchBottom(PowerPoint.ShapeRange stretchShapes)
         {
-            var appropriateStretch = new GetAppropriateStretchAction((referenceEdge, checkShape) =>
+            GetAppropriateStretchAction appropriateStretch = new GetAppropriateStretchAction((referenceEdge, checkShape) =>
             {
                 // Opposite stretch
                 if (checkShape.VisualTop > referenceEdge)
@@ -128,7 +128,7 @@ namespace PowerPointLabs.ResizeLab
                 }
                 return StretchBottomAction;
             });
-            var defaultReferenceEdge = new GetDefaultReferenceEdge(referenceShape => referenceShape.VisualTop + referenceShape.AbsoluteHeight);
+            GetDefaultReferenceEdge defaultReferenceEdge = new GetDefaultReferenceEdge(referenceShape => referenceShape.VisualTop + referenceShape.AbsoluteHeight);
             Stretch(stretchShapes, appropriateStretch, defaultReferenceEdge, StretchType.Bottom);
         }
 
@@ -140,7 +140,7 @@ namespace PowerPointLabs.ResizeLab
 
         private static void StretchRightAction(float referenceEdge, PPShape stretchShape)
         {
-            var oldLeft = stretchShape.VisualLeft;
+            float oldLeft = stretchShape.VisualLeft;
             stretchShape.AbsoluteWidth += referenceEdge - GetRight(stretchShape);
             stretchShape.VisualLeft = oldLeft;
         }
@@ -153,7 +153,7 @@ namespace PowerPointLabs.ResizeLab
 
         private static void StretchBottomAction(float referenceEdge, PPShape stretchShape)
         {
-            var oldTop = stretchShape.VisualTop;
+            float oldTop = stretchShape.VisualTop;
             stretchShape.AbsoluteHeight += referenceEdge - GetBottom(stretchShape);
             stretchShape.VisualTop = oldTop;
         }
@@ -173,17 +173,17 @@ namespace PowerPointLabs.ResizeLab
                 return;
             }
 
-            var referenceShape = GetReferenceShape(stretchShapes, defaultReferenceEdge, stretchType);
-            var referenceEdge = defaultReferenceEdge(new PPShape(referenceShape));
+            PowerPoint.Shape referenceShape = GetReferenceShape(stretchShapes, defaultReferenceEdge, stretchType);
+            float referenceEdge = defaultReferenceEdge(new PPShape(referenceShape));
 
-            for (var i = 1; i <= stretchShapes.Count; i++)
+            for (int i = 1; i <= stretchShapes.Count; i++)
             {
                 if (referenceShape.Equals(stretchShapes[i]))
                 {
                     continue;
                 }
-                var stretchShape = new PPShape(stretchShapes[i]);
-                var sa = stretchAction(referenceEdge, stretchShape);
+                PPShape stretchShape = new PPShape(stretchShapes[i]);
+                StretchAction sa = stretchAction(referenceEdge, stretchShape);
                 sa(referenceEdge, stretchShape);
             }
         }
@@ -200,14 +200,14 @@ namespace PowerPointLabs.ResizeLab
         private PowerPoint.Shape GetReferenceShape(PowerPoint.ShapeRange shapes, GetDefaultReferenceEdge getReferenceEdge,
             StretchType stretchType)
         {
-            var refShapeIndex = 1;
+            int refShapeIndex = 1;
 
             if (ReferenceType == StretchRefType.Outermost)
             {
-                var refPpShape = new PPShape(shapes[1]);
-                for (var i = 2; i <= shapes.Count; i++)
+                PPShape refPpShape = new PPShape(shapes[1]);
+                for (int i = 2; i <= shapes.Count; i++)
                 {
-                    var tempPpShape = new PPShape(shapes[i]);
+                    PPShape tempPpShape = new PPShape(shapes[i]);
                     if (((stretchType == StretchType.Left || stretchType == StretchType.Top) &&
                         getReferenceEdge(refPpShape) > getReferenceEdge(tempPpShape)) ||
                         ((stretchType == StretchType.Right || stretchType == StretchType.Bottom) &&

--- a/PowerPointLabs/PowerPointLabs/ResizeLab/ResizeLabMain.SlightAdjust.cs
+++ b/PowerPointLabs/PowerPointLabs/ResizeLab/ResizeLabMain.SlightAdjust.cs
@@ -116,8 +116,8 @@ namespace PowerPointLabs.ResizeLab
             {
                 foreach (PowerPoint.Shape shape in shapes)
                 {
-                    var ppShape = new PPShape(shape);
-                    var anchorPoint = GetVisualAnchorPoint(ppShape);
+                    PPShape ppShape = new PPShape(shape);
+                    System.Drawing.PointF anchorPoint = GetVisualAnchorPoint(ppShape);
 
                     resizeAction(ppShape);
                     AlignVisualShape(ppShape, anchorPoint);
@@ -147,8 +147,8 @@ namespace PowerPointLabs.ResizeLab
             {
                 foreach (PowerPoint.Shape shape in shapes)
                 {
-                    var ppShape = new PPShape(shape, false);
-                    var anchorPoint = GetActualAnchorPoint(ppShape);
+                    PPShape ppShape = new PPShape(shape, false);
+                    System.Drawing.PointF anchorPoint = GetActualAnchorPoint(ppShape);
 
                     resizeAction(ppShape);
                     AlignActualShape(ppShape, anchorPoint);

--- a/PowerPointLabs/PowerPointLabs/ResizeLab/ResizeLabPaneWPF.xaml.InterfaceImpl.cs
+++ b/PowerPointLabs/PowerPointLabs/ResizeLab/ResizeLabPaneWPF.xaml.InterfaceImpl.cs
@@ -51,7 +51,7 @@ namespace PowerPointLabs.ResizeLab
 
         public void Reset()
         {
-            var selectedShapes = GetSelectedShapes(false);
+            PowerPoint.ShapeRange selectedShapes = GetSelectedShapes(false);
 
             if (selectedShapes != null && _isPreview)
             {

--- a/PowerPointLabs/PowerPointLabs/ResizeLab/ResizeLabPaneWPF.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/ResizeLab/ResizeLabPaneWPF.xaml.cs
@@ -294,7 +294,7 @@ namespace PowerPointLabs.ResizeLab
 
         private bool ProportionalPromptProportion(bool isForSameShapes = false)
         {
-            var noOfShapes = GetSelectedShapes()?.Count;
+            int? noOfShapes = GetSelectedShapes()?.Count;
             if (!noOfShapes.HasValue || noOfShapes < 2)
             {
                 _errorHandler.ProcessErrorCode(ResizeLabErrorHandler.ErrorCodeInvalidSelection, ResizeLabMain.AdjustProportionally_ErrorParameters);
@@ -302,7 +302,7 @@ namespace PowerPointLabs.ResizeLab
             }
             if (isForSameShapes)
             {
-                var errorCode = IsValidShapes(GetSelectedShapes());
+                int errorCode = IsValidShapes(GetSelectedShapes());
 
                 if (errorCode != -1)
                 {
@@ -329,17 +329,17 @@ namespace PowerPointLabs.ResizeLab
 
         private int IsValidShapes(PowerPoint.ShapeRange selectedShapes)
         {
-            var referenceShape = selectedShapes[1];
+            PowerPoint.Shape referenceShape = selectedShapes[1];
 
             if (referenceShape.Type == Microsoft.Office.Core.MsoShapeType.msoGroup)
             {
                 return ResizeLabErrorHandler.ErrorCodeGroupShapeNotSupported;
             }
 
-            var referenceAdjustments = referenceShape.Adjustments;
-            var isAutoShapeOrCallout = referenceShape.Type == Microsoft.Office.Core.MsoShapeType.msoAutoShape
+            PowerPoint.Adjustments referenceAdjustments = referenceShape.Adjustments;
+            bool isAutoShapeOrCallout = referenceShape.Type == Microsoft.Office.Core.MsoShapeType.msoAutoShape
                                        || referenceShape.Type == Microsoft.Office.Core.MsoShapeType.msoCallout;
-            var isFreeform = referenceShape.Type == Microsoft.Office.Core.MsoShapeType.msoFreeform;
+            bool isFreeform = referenceShape.Type == Microsoft.Office.Core.MsoShapeType.msoFreeform;
 
             Utils.PPShape referencePPShape;
             List<System.Drawing.PointF> referenceShapePoints = null;
@@ -352,7 +352,7 @@ namespace PowerPointLabs.ResizeLab
 
             for (int i = 2; i <= selectedShapes.Count; i++)
             {
-                var currentShape = selectedShapes[i];
+                PowerPoint.Shape currentShape = selectedShapes[i];
 
                 if (currentShape.Type == Microsoft.Office.Core.MsoShapeType.msoGroup)
                 {
@@ -366,7 +366,7 @@ namespace PowerPointLabs.ResizeLab
 
                 if (isAutoShapeOrCallout)
                 {
-                    var currentAdjustments = currentShape.Adjustments;
+                    PowerPoint.Adjustments currentAdjustments = currentShape.Adjustments;
 
                     if (currentAdjustments.Count != referenceAdjustments.Count)
                     {
@@ -383,17 +383,17 @@ namespace PowerPointLabs.ResizeLab
                 }
                 else if (isFreeform)
                 {
-                    var isAspectRatio = selectedShapes.LockAspectRatio;
+                    Microsoft.Office.Core.MsoTriState isAspectRatio = selectedShapes.LockAspectRatio;
                     selectedShapes.LockAspectRatio = Microsoft.Office.Core.MsoTriState.msoFalse;
 
-                    var duplicateCurrentShape = currentShape.Duplicate()[1];
+                    PowerPoint.Shape duplicateCurrentShape = currentShape.Duplicate()[1];
                     duplicateCurrentShape.Width = referenceShape.Width;
                     duplicateCurrentShape.Height = referenceShape.Height;
                     duplicateCurrentShape.Rotation = referenceShape.Rotation;
                     duplicateCurrentShape.Left = referenceShape.Left;
                     duplicateCurrentShape.Top = referenceShape.Top;
-                    var currentPPShape = new Utils.PPShape(duplicateCurrentShape, false);
-                    var currentShapePoints = currentPPShape.Points;
+                    Utils.PPShape currentPPShape = new Utils.PPShape(duplicateCurrentShape, false);
+                    List<System.Drawing.PointF> currentShapePoints = currentPPShape.Points;
                     duplicateCurrentShape.Delete();
 
                     selectedShapes.LockAspectRatio = isAspectRatio;
@@ -574,8 +574,8 @@ namespace PowerPointLabs.ResizeLab
 
         private void AnchorBtn_Checked(object sender, RoutedEventArgs e)
         {
-            var checkedButton = sender as RadioButton;
-            foreach (var anAnchorPair in _anchorButtonLookUp)
+            RadioButton checkedButton = sender as RadioButton;
+            foreach (KeyValuePair<ResizeLabMain.AnchorPoint, RadioButton> anAnchorPair in _anchorButtonLookUp)
             {
                 if (checkedButton.Equals(anAnchorPair.Value))
                 {
@@ -622,7 +622,7 @@ namespace PowerPointLabs.ResizeLab
 
         private PowerPoint.ShapeRange GetSelectedShapes(bool handleError = false)
         {
-            var selection = GetSelection();
+            PowerPoint.Selection selection = GetSelection();
 
             return _resizeLab.IsSelectionValid(selection, handleError) ? GetSelection().ShapeRange : null;
         }
@@ -634,7 +634,7 @@ namespace PowerPointLabs.ResizeLab
 
         private void ClickHandler(Action<PowerPoint.ShapeRange> resizeAction, int minNoOfSelectedShapes, string[] errorParameters)
         {
-            var selectedShapes = GetSelectedShapes();
+            PowerPoint.ShapeRange selectedShapes = GetSelectedShapes();
 
             if (selectedShapes == null || selectedShapes.Count < minNoOfSelectedShapes)
             {
@@ -649,9 +649,9 @@ namespace PowerPointLabs.ResizeLab
         private void ClickHandler(Action<PowerPoint.ShapeRange, float, float, bool> resizeAction, int minNoOfSelectedShapes,
             string[] errorParameters)
         {
-            var selectedShapes = GetSelectedShapes();
-            var slideWidth = this.GetCurrentPresentation().SlideWidth;
-            var slideHeight = this.GetCurrentPresentation().SlideHeight;
+            PowerPoint.ShapeRange selectedShapes = GetSelectedShapes();
+            float slideWidth = this.GetCurrentPresentation().SlideWidth;
+            float slideHeight = this.GetCurrentPresentation().SlideHeight;
 
             if (selectedShapes == null || selectedShapes.Count < minNoOfSelectedShapes)
             {
@@ -668,7 +668,7 @@ namespace PowerPointLabs.ResizeLab
             Focus();
             _previewCallBack = delegate
             {
-                var selectedShapes = GetSelectedShapes();
+                PowerPoint.ShapeRange selectedShapes = GetSelectedShapes();
 
                 ModifySelectionAspectRatio();
                 Preview(selectedShapes, previewAction, minNoOfSelectedShapes);
@@ -685,9 +685,9 @@ namespace PowerPointLabs.ResizeLab
             Focus();
             _previewCallBack = delegate
             {
-                var selectedShapes = GetSelectedShapes();
-                var slideWidth = this.GetCurrentPresentation().SlideWidth;
-                var slideHeight = this.GetCurrentPresentation().SlideHeight;
+                PowerPoint.ShapeRange selectedShapes = GetSelectedShapes();
+                float slideWidth = this.GetCurrentPresentation().SlideWidth;
+                float slideHeight = this.GetCurrentPresentation().SlideHeight;
 
                 ModifySelectionAspectRatio();
                 Preview(selectedShapes, slideWidth, slideHeight, previewAction);

--- a/PowerPointLabs/PowerPointLabs/ResizeLab/Symmetric.cs
+++ b/PowerPointLabs/PowerPointLabs/ResizeLab/Symmetric.cs
@@ -84,8 +84,8 @@ namespace PowerPointLabs.ResizeLab
             {
                 for (int i = 1; i <= selectedShapes.Count; i++)
                 {
-                    var originalShape = new PPShape(selectedShapes[i]);
-                    var newShape = originalShape.Duplicate();
+                    PPShape originalShape = new PPShape(selectedShapes[i]);
+                    PPShape newShape = originalShape.Duplicate();
 
                     newShape.Flip(msoFlipCmd);
                     newShape.Select(MsoTriState.msoFalse);

--- a/PowerPointLabs/PowerPointLabs/ResizeLab/Views/AdjustProportionallySettingsDialog.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/ResizeLab/Views/AdjustProportionallySettingsDialog.xaml.cs
@@ -44,7 +44,7 @@ namespace PowerPointLabs.ResizeLab.Views
         private void AddShapeRow(string label)
         {
             // Increase height of main grid
-            var oldHeight = MainGrid.RowDefinitions[ShapeGridColumnIndex].Height.Value;
+            double oldHeight = MainGrid.RowDefinitions[ShapeGridColumnIndex].Height.Value;
             MainGrid.RowDefinitions[ShapeGridColumnIndex].Height = new GridLength(oldHeight + RowHeight);
             Height += RowHeight;
 
@@ -66,7 +66,7 @@ namespace PowerPointLabs.ResizeLab.Views
             textBox.ToolTip = ResizeLabTooltip.AdjustProportionallySettingsTextBox;
 
             // Append the element
-            var rowIndex = ShapesGrid.RowDefinitions.Count - 1;
+            int rowIndex = ShapesGrid.RowDefinitions.Count - 1;
             ShapesGrid.Children.Add(labelTextBlock);
             ShapesGrid.Children.Add(textBox);
 
@@ -89,8 +89,8 @@ namespace PowerPointLabs.ResizeLab.Views
             List<float> proportionList = new List<float>();
             for (int i = 1; i < ShapesGrid.Children.Count; i += 2)
             {
-                var textBox = ShapesGrid.Children[i] as TextBox;
-                var proportion = ResizeLabUtil.ConvertToFloat(textBox.Text);
+                TextBox textBox = ShapesGrid.Children[i] as TextBox;
+                float? proportion = ResizeLabUtil.ConvertToFloat(textBox.Text);
 
                 if (ResizeLabUtil.IsValidFactor(proportion))
                 {

--- a/PowerPointLabs/PowerPointLabs/ResizeLab/Views/SlightAdjustSettingsDialog.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/ResizeLab/Views/SlightAdjustSettingsDialog.xaml.cs
@@ -26,7 +26,7 @@ namespace PowerPointLabs.ResizeLab.Views
 
         private void OkBtn_Click(object sender, RoutedEventArgs e)
         {
-            var resizeFactor = ResizeLabUtil.ConvertToFloat(ResizeFactorTextBox.Text);
+            float? resizeFactor = ResizeLabUtil.ConvertToFloat(ResizeFactorTextBox.Text);
             if (ResizeLabUtil.IsValidFactor(resizeFactor))
             {
                 _resizeLab.SlightAdjustResizeFactor = (float)resizeFactor;

--- a/PowerPointLabs/PowerPointLabs/ResizeLab/Views/StretchSettingsDialog.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/ResizeLab/Views/StretchSettingsDialog.xaml.cs
@@ -72,7 +72,7 @@ namespace PowerPointLabs.ResizeLab.Views
         #region Helper functions
         private ResizeLabMain.StretchRefType RefTypeToCheckedRefTypeBtn()
         {
-            foreach (var aRefTypeButton in _refTypeButtonLookUp)
+            foreach (KeyValuePair<ResizeLabMain.StretchRefType, RadioButton> aRefTypeButton in _refTypeButtonLookUp)
             {
                 if (aRefTypeButton.Value.IsChecked.GetValueOrDefault())
                 {

--- a/PowerPointLabs/PowerPointLabs/Ribbon1.cs
+++ b/PowerPointLabs/PowerPointLabs/Ribbon1.cs
@@ -64,49 +64,49 @@ namespace PowerPointLabs
 
         public void OnAction(Office.IRibbonControl control)
         {
-            var actionHandler = ActionHandlerFactory.CreateInstance(control.Id, control.Tag);
+            ActionFramework.Common.Interface.ActionHandler actionHandler = ActionHandlerFactory.CreateInstance(control.Id, control.Tag);
             actionHandler.Execute(control.Id);
         }
 
         public bool GetEnabled(Office.IRibbonControl control)
         {
-            var enabledHandler = EnabledHandlerFactory.CreateInstance(control.Id, control.Tag);
+            ActionFramework.Common.Interface.EnabledHandler enabledHandler = EnabledHandlerFactory.CreateInstance(control.Id, control.Tag);
             return enabledHandler.Get(control.Id);
         }
 
         public string GetLabel(Office.IRibbonControl control)
         {
-            var labelHandler = LabelHandlerFactory.CreateInstance(control.Id, control.Tag);
+            ActionFramework.Common.Interface.LabelHandler labelHandler = LabelHandlerFactory.CreateInstance(control.Id, control.Tag);
             return labelHandler.Get(control.Id);
         }
 
         public string GetSupertip(Office.IRibbonControl control)
         {
-            var supertipHandler = SupertipHandlerFactory.CreateInstance(control.Id, control.Tag);
+            ActionFramework.Common.Interface.SupertipHandler supertipHandler = SupertipHandlerFactory.CreateInstance(control.Id, control.Tag);
             return supertipHandler.Get(control.Id);
         }
 
         public Bitmap GetImage(Office.IRibbonControl control)
         {
-            var imageHandler = ImageHandlerFactory.CreateInstance(control.Id, control.Tag);
+            ActionFramework.Common.Interface.ImageHandler imageHandler = ImageHandlerFactory.CreateInstance(control.Id, control.Tag);
             return imageHandler.Get(control.Id);
         }
 
         public string GetContent(Office.IRibbonControl control)
         {
-            var contentHandler = ContentHandlerFactory.CreateInstance(control.Id, control.Tag);
+            ActionFramework.Common.Interface.ContentHandler contentHandler = ContentHandlerFactory.CreateInstance(control.Id, control.Tag);
             return contentHandler.Get(control.Id);
         }
 
         public bool GetPressed(Office.IRibbonControl control)
         {
-            var pressedHandler = PressedHandlerFactory.CreateInstance(control.Id, control.Tag);
+            ActionFramework.Common.Interface.PressedHandler pressedHandler = PressedHandlerFactory.CreateInstance(control.Id, control.Tag);
             return pressedHandler.Get(control.Id);
         }
 
         public void OnCheckBoxAction(Office.IRibbonControl control, bool pressed)
         {
-            var checkBoxActionHandler = CheckBoxActionHandlerFactory.CreateInstance(control.Id, control.Tag);
+            ActionFramework.Common.Interface.CheckBoxActionHandler checkBoxActionHandler = CheckBoxActionHandlerFactory.CreateInstance(control.Id, control.Tag);
             checkBoxActionHandler.Execute(control.Id, pressed);
         }
 

--- a/PowerPointLabs/PowerPointLabs/ShapesLab/CustomShapePane.cs
+++ b/PowerPointLabs/PowerPointLabs/ShapesLab/CustomShapePane.cs
@@ -84,7 +84,7 @@ namespace PowerPointLabs.ShapesLab
         {
             get
             {
-                var shapeList = new List<string>();
+                List<string> shapeList = new List<string>();
 
                 if (myShapeFlowLayout.Controls.Count == 0 ||
                     myShapeFlowLayout.Controls.Contains(_noShapePanel))
@@ -110,7 +110,7 @@ namespace PowerPointLabs.ShapesLab
         {
             get
             {
-                var createParams = base.CreateParams;
+                CreateParams createParams = base.CreateParams;
 
                 // do this optimization only for office 2010 since painting speed on 2013 is
                 // really slow
@@ -139,7 +139,7 @@ namespace PowerPointLabs.ShapesLab
             _categoryBinding = new BindingSource { DataSource = Categories };
             categoryBox.DataSource = _categoryBinding;
 
-            for (var i = 0; i < Categories.Count; i++)
+            for (int i = 0; i < Categories.Count; i++)
             {
                 if (Categories[i] == defaultShapeCategoryName)
                 {
@@ -166,7 +166,7 @@ namespace PowerPointLabs.ShapesLab
         {
             DehighlightSelected();
 
-            var labeledThumbnail = new LabeledThumbnail(shapePath, shapeName) { ContextMenuStrip = shapeContextMenuStrip };
+            LabeledThumbnail labeledThumbnail = new LabeledThumbnail(shapePath, shapeName) { ContextMenuStrip = shapeContextMenuStrip };
 
             labeledThumbnail.Click += LabeledThumbnailClick;
             labeledThumbnail.DoubleClick += LabeledThumbnailDoubleClick;
@@ -197,7 +197,7 @@ namespace PowerPointLabs.ShapesLab
 
         public void RemoveCustomShape(string shapeName)
         {
-            var labeledThumbnail = FindLabeledThumbnail(shapeName);
+            LabeledThumbnail labeledThumbnail = FindLabeledThumbnail(shapeName);
 
             if (labeledThumbnail == null)
             {
@@ -210,7 +210,7 @@ namespace PowerPointLabs.ShapesLab
 
         public void RenameCustomShape(string oldShapeName, string newShapeName)
         {
-            var labeledThumbnail = FindLabeledThumbnail(oldShapeName);
+            LabeledThumbnail labeledThumbnail = FindLabeledThumbnail(oldShapeName);
 
             if (labeledThumbnail == null)
             {
@@ -299,7 +299,7 @@ namespace PowerPointLabs.ShapesLab
         {
             Globals.ThisAddIn.Application.StartNewUndoEntry();
 
-            var currentSlide = PowerPointCurrentPresentationInfo.CurrentSlide;
+            PowerPointSlide currentSlide = PowerPointCurrentPresentationInfo.CurrentSlide;
 
             if (currentSlide == null)
             {
@@ -348,7 +348,7 @@ namespace PowerPointLabs.ShapesLab
 
         private void ContextMenuStripImportCategoryClicked()
         {
-            var fileDialog = new OpenFileDialog
+            OpenFileDialog fileDialog = new OpenFileDialog
                                  {
                                      Filter = ImportLibraryFileDialogFilter,
                                      Multiselect = false,
@@ -369,7 +369,7 @@ namespace PowerPointLabs.ShapesLab
 
         private void ContextMenuStripImportShapesClicked()
         {
-            var fileDialog = new OpenFileDialog
+            OpenFileDialog fileDialog = new OpenFileDialog
                                  {
                                      Filter = ImportShapesFileDialogFilter,
                                      Multiselect = true,
@@ -383,7 +383,7 @@ namespace PowerPointLabs.ShapesLab
                 return;
             }
 
-            var importSuccess = fileDialog.FileNames.Aggregate(true,
+            bool importSuccess = fileDialog.FileNames.Aggregate(true,
                                                                (current, fileName) =>
                                                                ImportShapes(fileName, false) && current);
 
@@ -405,14 +405,14 @@ namespace PowerPointLabs.ShapesLab
                 return;
             }
 
-            var categoryIndex = categoryBox.SelectedIndex;
-            var categoryName = _categoryBinding[categoryIndex].ToString();
-            var categoryPath = Path.Combine(ShapeRootFolderPath, categoryName);
-            var isDefaultCategory = Globals.ThisAddIn.ShapesLabConfig.DefaultCategory == CurrentCategory;
+            int categoryIndex = categoryBox.SelectedIndex;
+            string categoryName = _categoryBinding[categoryIndex].ToString();
+            string categoryPath = Path.Combine(ShapeRootFolderPath, categoryName);
+            bool isDefaultCategory = Globals.ThisAddIn.ShapesLabConfig.DefaultCategory == CurrentCategory;
 
             if (isDefaultCategory)
             {
-                var result =
+                DialogResult result =
                     MessageBox.Show(ShapesLabText.RemoveDefaultCategoryMessage,
                                     ShapesLabText.RemoveDefaultCategoryCaption,
                                     MessageBoxButtons.OKCancel);
@@ -461,8 +461,8 @@ namespace PowerPointLabs.ShapesLab
 
             while (_selectedThumbnail.Count > 0)
             {
-                var thumbnail = _selectedThumbnail[0];
-                var removedShapename = thumbnail.NameLabel;
+                LabeledThumbnail thumbnail = _selectedThumbnail[0];
+                string removedShapename = thumbnail.NameLabel;
 
                 // remove shape from shape gallery
                 Globals.ThisAddIn.ShapePresentation.RemoveShape(CurrentShapeNameWithoutExtension);
@@ -498,7 +498,7 @@ namespace PowerPointLabs.ShapesLab
                 Globals.ThisAddIn.ShapePresentation.RenameCategory(newCategoryName);
 
                 // rename the category on the disk
-                var newPath = Path.Combine(ShapeRootFolderPath, newCategoryName);
+                string newPath = Path.Combine(ShapeRootFolderPath, newCategoryName);
 
                 try
                 {
@@ -510,7 +510,7 @@ namespace PowerPointLabs.ShapesLab
                 }
 
                 // rename the category in combo box
-                var categoryIndex = categoryBox.SelectedIndex;
+                int categoryIndex = categoryBox.SelectedIndex;
                 _categoryBinding[categoryIndex] = newCategoryName;
 
                 // update current category reference
@@ -555,8 +555,8 @@ namespace PowerPointLabs.ShapesLab
             RegulateSelectionRectPoint(ref loc1);
             RegulateSelectionRectPoint(ref loc2);
 
-            var size = new Size(Math.Abs(loc2.X - loc1.X), Math.Abs(loc2.Y - loc1.Y));
-            var rect = new Rectangle(new Point(Math.Min(loc1.X, loc2.X), Math.Min(loc1.Y, loc2.Y)), size);
+            Size size = new Size(Math.Abs(loc2.X - loc1.X), Math.Abs(loc2.Y - loc1.Y));
+            Rectangle rect = new Rectangle(new Point(Math.Min(loc1.X, loc2.X), Math.Min(loc1.Y, loc2.Y)), size);
 
             return rect;
         }
@@ -569,7 +569,7 @@ namespace PowerPointLabs.ShapesLab
                 return;
             }
             
-            foreach (var thumbnail in _selectedThumbnail)
+            foreach (LabeledThumbnail thumbnail in _selectedThumbnail)
             {
                 thumbnail.DeHighlight();
             }
@@ -597,12 +597,12 @@ namespace PowerPointLabs.ShapesLab
                 return -1;
             }
 
-            var totalControl = myShapeFlowLayout.Controls.Count;
-            var thisControlPosition = -1;
+            int totalControl = myShapeFlowLayout.Controls.Count;
+            int thisControlPosition = -1;
 
-            for (var i = 0; i < totalControl; i++)
+            for (int i = 0; i < totalControl; i++)
             {
-                var control = myShapeFlowLayout.Controls[i] as LabeledThumbnail;
+                LabeledThumbnail control = myShapeFlowLayout.Controls[i] as LabeledThumbnail;
 
                 if (control == null)
                 {
@@ -738,7 +738,7 @@ namespace PowerPointLabs.ShapesLab
 
         private bool ImportShapes(string importFilePath, bool fromLibrary)
         {
-            var importShapeGallery = PrepareImportGallery(importFilePath, fromLibrary);
+            PowerPointShapeGalleryPresentation importShapeGallery = PrepareImportGallery(importFilePath, fromLibrary);
 
             try
             {
@@ -792,7 +792,7 @@ namespace PowerPointLabs.ShapesLab
 
         private void ImportShapesFromLibrary(PowerPointShapeGalleryPresentation importShapeGallery)
         {
-            foreach (var importCategory in importShapeGallery.Categories)
+            foreach (string importCategory in importShapeGallery.Categories)
             {
                 importShapeGallery.CopyCategory(importCategory);
 
@@ -804,25 +804,25 @@ namespace PowerPointLabs.ShapesLab
 
         private void ImportShapesFromSingleShape(PowerPointShapeGalleryPresentation importShapeGallery)
         {
-            var shapeRange = importShapeGallery.Slides[0].Shapes.Range();
+            ShapeRange shapeRange = importShapeGallery.Slides[0].Shapes.Range();
 
             if (shapeRange.Count < 1)
             {
                 return;
             }
 
-            var shapeName = shapeRange[1].Name;
+            string shapeName = shapeRange[1].Name;
             importShapeGallery.CopyShape(shapeName);
 
             shapeName = Globals.ThisAddIn.ShapePresentation.AddShape(null, shapeName, fromClipBoard: true);
-            var exportPath = Path.Combine(CurrentShapeFolderPath, shapeName + ".png");
+            string exportPath = Path.Combine(CurrentShapeFolderPath, shapeName + ".png");
 
             GraphicsUtil.ExportShape(shapeRange, exportPath);
         }
 
         private bool MigrateShapeFolder(string oldPath, string newPath)
         {
-            var loadingDialog = new LoadingDialogBox(ShapesLabText.MigratingDialogTitle,
+            LoadingDialogBox loadingDialog = new LoadingDialogBox(ShapesLabText.MigratingDialogTitle,
                                                     ShapesLabText.MigratingDialogContent);
             loadingDialog.Show();
 
@@ -889,7 +889,7 @@ namespace PowerPointLabs.ShapesLab
             // thumbnail should be dehighlighted
             if (!ModifierKeys.HasFlag(Keys.Control))
             {
-                foreach (var thumbnail in _selectedThumbnail)
+                foreach (LabeledThumbnail thumbnail in _selectedThumbnail)
                 {
                     thumbnail.DeHighlight();
                 }
@@ -928,7 +928,7 @@ namespace PowerPointLabs.ShapesLab
 
         private PowerPointShapeGalleryPresentation PrepareImportGallery(string importFilePath, bool fromCategory)
         {
-            var importFileCopyPath = Path.Combine(ShapeRootFolderPath, ImportFileCopyName);
+            string importFileCopyPath = Path.Combine(ShapeRootFolderPath, ImportFileCopyName);
 
             // copy the file to the current shape root if the file is not under root 
             if (!File.Exists(importFileCopyPath))
@@ -937,7 +937,7 @@ namespace PowerPointLabs.ShapesLab
             }
 
             // init the file as an imported file
-            var importShapeGallery = new PowerPointShapeGalleryPresentation(ShapeRootFolderPath,
+            PowerPointShapeGalleryPresentation importShapeGallery = new PowerPointShapeGalleryPresentation(ShapeRootFolderPath,
                                                                             ImportFileNameNoExtension)
                                          {
                                              IsImportedFile = true,
@@ -951,11 +951,11 @@ namespace PowerPointLabs.ShapesLab
         {
             PrepareFolder();
 
-            var shapes = Directory.EnumerateFiles(CurrentShapeFolderPath, "*.png").OrderBy(item => item, _stringComparer);
+            IOrderedEnumerable<string> shapes = Directory.EnumerateFiles(CurrentShapeFolderPath, "*.png").OrderBy(item => item, _stringComparer);
 
-            foreach (var shape in shapes)
+            foreach (string shape in shapes)
             {
-                var shapeName = Path.GetFileNameWithoutExtension(shape);
+                string shapeName = Path.GetFileNameWithoutExtension(shape);
 
                 if (shapeName == null)
                 {
@@ -1020,7 +1020,7 @@ namespace PowerPointLabs.ShapesLab
                 return;
             }
 
-            var newPath = labeledThumbnail.ImagePath.Replace(@"\" + oldName, @"\" + labeledThumbnail.NameLabel);
+            string newPath = labeledThumbnail.ImagePath.Replace(@"\" + oldName, @"\" + labeledThumbnail.NameLabel);
 
             File.Move(labeledThumbnail.ImagePath, newPath);
             labeledThumbnail.ImagePath = newPath;
@@ -1032,7 +1032,7 @@ namespace PowerPointLabs.ShapesLab
 
         private void ReorderThumbnail(LabeledThumbnail labeledThumbnail)
         {
-            var index = FindLabeledThumbnailIndex(labeledThumbnail.NameLabel);
+            int index = FindLabeledThumbnailIndex(labeledThumbnail.NameLabel);
 
             // if the current control is the only control or something goes wrong, don't need
             // to reorder
@@ -1060,8 +1060,8 @@ namespace PowerPointLabs.ShapesLab
         # region Event Handlers
         private void CategoryBoxSelectedIndexChanged(object sender, EventArgs e)
         {
-            var selectedIndex = categoryBox.SelectedIndex;
-            var selectedCategory = _categoryBinding[selectedIndex].ToString();
+            int selectedIndex = categoryBox.SelectedIndex;
+            string selectedCategory = _categoryBinding[selectedIndex].ToString();
 
             CurrentCategory = selectedCategory;
             Globals.ThisAddIn.ShapePresentation.DefaultCategory = selectedCategory;
@@ -1070,7 +1070,7 @@ namespace PowerPointLabs.ShapesLab
 
         private void CategoryBoxOwnerDraw(object sender, DrawItemEventArgs e)
         {
-            var comboBox = sender as ComboBox;
+            ComboBox comboBox = sender as ComboBox;
 
             if (comboBox == null ||
                 e.Index == -1)
@@ -1078,8 +1078,8 @@ namespace PowerPointLabs.ShapesLab
                 return;
             }
 
-            var font = comboBox.Font;
-            var text = (string)_categoryBinding[e.Index];
+            Font font = comboBox.Font;
+            string text = (string)_categoryBinding[e.Index];
 
             if (text == Globals.ThisAddIn.ShapesLabConfig.DefaultCategory)
             {
@@ -1087,7 +1087,7 @@ namespace PowerPointLabs.ShapesLab
                 font = new Font(font, FontStyle.Bold);
             }
 
-            using (var brush = new SolidBrush(e.ForeColor))
+            using (SolidBrush brush = new SolidBrush(e.ForeColor))
             {
                 e.DrawBackground();
                 e.Graphics.DrawString(text, font, brush, e.Bounds);
@@ -1110,7 +1110,7 @@ namespace PowerPointLabs.ShapesLab
             {
                 if (category != CurrentCategory)
                 {
-                    var item = copyToToolStripMenuItem.DropDownItems.Add(category);
+                    ToolStripItem item = copyToToolStripMenuItem.DropDownItems.Add(category);
                     item.Click += CopyContextMenuStripSubMenuClick;
                 }
             }
@@ -1120,23 +1120,23 @@ namespace PowerPointLabs.ShapesLab
 
         private void CopyContextMenuStripSubMenuClick(object sender, EventArgs e)
         {
-            var item = sender as ToolStripItem;
+            ToolStripItem item = sender as ToolStripItem;
 
             if (item == null)
             {
                 return;
             }
 
-            var categoryName = item.Text;
+            string categoryName = item.Text;
 
             GraphicsUtil.SuspendDrawing(myShapeFlowLayout);
 
-            foreach (var thumbnail in _selectedThumbnail)
+            foreach (LabeledThumbnail thumbnail in _selectedThumbnail)
             {
-                var shapeName = thumbnail.NameLabel;
+                string shapeName = thumbnail.NameLabel;
 
-                var oriPath = Path.Combine(CurrentShapeFolderPath, shapeName) + ".png";
-                var destPath = Path.Combine(ShapeRootFolderPath, categoryName, shapeName) + ".png";
+                string oriPath = Path.Combine(CurrentShapeFolderPath, shapeName) + ".png";
+                string destPath = Path.Combine(ShapeRootFolderPath, categoryName, shapeName) + ".png";
 
                 // if we have an identical name in the destination category, we won't allow
                 // moving
@@ -1169,7 +1169,7 @@ namespace PowerPointLabs.ShapesLab
 
         private void FlowlayoutContextMenuStripItemClicked(object sender, ToolStripItemClickedEventArgs e)
         {
-            var item = e.ClickedItem;
+            ToolStripItem item = e.ClickedItem;
 
             if (item.Name.Contains("settings"))
             {
@@ -1235,7 +1235,7 @@ namespace PowerPointLabs.ShapesLab
             if (_isPanelMouseDown)
             {
                 _curPosition = e.Location;
-                var rect = CreateRect(_curPosition, _startPosition);
+                Rectangle rect = CreateRect(_curPosition, _startPosition);
 
                 _selectRect.Size = rect.Size;
                 _selectRect.Location = myShapeFlowLayout.PointToScreen(rect.Location);
@@ -1247,8 +1247,8 @@ namespace PowerPointLabs.ShapesLab
                         continue;
                     }
 
-                    var labeledThumbnail = control as LabeledThumbnail;
-                    var labeledThumbnailRect =
+                    LabeledThumbnail labeledThumbnail = control as LabeledThumbnail;
+                    Rectangle labeledThumbnailRect =
                         myShapeFlowLayout.RectangleToClient(
                             labeledThumbnail.RectangleToScreen(labeledThumbnail.ClientRectangle));
 
@@ -1280,7 +1280,7 @@ namespace PowerPointLabs.ShapesLab
             _isPanelDrawingFinish = true;
             _selectRect.Hide();
 
-            foreach (var thumbnail in _selectingThumbnail)
+            foreach (LabeledThumbnail thumbnail in _selectingThumbnail)
             {
                 if (_selectedThumbnail.Contains(thumbnail))
                 {
@@ -1302,14 +1302,14 @@ namespace PowerPointLabs.ShapesLab
         {
             if (_isPanelMouseDown)
             {
-                var rect = CreateRect(_curPosition, _startPosition);
+                Rectangle rect = CreateRect(_curPosition, _startPosition);
 
-                using (var brush = new SolidBrush(Color.FromArgb(100, 0, 0, 255)))
+                using (SolidBrush brush = new SolidBrush(Color.FromArgb(100, 0, 0, 255)))
                 {
                     e.Graphics.FillRectangle(brush, rect);
                 }
 
-                using (var pen = new Pen(Color.FromArgb(200, 0, 0, 255)))
+                using (Pen pen = new Pen(Color.FromArgb(200, 0, 0, 255)))
                 {
                     e.Graphics.DrawRectangle(pen, rect);
                 }
@@ -1361,10 +1361,10 @@ namespace PowerPointLabs.ShapesLab
                 return;
             }
 
-            var clickedThumbnail = sender as LabeledThumbnail;
+            LabeledThumbnail clickedThumbnail = sender as LabeledThumbnail;
 
-            var shapeName = clickedThumbnail.NameLabel;
-            var currentSlide = PowerPointCurrentPresentationInfo.CurrentSlide;
+            string shapeName = clickedThumbnail.NameLabel;
+            PowerPointSlide currentSlide = PowerPointCurrentPresentationInfo.CurrentSlide;
             
             if (currentSlide != null)
             {
@@ -1381,7 +1381,7 @@ namespace PowerPointLabs.ShapesLab
 
         private void NameEditFinishHandler(object sender, string oldName)
         {
-            var labeledThumbnail = sender as LabeledThumbnail;
+            LabeledThumbnail labeledThumbnail = sender as LabeledThumbnail;
 
             // by right, name change only happens when the labeled thumbnail is selected.
             // Therfore, if the notifier doesn't come from the selected object, something
@@ -1416,7 +1416,7 @@ namespace PowerPointLabs.ShapesLab
             {
                 if (category != CurrentCategory)
                 {
-                    var item = moveShapeToolStripMenuItem.DropDownItems.Add(category);
+                    ToolStripItem item = moveShapeToolStripMenuItem.DropDownItems.Add(category);
                     item.Click += MoveContextMenuStripSubMenuClick;
                 }
             }
@@ -1426,23 +1426,23 @@ namespace PowerPointLabs.ShapesLab
 
         private void MoveContextMenuStripSubMenuClick(object sender, EventArgs e)
         {
-            var item = sender as ToolStripItem;
+            ToolStripItem item = sender as ToolStripItem;
 
             if (item == null)
             {
                 return;
             }
 
-            var categoryName = item.Text;
+            string categoryName = item.Text;
 
             GraphicsUtil.SuspendDrawing(myShapeFlowLayout);
 
-            foreach (var thumbnail in _selectedThumbnail)
+            foreach (LabeledThumbnail thumbnail in _selectedThumbnail)
             {
-                var shapeName = thumbnail.NameLabel;
+                string shapeName = thumbnail.NameLabel;
 
-                var oriPath = Path.Combine(CurrentShapeFolderPath, shapeName) + ".png";
-                var destPath = Path.Combine(ShapeRootFolderPath, categoryName, shapeName) + ".png";
+                string oriPath = Path.Combine(CurrentShapeFolderPath, shapeName) + ".png";
+                string destPath = Path.Combine(ShapeRootFolderPath, categoryName, shapeName) + ".png";
 
                 // if we have an identical name in the destination category, we won't allow
                 // moving
@@ -1473,7 +1473,7 @@ namespace PowerPointLabs.ShapesLab
 
         private void ThumbnailContextMenuStripItemClicked(object sender, ToolStripItemClickedEventArgs e)
         {
-            var item = e.ClickedItem;
+            ToolStripItem item = e.ClickedItem;
 
             if (item.Name.Contains("remove"))
             {

--- a/PowerPointLabs/PowerPointLabs/ShapesLab/LabeledThumbnail.cs
+++ b/PowerPointLabs/PowerPointLabs/ShapesLab/LabeledThumbnail.cs
@@ -139,7 +139,7 @@ namespace PowerPointLabs.ShapesLab
             _nameFinishHandled = true;
             NameLabel = labelTextBox.Text;
 
-            var oldName = Path.GetFileNameWithoutExtension(ImagePath);
+            string oldName = Path.GetFileNameWithoutExtension(ImagePath);
 
             if (_isGoodName &&
                 !IsDuplicateName(oldName))
@@ -213,7 +213,7 @@ namespace PowerPointLabs.ShapesLab
             // critical line, we need to free the reference to the image immediately after we've
             // finished thumbnail generation, else we could not modify (rename/ delete) the
             // image. Therefore, we use using keyword to ensure a collection.
-            using (var bitmap = new Bitmap(ImagePath))
+            using (Bitmap bitmap = new Bitmap(ImagePath))
             {
                 thumbnailPanel.BackgroundImage = Utils.GraphicsUtil.CreateThumbnailImage(bitmap, 50, 50);
             }
@@ -231,7 +231,7 @@ namespace PowerPointLabs.ShapesLab
                 return false;
             }
 
-            var newPath = ImagePath.Replace(oldName, NameLabel);
+            string newPath = ImagePath.Replace(oldName, NameLabel);
 
             // if the new name has been used, the new name is not allowed
             if (File.Exists(newPath))
@@ -251,7 +251,7 @@ namespace PowerPointLabs.ShapesLab
 
         private bool Verify(string name)
         {
-            var invalidChars = new Regex(InvalidCharsRegex);
+            Regex invalidChars = new Regex(InvalidCharsRegex);
             
             return !(string.IsNullOrWhiteSpace(name) ||
                      invalidChars.IsMatch(name) ||

--- a/PowerPointLabs/PowerPointLabs/ShapesLab/ShapesLabConfigSaveFile.cs
+++ b/PowerPointLabs/PowerPointLabs/ShapesLab/ShapesLabConfigSaveFile.cs
@@ -38,8 +38,8 @@ namespace PowerPointLabs.ShapesLab
             else
             {
                 // if it's in FT, use new temp shape root folder every time
-                var tmpPath = TempPath.GetTempTestFolder();
-                var hash = DateTime.Now.GetHashCode();
+                string tmpPath = TempPath.GetTempTestFolder();
+                int hash = DateTime.Now.GetHashCode();
                 ShapesLabSettings.SaveFolderPath = tmpPath + DefaultShapeMasterFolderName + hash;
                 DefaultCategory = DefaultShapeCategoryName + hash;
                 _configFilePath = tmpPath + "ShapeRootFolder" + hash;
@@ -51,7 +51,7 @@ namespace PowerPointLabs.ShapesLab
         ~ShapesLabConfigSaveFile()
         {
             // flush shape root folder & default category info to the file
-            using (var fileWriter = File.CreateText(_configFilePath))
+            using (StreamWriter fileWriter = File.CreateText(_configFilePath))
             {
                 fileWriter.WriteLine(ShapesLabSettings.SaveFolderPath);
                 fileWriter.WriteLine(DefaultCategory);
@@ -69,7 +69,7 @@ namespace PowerPointLabs.ShapesLab
             if (File.Exists(_configFilePath) &&
                 (new FileInfo(_configFilePath)).Length != 0)
             {
-                using (var reader = new StreamReader(_configFilePath))
+                using (StreamReader reader = new StreamReader(_configFilePath))
                 {
                     ShapesLabSettings.SaveFolderPath = reader.ReadLine();
                     

--- a/PowerPointLabs/PowerPointLabs/ShapesLab/Views/ShapesLabCategoryInfoDialogBox.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/ShapesLab/Views/ShapesLabCategoryInfoDialogBox.xaml.cs
@@ -63,7 +63,7 @@ namespace PowerPointLabs.ShapesLab.Views
                 return false;
             }
 
-            var invalidChars = new Regex(InvalidCharsRegex);
+            Regex invalidChars = new Regex(InvalidCharsRegex);
 
             if (string.IsNullOrWhiteSpace(name) || invalidChars.IsMatch(name))
             {

--- a/PowerPointLabs/PowerPointLabs/ShortcutsLab/ConvertToPicture.cs
+++ b/PowerPointLabs/PowerPointLabs/ShortcutsLab/ConvertToPicture.cs
@@ -18,7 +18,7 @@ namespace PowerPointLabs.ShortcutsLab
         {
             if (ShapeUtil.IsSelectionShapeOrText(selection))
             {
-                var shape = GetShapeFromSelection(selection);
+                PowerPoint.Shape shape = GetShapeFromSelection(selection);
                 shape = CutPasteShape(shape);
                 ConvertToPictureForShape(shape);
             }
@@ -65,7 +65,7 @@ namespace PowerPointLabs.ShortcutsLab
             float width = shape.Width;
             float height = shape.Height;
             shape.Delete();
-            var pic = PowerPointCurrentPresentationInfo.CurrentSlide.Shapes.PasteSpecial(PowerPoint.PpPasteDataType.ppPastePNG)[1];
+            PowerPoint.Shape pic = PowerPointCurrentPresentationInfo.CurrentSlide.Shapes.PasteSpecial(PowerPoint.PpPasteDataType.ppPastePNG)[1];
             pic.Left = x + (width - pic.Width) / 2;
             pic.Top = y + (height - pic.Height) / 2;
             pic.Rotation = rotation;

--- a/PowerPointLabs/PowerPointLabs/SpeechEngine/PromptToAudio.cs
+++ b/PowerPointLabs/PowerPointLabs/SpeechEngine/PromptToAudio.cs
@@ -18,7 +18,7 @@ namespace PowerPointLabs.SpeechEngine
                 return;
             }
 
-            using (var synthesizer = new SpeechSynthesizer())
+            using (SpeechSynthesizer synthesizer = new SpeechSynthesizer())
             {
                 synthesizer.SetOutputToWaveFile(directory);
                 synthesizer.Speak(p);
@@ -27,7 +27,7 @@ namespace PowerPointLabs.SpeechEngine
 
         public static void Speak(PromptBuilder p)
         {
-            var synthesizer = CreateSynthesizerOutputToAudio();
+            SpeechSynthesizer synthesizer = CreateSynthesizerOutputToAudio();
 
             Prompt spokenPrompt = synthesizer.SpeakAsync(p);
             SynthesisState state = new SynthesisState(synthesizer, spokenPrompt);
@@ -37,7 +37,7 @@ namespace PowerPointLabs.SpeechEngine
 
         private static SpeechSynthesizer CreateSynthesizerOutputToAudio()
         {
-            var synthesizer = new SpeechSynthesizer();
+            SpeechSynthesizer synthesizer = new SpeechSynthesizer();
             synthesizer.SetOutputToDefaultAudioDevice();
             return synthesizer;
         }

--- a/PowerPointLabs/PowerPointLabs/SpeechEngine/TextToSpeech.cs
+++ b/PowerPointLabs/PowerPointLabs/SpeechEngine/TextToSpeech.cs
@@ -14,17 +14,17 @@ namespace PowerPointLabs.SpeechEngine
 
         public static IEnumerable<string> GetVoices()
         {
-            using (var synthesizer = new SpeechSynthesizer())
+            using (SpeechSynthesizer synthesizer = new SpeechSynthesizer())
             {
-                var installedVoices = synthesizer.GetInstalledVoices();
-                var voices = installedVoices.Where(voice => voice.Enabled);
+                System.Collections.ObjectModel.ReadOnlyCollection<InstalledVoice> installedVoices = synthesizer.GetInstalledVoices();
+                IEnumerable<InstalledVoice> voices = installedVoices.Where(voice => voice.Enabled);
                 return voices.Select(voice => voice.VoiceInfo.Name);
             }
         }
 
         public static void SaveStringToWaveFiles(string notesText, string folderPath, string fileNameFormat)
         {
-            var taggedNotes = new TaggedText(notesText);
+            TaggedText taggedNotes = new TaggedText(notesText);
             List<String> stringsToSave = taggedNotes.SplitByClicks();
             //MD5 md5 = MD5.Create();
 
@@ -44,7 +44,7 @@ namespace PowerPointLabs.SpeechEngine
 
         public static void SaveStringToWaveFile(String textToSave, String filePath)
         {
-            var builder = GetPromptForText(textToSave);
+            PromptBuilder builder = GetPromptForText(textToSave);
             PromptToAudio.SaveAsWav(builder, filePath);
         }
 
@@ -55,13 +55,13 @@ namespace PowerPointLabs.SpeechEngine
                 return;
             }
 
-            var builder = GetPromptForText(textToSpeak);
+            PromptBuilder builder = GetPromptForText(textToSpeak);
             PromptToAudio.Speak(builder);
         }
 
         private static PromptBuilder GetPromptForText(string textToConvert)
         {
-            var taggedText = new TaggedText(textToConvert);
+            TaggedText taggedText = new TaggedText(textToConvert);
             PromptBuilder builder = taggedText.ToPromptBuilder(DefaultVoiceName);
             return builder;
         }

--- a/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/FillFormat.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/FillFormat.cs
@@ -11,7 +11,7 @@ namespace PowerPointLabs.SyncLab.ObjectFormats
     {
         public static bool CanCopy(Shape formatShape)
         {
-            var duplicateShape = formatShape.Duplicate()[1];
+            Shape duplicateShape = formatShape.Duplicate()[1];
             bool canCopy = Sync(formatShape, duplicateShape);
             duplicateShape.Delete();
             return canCopy;
@@ -72,7 +72,7 @@ namespace PowerPointLabs.SyncLab.ObjectFormats
 
         private static void SyncGradient(Shape formatShape, Shape newShape) //should return bool?
         {
-            var gradientColorType = formatShape.Fill.GradientColorType;
+            Microsoft.Office.Core.MsoGradientColorType gradientColorType = formatShape.Fill.GradientColorType;
 
             if (gradientColorType == Microsoft.Office.Core.MsoGradientColorType.msoGradientOneColor)
             {

--- a/PowerPointLabs/PowerPointLabs/SyncLab/SyncFormatUtil.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/SyncFormatUtil.cs
@@ -15,7 +15,7 @@ namespace PowerPointLabs.SyncLab
 
         public static Shapes GetTemplateShapes()
         {
-            var shapeStorage = SyncLabShapeStorage.Instance;
+            SyncLabShapeStorage shapeStorage = SyncLabShapeStorage.Instance;
             return shapeStorage.Slides[SyncLabShapeStorage.FormatStorageSlide].Shapes;
         }
 

--- a/PowerPointLabs/PowerPointLabs/SyncLab/SyncLabShapeStorage.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/SyncLabShapeStorage.cs
@@ -55,7 +55,7 @@ namespace PowerPointLabs.SyncLab
 
         public Shape GetShape(string shapeKey)
         {
-            var shapes = Slides[0].Shapes;
+            Shapes shapes = Slides[0].Shapes;
             for (int i = 1; i <= shapes.Count; i++)
             {
                 if (shapes[i].Name.Equals(shapeKey))
@@ -68,8 +68,8 @@ namespace PowerPointLabs.SyncLab
 
         public void RemoveShape(string shapeKey)
         {
-            var index = 1;
-            var shapes = Slides[0].Shapes;
+            int index = 1;
+            Shapes shapes = Slides[0].Shapes;
             while (index <= shapes.Count)
             {
                 if (shapes[index].Name.Equals(shapeKey))

--- a/PowerPointLabs/PowerPointLabs/SyncLab/Views/SyncPaneWPF.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/Views/SyncPaneWPF.xaml.cs
@@ -33,13 +33,13 @@ namespace PowerPointLabs.SyncLab.Views
 
         public void SyncPaneWPF_Loaded(object sender, RoutedEventArgs e)
         {
-            var syncLabPane = this.GetAddIn().GetActivePane(typeof(SyncPane));
+            Microsoft.Office.Tools.CustomTaskPane syncLabPane = this.GetAddIn().GetActivePane(typeof(SyncPane));
             if (syncLabPane == null || !(syncLabPane.Control is SyncPane))
             {
                 MessageBox.Show("Error: SyncPane not opened.");
                 return;
             }
-            var syncLab = syncLabPane.Control as SyncPane;
+            SyncPane syncLab = syncLabPane.Control as SyncPane;
 
             syncLab.HandleDestroyed += SyncPane_Closing;
         }
@@ -118,7 +118,7 @@ namespace PowerPointLabs.SyncLab.Views
 
         public void ApplyFormats(FormatTreeNode[] nodes, Shape formatShape)
         {
-            var selection = this.GetCurrentSelection();
+            Selection selection = this.GetCurrentSelection();
             if ((selection.Type != PpSelectionType.ppSelectionShapes &&
                 selection.Type != PpSelectionType.ppSelectionText) ||
                 selection.ShapeRange.Count == 0)
@@ -127,7 +127,7 @@ namespace PowerPointLabs.SyncLab.Views
                 return;
             }
 
-            var shapes = selection.ShapeRange;
+            ShapeRange shapes = selection.ShapeRange;
             if (selection.HasChildShapeRange)
             {
                 shapes = selection.ChildShapeRange;
@@ -187,7 +187,7 @@ namespace PowerPointLabs.SyncLab.Views
         #region GUI Handles
         private void CopyButton_Click(object sender, RoutedEventArgs e)
         {
-            var selection = this.GetCurrentSelection();
+            Selection selection = this.GetCurrentSelection();
             if ((selection.Type != PpSelectionType.ppSelectionShapes &&
                 selection.Type != PpSelectionType.ppSelectionText) ||
                 selection.ShapeRange.Count != 1)
@@ -196,7 +196,7 @@ namespace PowerPointLabs.SyncLab.Views
                 return;
             }
 
-            var shape = selection.ShapeRange[1];
+            Shape shape = selection.ShapeRange[1];
             if (selection.HasChildShapeRange)
             {
                 if (selection.ChildShapeRange.Count != 1)

--- a/PowerPointLabs/PowerPointLabs/TagMatchers/EndSpeedTagMatcher.cs
+++ b/PowerPointLabs/PowerPointLabs/TagMatchers/EndSpeedTagMatcher.cs
@@ -9,13 +9,13 @@ namespace PowerPointLabs.TagMatchers
         public Regex Regex { get { return new Regex(@"\[EndSpeed\]", RegexOptions.IgnoreCase); } }
         public List<ITag> Matches(string text)
         {
-            var foundMatches = new List<ITag>();
+            List<ITag> foundMatches = new List<ITag>();
 
             MatchCollection regexMatches = Regex.Matches(text);
             foreach (Match match in regexMatches)
             {
-                var matchStart = match.Index;
-                var matchEnd = match.Index + match.Length - 1; // 0-based indices.
+                int matchStart = match.Index;
+                int matchEnd = match.Index + match.Length - 1; // 0-based indices.
                 EndSpeedTag tag = new EndSpeedTag(matchStart, matchEnd, match.Value);
                 foundMatches.Add(tag);
             }

--- a/PowerPointLabs/PowerPointLabs/TagMatchers/EndVoiceTagMatcher.cs
+++ b/PowerPointLabs/PowerPointLabs/TagMatchers/EndVoiceTagMatcher.cs
@@ -9,13 +9,13 @@ namespace PowerPointLabs.TagMatchers
         public Regex Regex { get { return new Regex(@"\[EndVoice\]", RegexOptions.IgnoreCase); }}
         public List<ITag> Matches(string text)
         {
-            var foundMatches = new List<ITag>();
+            List<ITag> foundMatches = new List<ITag>();
 
             MatchCollection regexMatches = Regex.Matches(text);
             foreach (Match match in regexMatches)
             {
-                var matchStart = match.Index;
-                var matchEnd = match.Index + match.Length - 1; // 0-based indices.
+                int matchStart = match.Index;
+                int matchEnd = match.Index + match.Length - 1; // 0-based indices.
                 EndVoiceTag tag = new EndVoiceTag(matchStart, matchEnd, match.Value);
                 foundMatches.Add(tag);
             }

--- a/PowerPointLabs/PowerPointLabs/TagMatchers/NoEffectTagMatcher.cs
+++ b/PowerPointLabs/PowerPointLabs/TagMatchers/NoEffectTagMatcher.cs
@@ -10,13 +10,13 @@ namespace PowerPointLabs.TagMatchers
 
         public List<ITag> Matches(string text)
         {
-            var foundMatches = new List<ITag>();
+            List<ITag> foundMatches = new List<ITag>();
 
             MatchCollection regexMatches = Regex.Matches(text);
             foreach (Match match in regexMatches)
             {
-                var matchStart = match.Index;
-                var matchEnd = match.Index + match.Length - 1; // 0-based indices.
+                int matchStart = match.Index;
+                int matchEnd = match.Index + match.Length - 1; // 0-based indices.
                 NoEffectTag tag = new NoEffectTag(matchStart, matchEnd, match.Value);
                 foundMatches.Add(tag);
             }

--- a/PowerPointLabs/PowerPointLabs/TagMatchers/PauseTagMatcher.cs
+++ b/PowerPointLabs/PowerPointLabs/TagMatchers/PauseTagMatcher.cs
@@ -9,13 +9,13 @@ namespace PowerPointLabs.TagMatchers
         public Regex Regex { get { return new Regex(@"\[Pause: \d+?(\.?\d+?)?\]", RegexOptions.IgnoreCase); } }
         public List<ITag> Matches(string text)
         {
-            var foundMatches = new List<ITag>();
+            List<ITag> foundMatches = new List<ITag>();
 
             MatchCollection regexMatches = Regex.Matches(text);
             foreach (Match match in regexMatches)
             {
-                var matchStart = match.Index;
-                var matchEnd = match.Index + match.Length - 1; // 0-based indices.
+                int matchStart = match.Index;
+                int matchEnd = match.Index + match.Length - 1; // 0-based indices.
                 PauseTag tag = new PauseTag(matchStart, matchEnd, match.Value);
                 foundMatches.Add(tag);
             }

--- a/PowerPointLabs/PowerPointLabs/TagMatchers/PronounceTagMatcher.cs
+++ b/PowerPointLabs/PowerPointLabs/TagMatchers/PronounceTagMatcher.cs
@@ -9,13 +9,13 @@ namespace PowerPointLabs.TagMatchers
         public Regex Regex { get { return new Regex(@"\[Pronounce: .+?\].+?\[EndPronounce\]", RegexOptions.IgnoreCase); } }
         public List<ITag> Matches(string text)
         {
-            var foundMatches = new List<ITag>();
+            List<ITag> foundMatches = new List<ITag>();
 
             MatchCollection regexMatches = Regex.Matches(text);
             foreach (Match match in regexMatches)
             {
-                var matchStart = match.Index;
-                var matchEnd = match.Index + match.Length - 1; // 0-based indices.
+                int matchStart = match.Index;
+                int matchEnd = match.Index + match.Length - 1; // 0-based indices.
                 PronounceTag tag = new PronounceTag(matchStart, matchEnd, match.Value);
                 foundMatches.Add(tag);
             }

--- a/PowerPointLabs/PowerPointLabs/TagMatchers/StartSpeedTagMatcher.cs
+++ b/PowerPointLabs/PowerPointLabs/TagMatchers/StartSpeedTagMatcher.cs
@@ -9,13 +9,13 @@ namespace PowerPointLabs.TagMatchers
         public Regex Regex { get { return new Regex(@"\[speed: (extra slow|slow|medium|fast|extra fast)\]", RegexOptions.IgnoreCase); } }
         public List<ITag> Matches(string text)
         {
-            var foundMatches = new List<ITag>();
+            List<ITag> foundMatches = new List<ITag>();
 
             MatchCollection regexMatches = Regex.Matches(text);
             foreach (Match match in regexMatches)
             {
-                var matchStart = match.Index;
-                var matchEnd = match.Index + match.Length - 1; // 0-based indices.
+                int matchStart = match.Index;
+                int matchEnd = match.Index + match.Length - 1; // 0-based indices.
                 StartSpeedTag tag = new StartSpeedTag(matchStart, matchEnd, match.Value);
                 foundMatches.Add(tag);
             }

--- a/PowerPointLabs/PowerPointLabs/TagMatchers/StartVoiceTagMatcher.cs
+++ b/PowerPointLabs/PowerPointLabs/TagMatchers/StartVoiceTagMatcher.cs
@@ -10,13 +10,13 @@ namespace PowerPointLabs.TagMatchers
 
         public List<ITag> Matches(string text)
         {
-            var foundMatches = new List<ITag>();
+            List<ITag> foundMatches = new List<ITag>();
 
             MatchCollection regexMatches = Regex.Matches(text);
             foreach (Match match in regexMatches)
             {
-                var matchStart = match.Index;
-                var matchEnd = match.Index + match.Length - 1; // 0-based indices.
+                int matchStart = match.Index;
+                int matchEnd = match.Index + match.Length - 1; // 0-based indices.
                 StartVoiceTag tag = new StartVoiceTag(matchStart, matchEnd, match.Value);
                 foundMatches.Add(tag);
             }

--- a/PowerPointLabs/PowerPointLabs/Tags/PronounceTag.cs
+++ b/PowerPointLabs/PowerPointLabs/Tags/PronounceTag.cs
@@ -16,7 +16,7 @@ namespace PowerPointLabs.Tags
         {
             String pronounciation = ParseTagArgument();
 
-            var wordToPronounce = ParseWordToPronounce();
+            string wordToPronounce = ParseWordToPronounce();
             try
             {
                 builder.AppendTextWithPronunciation(wordToPronounce, pronounciation);

--- a/PowerPointLabs/PowerPointLabs/Tags/StartVoiceTag.cs
+++ b/PowerPointLabs/PowerPointLabs/Tags/StartVoiceTag.cs
@@ -38,12 +38,12 @@ namespace PowerPointLabs.Tags
         private static string FindFullVoiceName(string voiceArgument)
         {
             string voiceName = null;
-            using (var synthesizer = new SpeechSynthesizer())
+            using (SpeechSynthesizer synthesizer = new SpeechSynthesizer())
             {
-                var installedVoices = synthesizer.GetInstalledVoices();
-                var enabledVoices = installedVoices.Where(voice => voice.Enabled);
+                System.Collections.ObjectModel.ReadOnlyCollection<InstalledVoice> installedVoices = synthesizer.GetInstalledVoices();
+                System.Collections.Generic.IEnumerable<InstalledVoice> enabledVoices = installedVoices.Where(voice => voice.Enabled);
 
-                var selectedVoice = enabledVoices.FirstOrDefault(voice => voice.VoiceInfo.Name.ToLowerInvariant().Contains(voiceArgument));
+                InstalledVoice selectedVoice = enabledVoices.FirstOrDefault(voice => voice.VoiceInfo.Name.ToLowerInvariant().Contains(voiceArgument));
                 if (selectedVoice != null)
                 {
                     voiceName = selectedVoice.VoiceInfo.Name;

--- a/PowerPointLabs/PowerPointLabs/ThisAddIn.cs
+++ b/PowerPointLabs/PowerPointLabs/ThisAddIn.cs
@@ -78,7 +78,7 @@ namespace PowerPointLabs
 
         public Control GetActiveControl(Type type)
         {
-            var taskPane = GetActivePane(type);
+            CustomTaskPane taskPane = GetActivePane(type);
 
             return taskPane == null ? null : taskPane.Control;
         }
@@ -99,7 +99,7 @@ namespace PowerPointLabs
 
         public Control GetControlFromWindow(Type type, PowerPoint.DocumentWindow window)
         {
-            var taskPane = GetPaneFromWindow(typeof(CustomShapePane), window);
+            CustomTaskPane taskPane = GetPaneFromWindow(typeof(CustomShapePane), window);
 
             return taskPane == null ? null : taskPane.Control;
         }
@@ -111,13 +111,13 @@ namespace PowerPointLabs
                 return null;
             }
 
-            var panes = _documentPaneMapper[window];
+            List<CustomTaskPane> panes = _documentPaneMapper[window];
 
-            foreach (var pane in panes)
+            foreach (CustomTaskPane pane in panes)
             {
                 try
                 {
-                    var control = pane.Control;
+                    UserControl control = pane.Control;
 
                     if (control.GetType() == type)
                     {
@@ -146,7 +146,7 @@ namespace PowerPointLabs
                 return;
             }
 
-            var shapeRootFolderPath = ShapesLabSettings.SaveFolderPath;
+            string shapeRootFolderPath = ShapesLabSettings.SaveFolderPath;
 
             ShapePresentation =
                 new PowerPointShapeGalleryPresentation(shapeRootFolderPath, ShapeGalleryPptxName);
@@ -191,8 +191,8 @@ namespace PowerPointLabs
 
         public void PrepareMediaFiles(PowerPoint.Presentation pres, string tempPath)
         {
-            var presFullName = pres.FullName;
-            var presName = pres.Name;
+            string presFullName = pres.FullName;
+            string presName = pres.Name;
 
             // in case of embedded slides, we need to regulate the file name and full name
             RegulatePresentationName(pres, tempPath, ref presName, ref presFullName);
@@ -204,7 +204,7 @@ namespace PowerPointLabs
                     return;
                 }
 
-                var zipFullPath = tempPath + TempZipName;
+                string zipFullPath = tempPath + TempZipName;
 
                 // before we do everything, check if there's an undelete old zip file
                 // due to some error
@@ -228,13 +228,13 @@ namespace PowerPointLabs
 
         public string PrepareTempFolder(PowerPoint.Presentation pres)
         {
-            var presName = pres.Name;
-            var presFullName = pres.FullName;
+            string presName = pres.Name;
+            string presFullName = pres.FullName;
 
             // here presFullName makes no use, just to fit in the signature
             RegulatePresentationName(pres, null, ref presName, ref presFullName);
 
-            var tempPath = GetPresentationTempFolder(presName);
+            string tempPath = GetPresentationTempFolder(presName);
 
             // if temp folder doesn't exist, create
             try
@@ -263,7 +263,7 @@ namespace PowerPointLabs
                 return;
             }
 
-            var activeWindow = presentation.Application.ActiveWindow;
+            PowerPoint.DocumentWindow activeWindow = presentation.Application.ActiveWindow;
 
             RegisterTaskPane(new ResizeLabPane(), ResizeLabText.TaskPaneTitle, activeWindow,
                 ResizeTaskPaneVisibleValueChangedEventHandler, null);
@@ -287,7 +287,7 @@ namespace PowerPointLabs
                 return;
             }
 
-            var activeWindow = presentation.Application.ActiveWindow;
+            PowerPoint.DocumentWindow activeWindow = presentation.Application.ActiveWindow;
 
             RegisterTaskPane(new ColorPane(), ColorsLabText.TaskPanelTitle, activeWindow, null, null);
         }
@@ -299,7 +299,7 @@ namespace PowerPointLabs
                 return;
             }
 
-            var activeWindow = presentation.Application.ActiveWindow;
+            PowerPoint.DocumentWindow activeWindow = presentation.Application.ActiveWindow;
 
             RegisterTaskPane(
                 new CustomShapePane(ShapesLabSettings.SaveFolderPath, ShapesLabConfig.DefaultCategory),
@@ -315,7 +315,7 @@ namespace PowerPointLabs
                     continue;
                 }
 
-                var shapePaneControl = GetControlFromWindow(typeof(CustomShapePane), window) as CustomShapePane;
+                CustomShapePane shapePaneControl = GetControlFromWindow(typeof(CustomShapePane), window) as CustomShapePane;
 
                 if (shapePaneControl != null &&
                     shapePaneControl.CurrentCategory == category)
@@ -334,7 +334,7 @@ namespace PowerPointLabs
                     continue;
                 }
 
-                var shapePaneControl = GetControlFromWindow(typeof(CustomShapePane), window) as CustomShapePane;
+                CustomShapePane shapePaneControl = GetControlFromWindow(typeof(CustomShapePane), window) as CustomShapePane;
 
                 if (shapePaneControl != null &&
                     shapePaneControl.CurrentCategory == category)
@@ -353,7 +353,7 @@ namespace PowerPointLabs
                     continue;
                 }
 
-                var shapePaneControl = GetControlFromWindow(typeof(CustomShapePane), window) as CustomShapePane;
+                CustomShapePane shapePaneControl = GetControlFromWindow(typeof(CustomShapePane), window) as CustomShapePane;
 
                 if (shapePaneControl != null &&
                     shapePaneControl.CurrentCategory == category)
@@ -365,7 +365,7 @@ namespace PowerPointLabs
 
         public bool VerifyOnLocal(PowerPoint.Presentation pres)
         {
-            var invalidPathRegex = new Regex("^[hH]ttps?:");
+            Regex invalidPathRegex = new Regex("^[hH]ttps?:");
 
             return !invalidPathRegex.IsMatch(pres.Path);
         }
@@ -383,15 +383,15 @@ namespace PowerPointLabs
     EventHandler visibleChangeEventHandler = null,
     EventHandler dockPositionChangeEventHandler = null)
         {
-            var loadingDialog = new LoadingDialogBox();
+            LoadingDialogBox loadingDialog = new LoadingDialogBox();
             loadingDialog.Show();
 
             // note down the control's width
-            var width = control.Width;
+            int width = control.Width;
 
             // register the user control to the CustomTaskPanes collection and set it as
             // current active task pane;
-            var taskPane = CustomTaskPanes.Add(control, title, wnd);
+            CustomTaskPane taskPane = CustomTaskPanes.Add(control, title, wnd);
 
             // task pane UI setup
             taskPane.Visible = false;
@@ -439,8 +439,8 @@ namespace PowerPointLabs
                 Directory.CreateDirectory(AppDataFolder);
             }
 
-            var fileName = DateTime.Now.ToString("yyyy-MM-dd") + AppLogName;
-            var logPath = Path.Combine(AppDataFolder, fileName);
+            string fileName = DateTime.Now.ToString("yyyy-MM-dd") + AppLogName;
+            string logPath = Path.Combine(AppDataFolder, fileName);
 
             Trace.AutoFlush = true;
             Trace.Listeners.Add(new TextWriterTraceListener(logPath));
@@ -448,7 +448,7 @@ namespace PowerPointLabs
 
         private void ShutDownRecorderPane()
         {
-            var recorder = GetActiveControl(typeof(RecorderTaskPane)) as RecorderTaskPane;
+            RecorderTaskPane recorder = GetActiveControl(typeof(RecorderTaskPane)) as RecorderTaskPane;
 
             if (recorder != null &&
                 recorder.HasEvent())
@@ -459,14 +459,14 @@ namespace PowerPointLabs
 
         private void ShutDownColorPane()
         {
-            var colorPane = GetActivePane(typeof(ColorPane));
+            CustomTaskPane colorPane = GetActivePane(typeof(ColorPane));
 
             if (colorPane == null)
             {
                 return;
             }
 
-            var colorLabs = colorPane.Control as ColorPane;
+            ColorPane colorLabs = colorPane.Control as ColorPane;
             if (colorLabs != null)
             {
                 colorLabs.SaveDefaultColorPaneThemeColors();
@@ -480,8 +480,8 @@ namespace PowerPointLabs
                 return;
             }
 
-            var activePanes = _documentPaneMapper[activeWindow];
-            foreach (var pane in activePanes)
+            List<CustomTaskPane> activePanes = _documentPaneMapper[activeWindow];
+            foreach (CustomTaskPane pane in activePanes)
             {
                 CustomTaskPanes.Remove(pane);
             }
@@ -496,10 +496,10 @@ namespace PowerPointLabs
                 return;
             }
 
-            var activePanes = _documentPaneMapper[window];
-            for (var i = activePanes.Count - 1; i >= 0; i--)
+            List<CustomTaskPane> activePanes = _documentPaneMapper[window];
+            for (int i = activePanes.Count - 1; i >= 0; i--)
             {
-                var pane = activePanes[i];
+                CustomTaskPane pane = activePanes[i];
                 if (pane.Control.GetType() != paneType)
                 {
                     continue;
@@ -535,14 +535,14 @@ namespace PowerPointLabs
 
         private void TaskPaneVisibleValueChangedEventHandler(object sender, EventArgs e)
         {
-            var recorderPane = GetActivePane(typeof(RecorderTaskPane));
+            CustomTaskPane recorderPane = GetActivePane(typeof(RecorderTaskPane));
 
             if (recorderPane == null)
             {
                 return;
             }
 
-            var recorder = recorderPane.Control as RecorderTaskPane;
+            RecorderTaskPane recorder = recorderPane.Control as RecorderTaskPane;
 
             // trigger close form event when closing hide the pane
             if (recorder != null && !recorderPane.Visible)
@@ -555,7 +555,7 @@ namespace PowerPointLabs
 
         private void ResizeTaskPaneVisibleValueChangedEventHandler(object sender, EventArgs e)
         {
-            var resizePane = GetActivePane(typeof(ResizeLabPane));
+            CustomTaskPane resizePane = GetActivePane(typeof(ResizeLabPane));
 
             if (resizePane == null)
             {
@@ -601,7 +601,7 @@ namespace PowerPointLabs
         {
             _isInSlideShow = false;
 
-            var recorder = GetActiveControl(typeof(RecorderTaskPane)) as RecorderTaskPane;
+            RecorderTaskPane recorder = GetActiveControl(typeof(RecorderTaskPane)) as RecorderTaskPane;
 
             if (recorder == null)
             {
@@ -624,16 +624,16 @@ namespace PowerPointLabs
             // if audio buffer is not empty, render the effects
             if (recorder.AudioBuffer.Count != 0)
             {
-                var slides = PowerPointPresentation.Current.Slides.ToList();
+                List<PowerPointSlide> slides = PowerPointPresentation.Current.Slides.ToList();
 
-                for (var i = 0; i < recorder.AudioBuffer.Count; i++)
+                for (int i = 0; i < recorder.AudioBuffer.Count; i++)
                 {
                     if (recorder.AudioBuffer[i].Count == 0)
                     {
                         continue;
                     }
 
-                    foreach (var audio in recorder.AudioBuffer[i])
+                    foreach (Tuple<AudioMisc.Audio, int> audio in recorder.AudioBuffer[i])
                     {
                         audio.Item1.EmbedOnSlide(slides[i], audio.Item2);
 
@@ -664,14 +664,14 @@ namespace PowerPointLabs
                 return false;
             }
 
-            var fileInfo = new FileInfo(filePath);
+            FileInfo fileInfo = new FileInfo(filePath);
 
             return fileInfo.Length == 0;
         }
 
         private void UpdateRecorderPane(int count, int id)
         {
-            var recorderPane = GetActivePane(typeof(RecorderTaskPane));
+            CustomTaskPane recorderPane = GetActivePane(typeof(RecorderTaskPane));
 
             // if there's no active pane associated with the current window, return
             if (recorderPane == null)
@@ -679,7 +679,7 @@ namespace PowerPointLabs
                 return;
             }
 
-            var recorder = recorderPane.Control as RecorderTaskPane;
+            RecorderTaskPane recorder = recorderPane.Control as RecorderTaskPane;
 
             if (recorder == null)
             {
@@ -709,8 +709,8 @@ namespace PowerPointLabs
 
         private string GetPresentationTempFolder(string presName)
         {
-            var tempName = presName.GetHashCode().ToString(CultureInfo.InvariantCulture);
-            var tempPath = Path.GetTempPath() + TempFolderNamePrefix + tempName + @"\";
+            string tempName = presName.GetHashCode().ToString(CultureInfo.InvariantCulture);
+            string tempPath = Path.GetTempPath() + TempFolderNamePrefix + tempName + @"\";
 
             return tempPath;
         }
@@ -732,14 +732,14 @@ namespace PowerPointLabs
         {
             try
             {
-                var zip = ZipStorer.Open(zipFullPath, FileAccess.Read);
-                var dir = zip.ReadCentralDir();
+                ZipStorer zip = ZipStorer.Open(zipFullPath, FileAccess.Read);
+                List<ZipStorer.ZipFileEntry> dir = zip.ReadCentralDir();
 
-                var regex = new Regex(SlideXmlSearchPattern);
+                Regex regex = new Regex(SlideXmlSearchPattern);
 
-                foreach (var entry in dir)
+                foreach (ZipStorer.ZipFileEntry entry in dir)
                 {
-                    var name = Path.GetFileName(entry.FilenameInZip);
+                    string name = Path.GetFileName(entry.FilenameInZip);
 
                     if (name == null)
                     {
@@ -765,7 +765,7 @@ namespace PowerPointLabs
 
         private void BreakRecorderEvents()
         {
-            var recorder = GetActiveControl(typeof(RecorderTaskPane)) as RecorderTaskPane;
+            RecorderTaskPane recorder = GetActiveControl(typeof(RecorderTaskPane)) as RecorderTaskPane;
 
             if (recorder != null &&
                 recorder.HasEvent())
@@ -847,12 +847,12 @@ namespace PowerPointLabs
         {
             if (pres != null)
             {
-                var customShape = GetActiveControl(typeof(CustomShapePane)) as CustomShapePane;
+                CustomShapePane customShape = GetActiveControl(typeof(CustomShapePane)) as CustomShapePane;
 
                 // make sure ShapeGallery's default category is consistent with current presentation
                 if (customShape != null)
                 {
-                    var currentCategory = customShape.CurrentCategory;
+                    string currentCategory = customShape.CurrentCategory;
                     ShapePresentation.DefaultCategory = currentCategory;
                 }
 
@@ -963,8 +963,8 @@ namespace PowerPointLabs
 
         private void ThisAddInNewPresentation(PowerPoint.Presentation pres)
         {
-            var activeWindow = pres.Application.ActiveWindow;
-            var tempName = pres.Name.GetHashCode().ToString(CultureInfo.InvariantCulture);
+            PowerPoint.DocumentWindow activeWindow = pres.Application.ActiveWindow;
+            string tempName = pres.Name.GetHashCode().ToString(CultureInfo.InvariantCulture);
 
             _documentHashcodeMapper[activeWindow] = tempName;
         }
@@ -979,8 +979,8 @@ namespace PowerPointLabs
 
         private void ThisAddInPrensentationOpen(PowerPoint.Presentation pres)
         {
-            var activeWindow = pres.Application.ActiveWindow;
-            var tempName = pres.Name.GetHashCode().ToString(CultureInfo.InvariantCulture);
+            PowerPoint.DocumentWindow activeWindow = pres.Application.ActiveWindow;
+            string tempName = pres.Name.GetHashCode().ToString(CultureInfo.InvariantCulture);
 
             // if we opened a new window, register the window with its name
             if (!_documentHashcodeMapper.ContainsKey(activeWindow))
@@ -1036,7 +1036,7 @@ namespace PowerPointLabs
             // for Functional Test to close presentation
             if (PowerPointLabsFT.IsFunctionalTestOn)
             {
-                var handle = Native.FindWindow("PPTFrameClass", pres.Name + " - Microsoft PowerPoint");
+                IntPtr handle = Native.FindWindow("PPTFrameClass", pres.Name + " - Microsoft PowerPoint");
                 Native.SetForegroundWindow(handle);
                 SendKeys.Send("N");
             }
@@ -1047,7 +1047,7 @@ namespace PowerPointLabs
 
         private void ShutDownImageSearchPane()
         {
-            var pictureSlidesLabWindow = Globals.ThisAddIn.Ribbon.PictureSlidesLabWindow;
+            PictureSlidesLab.Views.PictureSlidesLabWindow pictureSlidesLabWindow = Globals.ThisAddIn.Ribbon.PictureSlidesLabWindow;
             if (pictureSlidesLabWindow != null && pictureSlidesLabWindow.IsOpen && Application.Presentations.Count == 2)
             {
                 pictureSlidesLabWindow.Close();
@@ -1081,8 +1081,8 @@ namespace PowerPointLabs
         {
             try
             {
-                var currentSlide = Application.ActiveWindow.View.Slide as PowerPoint.Slide;
-                var pptName = Application.ActivePresentation.Name;
+                PowerPoint.Slide currentSlide = Application.ActiveWindow.View.Slide as PowerPoint.Slide;
+                string pptName = Application.ActivePresentation.Name;
 
                 if (selection.Type == PowerPoint.PpSelectionType.ppSelectionShapes
                     && currentSlide != null
@@ -1091,12 +1091,12 @@ namespace PowerPointLabs
                 {
                     PowerPoint.ShapeRange pastedShapes = selection.ShapeRange;
 
-                    var nameListForPastedShapes = new List<string>();
-                    var nameDictForPastedShapes = new Dictionary<string, string>();
-                    var nameListForCopiedShapes = new List<string>();
-                    var corruptedShapes = new List<PowerPoint.Shape>();
+                    List<string> nameListForPastedShapes = new List<string>();
+                    Dictionary<string, string> nameDictForPastedShapes = new Dictionary<string, string>();
+                    List<string> nameListForCopiedShapes = new List<string>();
+                    List<PowerPoint.Shape> corruptedShapes = new List<PowerPoint.Shape>();
 
-                    foreach (var shape in _copiedShapes)
+                    foreach (PowerPoint.Shape shape in _copiedShapes)
                     {
                         try
                         {
@@ -1106,7 +1106,7 @@ namespace PowerPointLabs
                         {
                             //handling corrupted shapes
                             shape.Copy();
-                            var fixedShape = _previousSlideForCopyEvent.Shapes.Paste()[1];
+                            PowerPoint.Shape fixedShape = _previousSlideForCopyEvent.Shapes.Paste()[1];
                             fixedShape.Left = shape.Left;
                             fixedShape.Top = shape.Top;
                             while (fixedShape.ZOrderPosition > shape.ZOrderPosition)
@@ -1135,7 +1135,7 @@ namespace PowerPointLabs
                         nameListForPastedShapes.Add(shape.Name);
                     }
                     //Re-select pasted shapes
-                    var range = currentSlide.Shapes.Range(nameListForPastedShapes.ToArray());
+                    PowerPoint.ShapeRange range = currentSlide.Shapes.Range(nameListForPastedShapes.ToArray());
                     foreach (PowerPoint.Shape shape in range)
                     {
                         shape.Name = nameDictForPastedShapes[shape.Name];
@@ -1144,9 +1144,9 @@ namespace PowerPointLabs
                 }
                 else if (selection.Type == PowerPoint.PpSelectionType.ppSelectionSlides)
                 {
-                    var pastedSlides = selection.SlideRange.Cast<PowerPoint.Slide>().OrderBy(x => x.SlideIndex).ToList();
+                    List<PowerPoint.Slide> pastedSlides = selection.SlideRange.Cast<PowerPoint.Slide>().OrderBy(x => x.SlideIndex).ToList();
 
-                    for (var i = 0; i < pastedSlides.Count; i++)
+                    for (int i = 0; i < pastedSlides.Count; i++)
                     {
                         if (AgendaLab.AgendaSlide.IsReferenceslide(_copiedSlides[i]))
                         {
@@ -1214,7 +1214,7 @@ namespace PowerPointLabs
         private bool IsSimilarName(string name1, string name2)
         {
             //remove enclosing brackets for name2
-            var nameEnclosedInBrackets = new Regex(@"^\[\D+\s\d+\]$");
+            Regex nameEnclosedInBrackets = new Regex(@"^\[\D+\s\d+\]$");
             if (!nameEnclosedInBrackets.IsMatch(name1)
                 && nameEnclosedInBrackets.IsMatch(name2)
                 && name2.Length > 2)
@@ -1231,9 +1231,9 @@ namespace PowerPointLabs
             if (_shapeNamePattern.IsMatch(name1)
                 && _shapeNamePattern.IsMatch(name2))
             {
-                var shapeTypeInName = new Regex(@"^[^\[]\D+\s(?=\d+$)");
-                var shapeTypeForName1 = shapeTypeInName.Match(name1).ToString();
-                var shapeTypeForName2 = shapeTypeInName.Match(name2).ToString();
+                Regex shapeTypeInName = new Regex(@"^[^\[]\D+\s(?=\d+$)");
+                string shapeTypeForName1 = shapeTypeInName.Match(name1).ToString();
+                string shapeTypeForName2 = shapeTypeInName.Match(name2).ToString();
                 return shapeTypeForName1.Equals(shapeTypeForName2);
             }
             return false;
@@ -1258,9 +1258,9 @@ namespace PowerPointLabs
                     return;
                 }
 
-                var copyFromRecorderPane =
+                RecorderTaskPane copyFromRecorderPane =
                     GetPaneFromWindow(typeof(RecorderTaskPane), _copyFromWnd).Control as RecorderTaskPane;
-                var activeRecorderPane = GetActivePane(typeof(RecorderTaskPane)).Control as RecorderTaskPane;
+                RecorderTaskPane activeRecorderPane = GetActivePane(typeof(RecorderTaskPane)).Control as RecorderTaskPane;
 
                 if (activeRecorderPane == null ||
                     copyFromRecorderPane == null)
@@ -1268,13 +1268,13 @@ namespace PowerPointLabs
                     return;
                 }
 
-                var slideRange = selection.SlideRange;
-                var oriSlide = 0;
+                PowerPoint.SlideRange slideRange = selection.SlideRange;
+                int oriSlide = 0;
 
-                foreach (var sld in slideRange)
+                foreach (object sld in slideRange)
                 {
-                    var oldSlide = PowerPointSlide.FromSlideFactory(_copiedSlides[oriSlide]);
-                    var newSlide = PowerPointSlide.FromSlideFactory(sld as PowerPoint.Slide);
+                    PowerPointSlide oldSlide = PowerPointSlide.FromSlideFactory(_copiedSlides[oriSlide]);
+                    PowerPointSlide newSlide = PowerPointSlide.FromSlideFactory(sld as PowerPoint.Slide);
 
                     activeRecorderPane.PasteSlideAudioAndScript(newSlide,
                                                                 copyFromRecorderPane.CopySlideAudioAndScript(oldSlide));
@@ -1297,9 +1297,9 @@ namespace PowerPointLabs
                 {
                     _copiedSlides.Clear();
 
-                    foreach (var sld in selection.SlideRange)
+                    foreach (object sld in selection.SlideRange)
                     {
-                        var slide = sld as PowerPoint.Slide;
+                        PowerPoint.Slide slide = sld as PowerPoint.Slide;
 
                         _copiedSlides.Add(slide);
                     }
@@ -1311,9 +1311,9 @@ namespace PowerPointLabs
                     _copiedShapes.Clear();
                     _previousSlideForCopyEvent = Application.ActiveWindow.View.Slide as PowerPoint.Slide;
                     _previousPptName = Application.ActivePresentation.Name;
-                    foreach (var sh in selection.ShapeRange)
+                    foreach (object sh in selection.ShapeRange)
                     {
-                        var shape = sh as PowerPoint.Shape;
+                        PowerPoint.Shape shape = sh as PowerPoint.Shape;
                         _copiedShapes.Add(shape);
                     }
 
@@ -1429,7 +1429,7 @@ namespace PowerPointLabs
             PowerPoint.Shape overlappingShape = null;
             int overlappingShapeZIndex = -1;
 
-            var shapesInCurrentSlide = PowerPointCurrentPresentationInfo.CurrentSlide.Shapes;
+            PowerPoint.Shapes shapesInCurrentSlide = PowerPointCurrentPresentationInfo.CurrentSlide.Shapes;
             foreach (PowerPoint.Shape shape in shapesInCurrentSlide)
             {
                 if (IsMouseWithinShape(shape)
@@ -1467,7 +1467,7 @@ namespace PowerPointLabs
         {
             if (!_isInSlideShow)
             {
-                var selectedShapes = selection.ShapeRange;
+                PowerPoint.ShapeRange selectedShapes = selection.ShapeRange;
                 Native.SendMessage(
                     Process.GetCurrentProcess().MainWindowHandle,
                     (uint)Native.Message.WM_COMMAND,

--- a/PowerPointLabs/PowerPointLabs/Utils/CommonUtil.cs
+++ b/PowerPointLabs/PowerPointLabs/Utils/CommonUtil.cs
@@ -16,15 +16,15 @@ namespace PowerPointLabs.Utils
 
         public static string NextAvailableName(List<string> nameList, string name)
         {
-            var orderedNameList = nameList.OrderBy(item => item, new Comparers.AtomicNumberStringCompare()).ToList();
-            var nextDefaultNumber = NextDefaultNumber(orderedNameList, name);
+            List<string> orderedNameList = nameList.OrderBy(item => item, new Comparers.AtomicNumberStringCompare()).ToList();
+            int nextDefaultNumber = NextDefaultNumber(orderedNameList, name);
 
             return nextDefaultNumber == 0 ? name : string.Format("{0} {1}", name, nextDefaultNumber);
         }
 
         public static string SkipRegexCharacter(string str)
         {
-            var replacePattern = new Regex(@"([^\d\s\w])");
+            Regex replacePattern = new Regex(@"([^\d\s\w])");
 
             return replacePattern.Replace(str, "\\$1");
         }
@@ -35,7 +35,7 @@ namespace PowerPointLabs.Utils
         /// </summary>
         public static string FilenameBase64(string str)
         {
-            var plainTextBytes = System.Text.Encoding.UTF8.GetBytes(str);
+            byte[] plainTextBytes = System.Text.Encoding.UTF8.GetBytes(str);
             str = Convert.ToBase64String(plainTextBytes);
             str = str.Replace("+", "-");
             str = str.Replace("/", "_");
@@ -47,7 +47,7 @@ namespace PowerPointLabs.Utils
         /// </summary>
         public static string Base64Encode(string str)
         {
-            var plainTextBytes = System.Text.Encoding.UTF8.GetBytes(str);
+            byte[] plainTextBytes = System.Text.Encoding.UTF8.GetBytes(str);
             str = Convert.ToBase64String(plainTextBytes);
             return str;
         }
@@ -57,7 +57,7 @@ namespace PowerPointLabs.Utils
         /// </summary>
         public static string Base64Decode(string base64EncodedData)
         {
-            var base64EncodedBytes = Convert.FromBase64String(base64EncodedData);
+            byte[] base64EncodedBytes = Convert.FromBase64String(base64EncodedData);
             return System.Text.Encoding.UTF8.GetString(base64EncodedBytes);
         }
 
@@ -67,7 +67,7 @@ namespace PowerPointLabs.Utils
         /// </summary>
         public static string SerializeCollection(List<string> collection)
         {
-            var serialized = string.Join("@", collection.Select(Base64Encode));
+            string serialized = string.Join("@", collection.Select(Base64Encode));
             return serialized + "@" + ComputeCheckSum(serialized);
         }
 
@@ -77,15 +77,15 @@ namespace PowerPointLabs.Utils
         /// </summary>
         public static List<string> UnserializeCollection(string dataString)
         {
-            var lastDelim = dataString.LastIndexOf('@');
+            int lastDelim = dataString.LastIndexOf('@');
             if (lastDelim == -1)
             {
                 return null;
             }
 
             // Verify checksum
-            var hashCode = dataString.Substring(lastDelim + 1);
-            var serialized = dataString.Substring(0, lastDelim);
+            string hashCode = dataString.Substring(lastDelim + 1);
+            string serialized = dataString.Substring(0, lastDelim);
             if (ComputeCheckSum(serialized).ToString() != hashCode)
             {
                 return null;
@@ -113,7 +113,7 @@ namespace PowerPointLabs.Utils
         /// </summary>
         public static string[] GetUnusedStrings(IEnumerable<string> presentStrings, int nStrings)
         {
-            var unusedStrings = new List<string>();
+            List<string> unusedStrings = new List<string>();
 
             int longestString = presentStrings.Select(str => str.Length).Max();
             string baseString = new string('a', longestString);
@@ -142,9 +142,9 @@ namespace PowerPointLabs.Utils
 
         public static PointF RotatePoint(PointF p, PointF origin, float rotation)
         {
-            var rotationInRadian = DegreeToRadian(rotation);
-            var rotatedX = Math.Cos(rotationInRadian) * (p.X - origin.X) - Math.Sin(rotationInRadian) * (p.Y - origin.Y) + origin.X;
-            var rotatedY = Math.Sin(rotationInRadian) * (p.X - origin.X) + Math.Cos(rotationInRadian) * (p.Y - origin.Y) + origin.Y;
+            double rotationInRadian = DegreeToRadian(rotation);
+            double rotatedX = Math.Cos(rotationInRadian) * (p.X - origin.X) - Math.Sin(rotationInRadian) * (p.Y - origin.Y) + origin.X;
+            double rotatedY = Math.Sin(rotationInRadian) * (p.X - origin.X) + Math.Cos(rotationInRadian) * (p.Y - origin.Y) + origin.Y;
 
             return new PointF((float)rotatedX, (float)rotatedY);
         }
@@ -159,17 +159,17 @@ namespace PowerPointLabs.Utils
         #region Helper Function
         private static int NextDefaultNumber(List<string> nameList, string name)
         {
-            var namePattern = new Regex(string.Format("{0}(?: (\\d+))*", name));
-            var min = 0;
+            Regex namePattern = new Regex(string.Format("{0}(?: (\\d+))*", name));
+            int min = 0;
 
             if (!string.IsNullOrEmpty(namePattern.Match(nameList[0]).Groups[1].Value))
             {
                 return min;
             }
 
-            for (var i = 1; i < nameList.Count; i++)
+            for (int i = 1; i < nameList.Count; i++)
             {
-                var currentCnt = int.Parse(namePattern.Match(nameList[i]).Groups[1].Value);
+                int currentCnt = int.Parse(namePattern.Match(nameList[i]).Groups[1].Value);
 
                 if (currentCnt != min + 1)
                 {
@@ -189,7 +189,7 @@ namespace PowerPointLabs.Utils
         private static string ComputeCheckSum(string s)
         {
             uint x = 0;
-            foreach (var c in s)
+            foreach (char c in s)
             {
                 x += c;
                 x *= 565325351;

--- a/PowerPointLabs/PowerPointLabs/Utils/Comparers.cs
+++ b/PowerPointLabs/PowerPointLabs/Utils/Comparers.cs
@@ -14,20 +14,20 @@ namespace PowerPointLabs.Utils
             public int Compare(string thisString, string otherString)
             {
                 // some characters + number
-                var pattern = new Regex(@"([^\d]+)(\d+)");
-                var thisStringMatch = pattern.Match(thisString);
-                var otherStringMatch = pattern.Match(otherString);
+                Regex pattern = new Regex(@"([^\d]+)(\d+)");
+                Match thisStringMatch = pattern.Match(thisString);
+                Match otherStringMatch = pattern.Match(otherString);
 
                 // specially compare the pattern, after run out of the pattern, compare
                 // 2 strings normally
                 while (thisStringMatch.Success &&
                        otherStringMatch.Success)
                 {
-                    var thisStringPart = thisStringMatch.Groups[1].Value;
-                    var thisNumPart = int.Parse(thisStringMatch.Groups[2].Value);
+                    string thisStringPart = thisStringMatch.Groups[1].Value;
+                    int thisNumPart = int.Parse(thisStringMatch.Groups[2].Value);
 
-                    var otherStringPart = otherStringMatch.Groups[1].Value;
-                    var otherNumPart = int.Parse(otherStringMatch.Groups[2].Value);
+                    string otherStringPart = otherStringMatch.Groups[1].Value;
+                    int otherNumPart = int.Parse(otherStringMatch.Groups[2].Value);
 
                     // if string part is not the same, we can tell the diff
                     if (!string.Equals(thisStringPart, otherStringPart))

--- a/PowerPointLabs/PowerPointLabs/Utils/FileDir.cs
+++ b/PowerPointLabs/PowerPointLabs/Utils/FileDir.cs
@@ -13,7 +13,7 @@ namespace PowerPointLabs.Utils
         # region Folder Operations
         public static bool CopyFolder(string oldPath, string newPath)
         {
-            var copySuccess = true;
+            bool copySuccess = true;
 
             // create subfolder during recursions
             if (!Directory.Exists(newPath))
@@ -22,11 +22,11 @@ namespace PowerPointLabs.Utils
             }
 
             // copy files in a folder first
-            var files = Directory.GetFiles(oldPath);
+            string[] files = Directory.GetFiles(oldPath);
 
-            foreach (var file in files)
+            foreach (string file in files)
             {
-                var name = Path.GetFileName(file);
+                string name = Path.GetFileName(file);
 
                 // ignore thumb.db
                 if (name == null ||
@@ -35,11 +35,11 @@ namespace PowerPointLabs.Utils
                     continue;
                 }
 
-                var dest = Path.Combine(newPath, name);
+                string dest = Path.Combine(newPath, name);
 
                 try
                 {
-                    var fileAttribute = File.GetAttributes(file);
+                    FileAttributes fileAttribute = File.GetAttributes(file);
                     
                     try
                     {
@@ -58,18 +58,18 @@ namespace PowerPointLabs.Utils
             }
 
             // then recursively copy contents in subfolders
-            var folders = Directory.GetDirectories(oldPath);
+            string[] folders = Directory.GetDirectories(oldPath);
 
-            foreach (var folder in folders)
+            foreach (string folder in folders)
             {
-                var name = Path.GetFileName(folder);
+                string name = Path.GetFileName(folder);
 
                 if (name == null)
                 {
                     continue;
                 }
 
-                var dest = Path.Combine(newPath, name);
+                string dest = Path.Combine(newPath, name);
 
                 copySuccess = copySuccess && CopyFolder(folder, dest);
             }
@@ -79,13 +79,13 @@ namespace PowerPointLabs.Utils
 
         public static bool DeleteFolder(string path)
         {
-            var deleteSuccess = true;
+            bool deleteSuccess = true;
             // copy files in a folder first
-            var files = Directory.GetFiles(path);
+            string[] files = Directory.GetFiles(path);
 
-            foreach (var file in files)
+            foreach (string file in files)
             {
-                var name = Path.GetFileName(file);
+                string name = Path.GetFileName(file);
 
                 if (name == null)
                 {
@@ -102,11 +102,11 @@ namespace PowerPointLabs.Utils
                 }
             }
 
-            var folders = Directory.GetDirectories(path);
+            string[] folders = Directory.GetDirectories(path);
 
-            foreach (var folder in folders)
+            foreach (string folder in folders)
             {
-                var name = Path.GetFileName(folder);
+                string name = Path.GetFileName(folder);
 
                 if (name == null)
                 {
@@ -149,17 +149,17 @@ namespace PowerPointLabs.Utils
         public static void NormalizeFolder(string path)
         {
             // copy files in a folder first
-            var files = Directory.GetFiles(path);
+            string[] files = Directory.GetFiles(path);
 
-            foreach (var file in files)
+            foreach (string file in files)
             {
                 File.SetAttributes(file, FileAttributes.Normal);
             }
 
             // then recursively copy contents in subfolders
-            var folders = Directory.GetDirectories(path);
+            string[] folders = Directory.GetDirectories(path);
 
-            foreach (var folder in folders)
+            foreach (string folder in folders)
             {
                 NormalizeFolder(folder);
             }

--- a/PowerPointLabs/PowerPointLabs/Utils/GraphicsUtil.cs
+++ b/PowerPointLabs/PowerPointLabs/Utils/GraphicsUtil.cs
@@ -67,8 +67,8 @@ namespace PowerPointLabs.Utils
 
         public static void ExportShape(ShapeRange shapeRange, string exportPath)
         {
-            var slideWidth = (int)PowerPointPresentation.Current.SlideWidth;
-            var slideHeight = (int)PowerPointPresentation.Current.SlideHeight;
+            int slideWidth = (int)PowerPointPresentation.Current.SlideWidth;
+            int slideHeight = (int)PowerPointPresentation.Current.SlideHeight;
 
             shapeRange.Export(exportPath, PpShapeFormat.ppShapeFormatPNG, slideWidth,
                               slideHeight, PpExportMode.ppScaleToFit);
@@ -118,22 +118,22 @@ namespace PowerPointLabs.Utils
         #region Bitmap
         public static Bitmap CreateThumbnailImage(Image oriImage, int width, int height)
         {
-            var scalingRatio = CalculateScalingRatio(oriImage.Size, new Size(width, height));
+            double scalingRatio = CalculateScalingRatio(oriImage.Size, new Size(width, height));
 
             // calculate width and height after scaling
-            var scaledWidth = (int)Math.Round(oriImage.Size.Width * scalingRatio);
-            var scaledHeight = (int)Math.Round(oriImage.Size.Height * scalingRatio);
+            int scaledWidth = (int)Math.Round(oriImage.Size.Width * scalingRatio);
+            int scaledHeight = (int)Math.Round(oriImage.Size.Height * scalingRatio);
 
             // calculate left top corner position of the image in the thumbnail
-            var scaledLeft = (width - scaledWidth) / 2;
-            var scaledTop = (height - scaledHeight) / 2;
+            int scaledLeft = (width - scaledWidth) / 2;
+            int scaledTop = (height - scaledHeight) / 2;
 
             // define drawing area
-            var drawingRect = new Rectangle(scaledLeft, scaledTop, scaledWidth, scaledHeight);
-            var thumbnail = new Bitmap(width, height);
+            Rectangle drawingRect = new Rectangle(scaledLeft, scaledTop, scaledWidth, scaledHeight);
+            Bitmap thumbnail = new Bitmap(width, height);
 
             // here we set the thumbnail as the highest quality
-            using (var thumbnailGraphics = System.Drawing.Graphics.FromImage(thumbnail))
+            using (Graphics thumbnailGraphics = System.Drawing.Graphics.FromImage(thumbnail))
             {
                 thumbnailGraphics.CompositingQuality = CompositingQuality.HighQuality;
                 thumbnailGraphics.InterpolationMode = InterpolationMode.HighQualityBicubic;
@@ -240,16 +240,16 @@ namespace PowerPointLabs.Utils
         /// <returns>The converted object</returns>
         public static BitmapSource CreateBitmapSourceFromGdiBitmap(Bitmap bitmap)
         {
-            var rect = new System.Drawing.Rectangle(0, 0, bitmap.Width, bitmap.Height);
+            Rectangle rect = new System.Drawing.Rectangle(0, 0, bitmap.Width, bitmap.Height);
 
-            var bitmapData = bitmap.LockBits(
+            BitmapData bitmapData = bitmap.LockBits(
                 rect,
                 ImageLockMode.ReadWrite,
                 Drawing.Imaging.PixelFormat.Format32bppArgb);
 
             try
             {
-                var size = (rect.Width * rect.Height) * 4;
+                int size = (rect.Width * rect.Height) * 4;
 
                 return BitmapSource.Create(
                     bitmap.Width,

--- a/PowerPointLabs/PowerPointLabs/Utils/PPShape.API.cs
+++ b/PowerPointLabs/PowerPointLabs/Utils/PPShape.API.cs
@@ -182,7 +182,7 @@ namespace PowerPointLabs.Utils
             get { return GetRotatedPoint(-_shape.Width/2, -_shape.Height/2); }
             set
             {
-                var center = GetCenterPoint(value, -_shape.Width/2, -_shape.Height/2);
+                PointF center = GetCenterPoint(value, -_shape.Width/2, -_shape.Height/2);
                 AlignToCenter(center);
             }
         }
@@ -208,7 +208,7 @@ namespace PowerPointLabs.Utils
             get { return GetRotatedPoint(0, -_shape.Height/2); }
             set
             {
-                var center = GetCenterPoint(value, 0, -_shape.Height/2);
+                PointF center = GetCenterPoint(value, 0, -_shape.Height/2);
                 AlignToCenter(center);
             }
         }
@@ -237,7 +237,7 @@ namespace PowerPointLabs.Utils
             }
             set
             {
-                var center = GetCenterPoint(value, _shape.Width/2, -_shape.Height/2);
+                PointF center = GetCenterPoint(value, _shape.Width/2, -_shape.Height/2);
                 AlignToCenter(center);
             }
         }
@@ -263,7 +263,7 @@ namespace PowerPointLabs.Utils
             get { return GetRotatedPoint(-_shape.Width/2, 0); }
             set
             {
-                var center = GetCenterPoint(value, -_shape.Width/2, 0); 
+                PointF center = GetCenterPoint(value, -_shape.Width/2, 0); 
                 AlignToCenter(center);
             }
         }
@@ -289,7 +289,7 @@ namespace PowerPointLabs.Utils
             get { return GetRotatedPoint(_shape.Width/2, 0); }
             set
             {
-                var center = GetCenterPoint(value, _shape.Width/2, 0);
+                PointF center = GetCenterPoint(value, _shape.Width/2, 0);
                 AlignToCenter(center);
             }
         }
@@ -315,7 +315,7 @@ namespace PowerPointLabs.Utils
             get { return GetRotatedPoint(-_shape.Width/2, _shape.Height/2); }
             set
             {
-                var center = GetCenterPoint(value, -_shape.Width/2, _shape.Height/2);
+                PointF center = GetCenterPoint(value, -_shape.Width/2, _shape.Height/2);
                 AlignToCenter(center);
             }
         }
@@ -341,7 +341,7 @@ namespace PowerPointLabs.Utils
             get { return GetRotatedPoint(0, _shape.Height/2); }
             set
             {
-                var center = GetCenterPoint(value, 0, _shape.Height/2);
+                PointF center = GetCenterPoint(value, 0, _shape.Height/2);
                 AlignToCenter(center);
             }
         }
@@ -367,7 +367,7 @@ namespace PowerPointLabs.Utils
             get { return GetRotatedPoint(_shape.Width/2, _shape.Height/2); }
             set
             {
-                var center = GetCenterPoint(value, _shape.Width/2, _shape.Height/2);
+                PointF center = GetCenterPoint(value, _shape.Width/2, _shape.Height/2);
                 AlignToCenter(center);
             }
         }
@@ -450,7 +450,7 @@ namespace PowerPointLabs.Utils
         /// <returns></returns>
         public PPShape Duplicate()
         {
-            var newShape = new PPShape(_shape.Duplicate()[1]) {Name = _shape.Name + "Copy"};
+            PPShape newShape = new PPShape(_shape.Duplicate()[1]) {Name = _shape.Name + "Copy"};
             return newShape;
         }
 
@@ -502,21 +502,21 @@ namespace PowerPointLabs.Utils
                 return;
             }
 
-            var isSecondOrFourthQuadrant = (_originalRotation >= 90 && _originalRotation < 180) ||
+            bool isSecondOrFourthQuadrant = (_originalRotation >= 90 && _originalRotation < 180) ||
                                          (_originalRotation >= 270 && _originalRotation < 360);
 
-            var rotation = GetStandardizedRotation(_originalRotation%90);
-            var centerLeft = VisualCenter.X;
-            var centerTop = VisualCenter.Y;
+            float rotation = GetStandardizedRotation(_originalRotation%90);
+            float centerLeft = VisualCenter.X;
+            float centerTop = VisualCenter.Y;
 
             for (int i = 1; i <= _shape.Nodes.Count; i++)
             {
-                var node = _shape.Nodes[i];
-                var point = node.Points;
-                var oldX = point[1, 1];
-                var oldY = point[1, 2];
-                var newX = oldY*Math.Sin(rotation) + oldX*Math.Cos(rotation);
-                var newY = oldY*Math.Cos(rotation) - oldX*Math.Sin(rotation);
+                PowerPoint.ShapeNode node = _shape.Nodes[i];
+                dynamic point = node.Points;
+                dynamic oldX = point[1, 1];
+                dynamic oldY = point[1, 2];
+                dynamic newX = oldY*Math.Sin(rotation) + oldX*Math.Cos(rotation);
+                dynamic newY = oldY*Math.Cos(rotation) - oldX*Math.Sin(rotation);
 
                 if (isSecondOrFourthQuadrant)
                 {

--- a/PowerPointLabs/PowerPointLabs/Utils/PPShape.Helper.cs
+++ b/PowerPointLabs/PowerPointLabs/Utils/PPShape.Helper.cs
@@ -40,8 +40,8 @@ namespace PowerPointLabs.Utils
 
             for (int i = 0; i < _points.Count; i++)
             {
-                var point = _points[i];
-                var nodeIndex = i + 1;
+                PointF point = _points[i];
+                int nodeIndex = i + 1;
 
                 _shape.Nodes.SetPosition(nodeIndex, point.X, point.Y);
             }
@@ -52,7 +52,7 @@ namespace PowerPointLabs.Utils
         /// </summary>
         private void UpdateAbsoluteWidth()
         {
-            var rotation = GetStandardizedRotation(_shape.Rotation);
+            float rotation = GetStandardizedRotation(_shape.Rotation);
 
             if (IsInQuadrant(_shape.Rotation))
             {
@@ -73,7 +73,7 @@ namespace PowerPointLabs.Utils
         /// </summary>
         private void UpdateAbsoluteHeight()
         {
-            var rotation = GetStandardizedRotation(_shape.Rotation);
+            float rotation = GetStandardizedRotation(_shape.Rotation);
 
             if (IsInQuadrant(_shape.Rotation))
             {
@@ -110,9 +110,9 @@ namespace PowerPointLabs.Utils
         /// </summary>
         private void SetToAbsoluteDimension()
         {
-            var rotation = GetStandardizedRotation(_shape.Rotation);
-            var sinAngle = Math.Sin(rotation);
-            var cosAngle = Math.Cos(rotation);
+            float rotation = GetStandardizedRotation(_shape.Rotation);
+            double sinAngle = Math.Sin(rotation);
+            double cosAngle = Math.Cos(rotation);
 
             if ((int) _shape.Rotation == 90 || (int) _shape.Rotation == 270)
             {
@@ -121,7 +121,7 @@ namespace PowerPointLabs.Utils
             }
             else
             {
-                var ratio = sinAngle / cosAngle;
+                double ratio = sinAngle / cosAngle;
                 _shape.Height = (float)((_absoluteWidth * ratio - _absoluteHeight) / (sinAngle * ratio - cosAngle));
                 _shape.Width = (float)((_absoluteWidth - _shape.Height * sinAngle) / cosAngle);
             }
@@ -130,8 +130,8 @@ namespace PowerPointLabs.Utils
         private void SetToAbsoluteHeightAspectRatio()
         {
             // Store the original position of the shape
-            var originalTop = _shape.Top;
-            var originalLeft = _shape.Left;
+            float originalTop = _shape.Top;
+            float originalLeft = _shape.Left;
 
             _shape.LockAspectRatio = MsoTriState.msoFalse;
             FitToSlide.FitToHeight(_shape, _absoluteWidth, _absoluteHeight);
@@ -147,8 +147,8 @@ namespace PowerPointLabs.Utils
         private void SetToAbsoluteWidthAspectRatio()
         {
             // Store the original position of the shape
-            var originalTop = _shape.Top;
-            var originalLeft = _shape.Left;
+            float originalTop = _shape.Top;
+            float originalLeft = _shape.Left;
 
             _shape.LockAspectRatio = MsoTriState.msoFalse;
             FitToSlide.FitToWidth(_shape, _absoluteWidth, _absoluteHeight);
@@ -188,7 +188,7 @@ namespace PowerPointLabs.Utils
                 return;
             }
 
-            var shape = _shape;
+            Microsoft.Office.Interop.PowerPoint.Shape shape = _shape;
 
             if (!isConvertToFreeform)
             {
@@ -208,9 +208,9 @@ namespace PowerPointLabs.Utils
 
             for (int i = 1; i <= shape.Nodes.Count; i++)
             {
-                var node = shape.Nodes[i];
-                var point = node.Points;
-                var newPoint = new PointF(point[1, 1], point[1, 2]);
+                Microsoft.Office.Interop.PowerPoint.ShapeNode node = shape.Nodes[i];
+                dynamic point = node.Points;
+                PointF newPoint = new PointF(point[1, 1], point[1, 2]);
 
                 _points.Add(newPoint);
             }
@@ -293,11 +293,11 @@ namespace PowerPointLabs.Utils
         /// <returns></returns>
         private PointF GetRotatedPoint(float widthDiff, float heightDiff)
         {
-            var rotation = ConvertDegToRad(_shape.Rotation);
-            var centerX = _shape.Left + _shape.Width/2;
-            var centerY = _shape.Top + _shape.Height/2;
-            var x = Math.Cos(rotation)*widthDiff - Math.Sin(rotation)*heightDiff + centerX;
-            var y = Math.Sin(rotation)*widthDiff + Math.Cos(rotation)*heightDiff + centerY;
+            float rotation = ConvertDegToRad(_shape.Rotation);
+            float centerX = _shape.Left + _shape.Width/2;
+            float centerY = _shape.Top + _shape.Height/2;
+            double x = Math.Cos(rotation)*widthDiff - Math.Sin(rotation)*heightDiff + centerX;
+            double y = Math.Sin(rotation)*widthDiff + Math.Cos(rotation)*heightDiff + centerY;
 
             return new PointF((float) x, (float) y);
         }
@@ -312,9 +312,9 @@ namespace PowerPointLabs.Utils
         /// <returns></returns>
         private PointF GetCenterPoint(PointF rotated, float widthDiff, float heightDiff)
         {
-            var rotation = ConvertDegToRad(_shape.Rotation);
-            var x = rotated.X - Math.Cos(rotation)*widthDiff + Math.Sin(rotation)*heightDiff;
-            var y = rotated.Y - Math.Sin(rotation)*widthDiff - Math.Cos(rotation)*heightDiff;
+            float rotation = ConvertDegToRad(_shape.Rotation);
+            double x = rotated.X - Math.Cos(rotation)*widthDiff + Math.Sin(rotation)*heightDiff;
+            double y = rotated.Y - Math.Sin(rotation)*widthDiff - Math.Cos(rotation)*heightDiff;
             
             return new PointF((float) x, (float) y);
         }

--- a/PowerPointLabs/PowerPointLabs/Utils/ShapeUtil.cs
+++ b/PowerPointLabs/PowerPointLabs/Utils/ShapeUtil.cs
@@ -313,7 +313,7 @@ namespace PowerPointLabs.Utils
         // TODO: This could be an extension method of shape.
         public static bool HasDefaultName(Shape shape)
         {
-            var copy = shape.Duplicate()[1];
+            Shape copy = shape.Duplicate()[1];
             bool hasDefaultName = copy.Name != shape.Name;
             copy.Delete();
             return hasDefaultName;
@@ -441,7 +441,7 @@ namespace PowerPointLabs.Utils
                 return 1.0f;
             }
 
-            var isAspectRatioLocked = shape.LockAspectRatio;
+            MsoTriState isAspectRatioLocked = shape.LockAspectRatio;
             shape.LockAspectRatio = MsoTriState.msoFalse;
 
             float oldWidth = shape.Width;
@@ -461,7 +461,7 @@ namespace PowerPointLabs.Utils
                 return 1.0f;
             }
 
-            var isAspectRatioLocked = shape.LockAspectRatio;
+            MsoTriState isAspectRatioLocked = shape.LockAspectRatio;
             shape.LockAspectRatio = MsoTriState.msoFalse;
 
             float oldHeight = shape.Height;
@@ -746,14 +746,14 @@ namespace PowerPointLabs.Utils
 
         public static void MakeShapeViewTimeInvisible(Shape shape, Slide curSlide)
         {
-            var sequence = curSlide.TimeLine.MainSequence;
+            Sequence sequence = curSlide.TimeLine.MainSequence;
 
-            var effectAppear = sequence.AddEffect(shape, MsoAnimEffect.msoAnimEffectAppear,
+            Effect effectAppear = sequence.AddEffect(shape, MsoAnimEffect.msoAnimEffectAppear,
                                                   MsoAnimateByLevel.msoAnimateLevelNone,
                                                   MsoAnimTriggerType.msoAnimTriggerWithPrevious);
             effectAppear.Timing.Duration = 0;
 
-            var effectDisappear = sequence.AddEffect(shape, MsoAnimEffect.msoAnimEffectAppear,
+            Effect effectDisappear = sequence.AddEffect(shape, MsoAnimEffect.msoAnimEffectAppear,
                                                      MsoAnimateByLevel.msoAnimateLevelNone,
                                                      MsoAnimTriggerType.msoAnimTriggerWithPrevious);
             effectDisappear.Exit = MsoTriState.msoTrue;
@@ -842,16 +842,16 @@ namespace PowerPointLabs.Utils
                 refShape.HasTextFrame == MsoTriState.msoTrue &&
                 candidateShape.HasTextFrame == MsoTriState.msoTrue)
             {
-                var refTextRange = refShape.TextFrame2.TextRange;
-                var candidateTextRange = candidateShape.TextFrame2.TextRange;
+                TextRange2 refTextRange = refShape.TextFrame2.TextRange;
+                TextRange2 candidateTextRange = candidateShape.TextFrame2.TextRange;
 
                 if (pickupTextContent)
                 {
                     candidateTextRange.Text = refTextRange.Text;
                 }
 
-                var refParagraphCount = refShape.TextFrame2.TextRange.Paragraphs.Count;
-                var candidateParagraphCount = candidateShape.TextFrame2.TextRange.Paragraphs.Count;
+                int refParagraphCount = refShape.TextFrame2.TextRange.Paragraphs.Count;
+                int candidateParagraphCount = candidateShape.TextFrame2.TextRange.Paragraphs.Count;
 
                 if (refParagraphCount > 0)
                 {
@@ -860,10 +860,10 @@ namespace PowerPointLabs.Utils
                     candidateTextRange.Text = originalText;
                 }
 
-                for (var i = 1; i <= candidateParagraphCount; i++)
+                for (int i = 1; i <= candidateParagraphCount; i++)
                 {
-                    var refParagraph = refTextRange.Paragraphs[i <= refParagraphCount ? i : refParagraphCount];
-                    var candidateParagraph = candidateTextRange.Paragraphs[i];
+                    TextRange2 refParagraph = refTextRange.Paragraphs[i <= refParagraphCount ? i : refParagraphCount];
+                    TextRange2 candidateParagraph = candidateTextRange.Paragraphs[i];
 
                     SyncTextRange(refParagraph, candidateParagraph, pickupTextContent, pickupTextFormat);
                 }
@@ -878,10 +878,10 @@ namespace PowerPointLabs.Utils
                 return;
             }
 
-            foreach (var shape in candidateShapeRange)
+            foreach (object shape in candidateShapeRange)
             {
-                var candidateShape = shape as Shape;
-                var refShape = refShapeRange.Cast<Shape>().FirstOrDefault(item => IsSameType(item, candidateShape) &&
+                Shape candidateShape = shape as Shape;
+                Shape refShape = refShapeRange.Cast<Shape>().FirstOrDefault(item => IsSameType(item, candidateShape) &&
                                                                                   IsSamePosition(item, candidateShape,
                                                                                                  false, 15) &&
                                                                                   IsSameSize(item, candidateShape));
@@ -901,7 +901,7 @@ namespace PowerPointLabs.Utils
             bool originallyHadNewLine = candidateTextRange.Text.EndsWith("\r");
             bool lostTheNewLine = false;
 
-            var candidateText = candidateTextRange.Text.TrimEnd('\r');
+            string candidateText = candidateTextRange.Text.TrimEnd('\r');
 
             if (pickupTextFormat)
             {
@@ -972,14 +972,14 @@ namespace PowerPointLabs.Utils
 
         public static TextRange ConvertTextRange2ToTextRange(TextRange2 textRange2)
         {
-            var textFrame2 = textRange2.Parent as TextFrame2;
+            TextFrame2 textFrame2 = textRange2.Parent as TextFrame2;
 
             if (textFrame2 == null)
             {
                 return null;
             }
 
-            var shape = textFrame2.Parent as Shape;
+            Shape shape = textFrame2.Parent as Shape;
 
             return shape == null ? null : shape.TextFrame.TextRange;
         }
@@ -1003,7 +1003,7 @@ namespace PowerPointLabs.Utils
         private static void SyncShapeSize(Shape refShape, Shape candidateShape)
         {
             // unlock aspect ratio to enable size tweak
-            var candidateLockRatio = candidateShape.LockAspectRatio;
+            MsoTriState candidateLockRatio = candidateShape.LockAspectRatio;
 
             candidateShape.LockAspectRatio = MsoTriState.msoFalse;
 

--- a/PowerPointLabs/PowerPointLabs/Utils/SlideUtil.cs
+++ b/PowerPointLabs/PowerPointLabs/Utils/SlideUtil.cs
@@ -58,7 +58,7 @@ namespace PowerPointLabs.Utils
             ShapeRange previousShapes = null;
             EffectTransition slideTransition = new EffectTransition();
 
-            foreach (var slide in slides)
+            foreach (PowerPointSlide slide in slides)
             {
                 if (firstSlide == null)
                 {
@@ -72,7 +72,7 @@ namespace PowerPointLabs.Utils
                     continue;
                 }
 
-                var effectSequence = firstSlide.GetNativeSlide().TimeLine.MainSequence;
+                Sequence effectSequence = firstSlide.GetNativeSlide().TimeLine.MainSequence;
                 int effectStartIndex = effectSequence.Count + 1;
 
                 slide.DeleteIndicator();
@@ -118,7 +118,7 @@ namespace PowerPointLabs.Utils
 
         public static void CopyToDesign(string designName, PowerPointSlide refSlide)
         {
-            var design = GetDesign(designName);
+            Design design = GetDesign(designName);
             if (design == null)
             {
                 design = CreateDesign(designName);
@@ -139,7 +139,7 @@ namespace PowerPointLabs.Utils
         /// </summary>
         private static EffectTransition GetTransitionFromSlide(PowerPointSlide slide)
         {
-            var transition = slide.GetNativeSlide().SlideShowTransition;
+            SlideShowTransition transition = slide.GetNativeSlide().SlideShowTransition;
 
             if (transition.AdvanceOnTime == MsoTriState.msoTrue)
             {
@@ -155,7 +155,7 @@ namespace PowerPointLabs.Utils
                 return;
             }
 
-            var effectFade = inSlide.GetNativeSlide().TimeLine.MainSequence.AddEffect(shape, MsoAnimEffect.msoAnimEffectAppear,
+            Effect effectFade = inSlide.GetNativeSlide().TimeLine.MainSequence.AddEffect(shape, MsoAnimEffect.msoAnimEffectAppear,
                 MsoAnimateByLevel.msoAnimateLevelNone, MsoAnimTriggerType.msoAnimTriggerWithPrevious, effectStartIndex);
             effectFade.Exit = MsoTriState.msoFalse;
         }
@@ -167,7 +167,7 @@ namespace PowerPointLabs.Utils
                 return;
             }
 
-            var effectFade = inSlide.GetNativeSlide().TimeLine.MainSequence.AddEffect(shape, MsoAnimEffect.msoAnimEffectAppear,
+            Effect effectFade = inSlide.GetNativeSlide().TimeLine.MainSequence.AddEffect(shape, MsoAnimEffect.msoAnimEffectAppear,
                 MsoAnimateByLevel.msoAnimateLevelNone, MsoAnimTriggerType.msoAnimTriggerWithPrevious, effectStartIndex);
             effectFade.Exit = MsoTriState.msoTrue;
         }

--- a/PowerPointLabs/PowerPointLabs/Utils/StringUtil.cs
+++ b/PowerPointLabs/PowerPointLabs/Utils/StringUtil.cs
@@ -19,7 +19,7 @@ namespace PowerPointLabs.Utils
         public static string GetHexValue(Color color)
         {
             byte[] rgbArray = { color.R, color.G, color.B };
-            var hex = BitConverter.ToString(rgbArray);
+            string hex = BitConverter.ToString(rgbArray);
             return "#" + hex.Replace("-", "");
         }
 

--- a/PowerPointLabs/PowerPointLabs/Utils/TempPath.cs
+++ b/PowerPointLabs/PowerPointLabs/Utils/TempPath.cs
@@ -29,9 +29,9 @@ namespace PowerPointLabs.Utils
 
         public static void DeleteTempTestFolder()
         {
-            var tempFolder = _tempTestPath;
+            string tempFolder = _tempTestPath;
 
-            var tempFolderInfo = new DirectoryInfo(tempFolder);
+            DirectoryInfo tempFolderInfo = new DirectoryInfo(tempFolder);
 
             try
             {
@@ -47,12 +47,12 @@ namespace PowerPointLabs.Utils
         {
             rootFolder.Attributes = FileAttributes.Normal;
 
-            foreach (var subFolder in rootFolder.GetDirectories())
+            foreach (DirectoryInfo subFolder in rootFolder.GetDirectories())
             {
                 DeepDeleteFolder(subFolder);
             }
 
-            foreach (var file in rootFolder.GetFiles())
+            foreach (FileInfo file in rootFolder.GetFiles())
             {
                 file.IsReadOnly = false;
                 try

--- a/PowerPointLabs/PowerPointLabs/Views/CustomPaintTextBox.cs
+++ b/PowerPointLabs/PowerPointLabs/Views/CustomPaintTextBox.cs
@@ -49,7 +49,7 @@ namespace PowerPointLabs.Views
         private void CustomPaint()
         {
             _bufferGraphics.Clear(_parentTextBox.BackColor);
-            var labeledThumbnail = _parentTextBox.Parent.Parent as LabeledThumbnail;
+            LabeledThumbnail labeledThumbnail = _parentTextBox.Parent.Parent as LabeledThumbnail;
 
             if (labeledThumbnail == null)
             {

--- a/PowerPointLabs/PowerPointLabs/Views/FolderDialogLauncher.cs
+++ b/PowerPointLabs/PowerPointLabs/Views/FolderDialogLauncher.cs
@@ -37,7 +37,7 @@ namespace PowerPointLabs.Views
         {
             DialogResult result;
 
-            using (var timer = new Timer())
+            using (Timer timer = new Timer())
             {
                 timer.Tick += TimerTickHandler;
                 timer.Interval = 10;
@@ -52,7 +52,7 @@ namespace PowerPointLabs.Views
 
         private static void TimerTickHandler(object sender, EventArgs args)
         {
-            var timer = sender as Timer;
+            Timer timer = sender as Timer;
 
             if (timer == null)
             {
@@ -64,17 +64,17 @@ namespace PowerPointLabs.Views
                 // retry 10 times until the dialog handle is created since we have no
                 // means to override wndproc of FolderBrowswerDialog to find handle.
                 --_retries;
-                var hwndDlg = Native.FindWindow(null, TopLevelSearchString);
+                IntPtr hwndDlg = Native.FindWindow(null, TopLevelSearchString);
                 if (hwndDlg != IntPtr.Zero)
                 {
-                    var hwndFolderCtrl = Native.GetDlgItem(hwndDlg, DlgItemBrowseControl);
+                    IntPtr hwndFolderCtrl = Native.GetDlgItem(hwndDlg, DlgItemBrowseControl);
                     if (hwndFolderCtrl != IntPtr.Zero)
                     {
-                        var hwndTreeView = Native.GetDlgItem(hwndFolderCtrl, DlgItemTreeView);
+                        IntPtr hwndTreeView = Native.GetDlgItem(hwndFolderCtrl, DlgItemTreeView);
 
                         if (hwndTreeView != IntPtr.Zero)
                         {
-                            var item = Native.SendMessage(hwndTreeView, (uint)Native.Message.TVM_GETNEXTITEM,
+                            IntPtr item = Native.SendMessage(hwndTreeView, (uint)Native.Message.TVM_GETNEXTITEM,
                                                           new IntPtr((uint)Native.Message.TVGN_CARET),
                                                           IntPtr.Zero);
                             if (item != IntPtr.Zero)

--- a/PowerPointLabs/PowerPointLabs/WPF/ClickSelectTextBox.cs
+++ b/PowerPointLabs/PowerPointLabs/WPF/ClickSelectTextBox.cs
@@ -31,7 +31,7 @@ namespace PowerPointLabs.WPF
 
             if (parent != null)
             {
-                var textBox = (TextBox)parent;
+                TextBox textBox = (TextBox)parent;
                 if (!textBox.IsKeyboardFocusWithin)
                 {
                     // If the text box is not yet focussed, give it the focus and
@@ -44,7 +44,7 @@ namespace PowerPointLabs.WPF
 
         private static void SelectAllText(object sender, RoutedEventArgs e)
         {
-            var textBox = e.OriginalSource as TextBox;
+            TextBox textBox = e.OriginalSource as TextBox;
             if (textBox != null)
             {
                 textBox.SelectAll();

--- a/PowerPointLabs/PowerPointLabs/WPF/Observable/Model.cs
+++ b/PowerPointLabs/PowerPointLabs/WPF/Observable/Model.cs
@@ -9,7 +9,7 @@ namespace PowerPointLabs.WPF.Observable
 
         protected virtual void OnPropertyChanged(string propertyName)
         {
-            var handler = PropertyChanged;
+            PropertyChangedEventHandler handler = PropertyChanged;
             if (handler != null)
             {
                 handler(this, new PropertyChangedEventArgs(propertyName));

--- a/PowerPointLabs/PowerPointLabs/WPF/WindowSettings.cs
+++ b/PowerPointLabs/PowerPointLabs/WPF/WindowSettings.cs
@@ -94,12 +94,12 @@ namespace PowerPointLabs.WPF
         /// </summary>
         private static void OnSaveInvalidated(DependencyObject pDependencyObject, DependencyPropertyChangedEventArgs pDependencyPropertyChangedEventArgs)
         {
-            var window = pDependencyObject as Window;
+            Window window = pDependencyObject as Window;
             if (window != null)
             {
                 if ((bool)pDependencyPropertyChangedEventArgs.NewValue)
                 {
-                    var settings = new WindowSettings(window);
+                    WindowSettings settings = new WindowSettings(window);
                     settings.Attach();
                 }
             }

--- a/PowerPointLabs/PowerPointLabs/XMLMisc/Data/AudioGenSpeechData.cs
+++ b/PowerPointLabs/PowerPointLabs/XMLMisc/Data/AudioGenSpeechData.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace PowerPointLabs.XMLMisc.Data
+{
+    class AudioGenSpeechData
+    {
+        public string Name { get; set; }
+        public string AudioID { get; set; }
+    }
+}

--- a/PowerPointLabs/PowerPointLabs/XMLMisc/XMLParser.cs
+++ b/PowerPointLabs/PowerPointLabs/XMLMisc/XMLParser.cs
@@ -36,15 +36,15 @@ namespace PowerPointLabs.XMLMisc
 
         private void ParseRelation(string path)
         {
-            var doc = File.ReadAllText(path);
+            string doc = File.ReadAllText(path);
             const string relaitonFormat = "<\\w+\\s\\w+=\\\"(\\w+\\d+)\\\" \\w+=\\\"[\\w\\:\\/\\.]+audio\\\" \\w+=\\\"[\\w\\.\\/]+(media\\d+\\.wav)\\\"\\/>";
 
-            var regexRelation = new Regex(relaitonFormat);
-            var matches = regexRelation.Matches(doc);
+            Regex regexRelation = new Regex(relaitonFormat);
+            MatchCollection matches = regexRelation.Matches(doc);
 
             for (int i = 0; i < matches.Count; i++)
             {
-                var match = matches[i];
+                Match match = matches[i];
 
                 audioIDFileMapper[match.Groups[1].Value] = match.Groups[2].Value;
             }
@@ -52,12 +52,12 @@ namespace PowerPointLabs.XMLMisc
 
         private void ParseShape(string path)
         {
-            var doc = XDocument.Load(path);
+            XDocument doc = XDocument.Load(path);
 
-            foreach (var element in doc.Descendants(_p + "spTree"))
+            foreach (XElement element in doc.Descendants(_p + "spTree"))
             {
-                var audioShape = element.Elements(_p + "pic");
-                var pptSpeechFormat = new Regex("PowerPointLabs|AudioGen Speech \\d+");
+                IEnumerable<XElement> audioShape = element.Elements(_p + "pic");
+                Regex pptSpeechFormat = new Regex("PowerPointLabs|AudioGen Speech \\d+");
 
                 var data = from item in audioShape
                            where

--- a/PowerPointLabs/PowerPointLabs/XMLMisc/XMLParser.cs
+++ b/PowerPointLabs/PowerPointLabs/XMLMisc/XMLParser.cs
@@ -59,18 +59,18 @@ namespace PowerPointLabs.XMLMisc
                 IEnumerable<XElement> audioShape = element.Elements(_p + "pic");
                 Regex pptSpeechFormat = new Regex("PowerPointLabs|AudioGen Speech \\d+");
 
-                var data = from item in audioShape
+                IEnumerable<Data.AudioGenSpeechData> data = from item in audioShape
                            where
                                pptSpeechFormat.IsMatch(item.Element(_p + "nvPicPr").Element(_p + "cNvPr").Attribute("name").Value)
-                           select new
+                           select new Data.AudioGenSpeechData
                                       {
-                                          name = item.Element(_p + "nvPicPr").Element(_p + "cNvPr").Attribute("name").Value,
-                                          audioID = item.Element(_p + "nvPicPr").Element(_p + "nvPr").Element(_a + "audioFile").Attribute(_r + "link").Value
+                                          Name = item.Element(_p + "nvPicPr").Element(_p + "cNvPr").Attribute("name").Value,
+                                          AudioID = item.Element(_p + "nvPicPr").Element(_p + "nvPr").Element(_a + "audioFile").Attribute(_r + "link").Value
                                       };
 
-                foreach (var entry in data)
+                foreach (Data.AudioGenSpeechData entry in data)
                 {
-                    shapeFileMapper[entry.name] = audioIDFileMapper[entry.audioID];
+                    shapeFileMapper[entry.Name] = audioIDFileMapper[entry.AudioID];
                 }
             }
         }

--- a/PowerPointLabs/PowerPointLabs/ZoomLab/AutoZoom.cs
+++ b/PowerPointLabs/PowerPointLabs/ZoomLab/AutoZoom.cs
@@ -66,7 +66,7 @@ namespace PowerPointLabs.ZoomLab
                     addedSlide.DeleteShapeAnimations(shapeToZoom);
 
                     currentSlide.Copy();
-                    var backgroundShape = addedSlide.Shapes.PasteSpecial(PowerPoint.PpPasteDataType.ppPastePNG)[1];
+                    PowerPoint.Shape backgroundShape = addedSlide.Shapes.PasteSpecial(PowerPoint.PpPasteDataType.ppPastePNG)[1];
                     backgroundShape.Apply();
                     ShapeUtil.FitShapeToSlide(ref backgroundShape);
                     backgroundShape.ZOrder(Office.MsoZOrderCmd.msoSendBackward);
@@ -90,7 +90,7 @@ namespace PowerPointLabs.ZoomLab
                     addedSlide.DeleteShapeAnimations(shapeToZoom);
 
                     currentSlide.Copy();
-                    var backgroundShape = addedSlide.Shapes.PasteSpecial(PowerPoint.PpPasteDataType.ppPastePNG)[1];
+                    PowerPoint.Shape backgroundShape = addedSlide.Shapes.PasteSpecial(PowerPoint.PpPasteDataType.ppPastePNG)[1];
                     backgroundShape.Apply();
                     ShapeUtil.FitShapeToSlide(ref backgroundShape);
                     backgroundShape.ZOrder(Office.MsoZOrderCmd.msoSendBackward);
@@ -273,11 +273,11 @@ namespace PowerPointLabs.ZoomLab
                 }
             }
 
-            var copiedShapes = new List<PowerPoint.Shape>();
+            List<PowerPoint.Shape> copiedShapes = new List<PowerPoint.Shape>();
             foreach (PowerPoint.Shape sh in shapesOnNextSlide)
             {
                 sh.Copy();
-                var shapeCopy = nextSlide.Shapes.Paste()[1];
+                PowerPoint.Shape shapeCopy = nextSlide.Shapes.Paste()[1];
                 LegacyShapeUtil.CopyShapeAttributes(sh, ref shapeCopy);
                 copiedShapes.Add(shapeCopy);
             }
@@ -309,7 +309,7 @@ namespace PowerPointLabs.ZoomLab
         {
             PowerPointSlide nextSlideCopy = nextSlide.Duplicate();
             List<PowerPoint.Shape> shapes = nextSlideCopy.Shapes.Cast<PowerPoint.Shape>().ToList();
-            var matchingShapes = shapes.Where(current => nextSlideCopy.HasEntryAnimation(current));
+            IEnumerable<PowerPoint.Shape> matchingShapes = shapes.Where(current => nextSlideCopy.HasEntryAnimation(current));
             foreach (PowerPoint.Shape s in matchingShapes)
             {
                 s.Delete();
@@ -326,7 +326,7 @@ namespace PowerPointLabs.ZoomLab
         {
             PowerPointSlide previousSlideCopy = previousSlide.Duplicate();
             List<PowerPoint.Shape> shapes = previousSlideCopy.Shapes.Cast<PowerPoint.Shape>().ToList();
-            var matchingShapes = shapes.Where(current => previousSlideCopy.HasExitAnimation(current));
+            IEnumerable<PowerPoint.Shape> matchingShapes = shapes.Where(current => previousSlideCopy.HasExitAnimation(current));
             foreach (PowerPoint.Shape s in matchingShapes)
             {
                 s.Delete();
@@ -381,7 +381,7 @@ namespace PowerPointLabs.ZoomLab
 
         private static bool IsSelectingShapes()
         {
-            var selection = Globals.ThisAddIn.Application.ActiveWindow.Selection;
+            PowerPoint.Selection selection = Globals.ThisAddIn.Application.ActiveWindow.Selection;
             return selection.Type == PowerPoint.PpSelectionType.ppSelectionShapes && selection.ShapeRange.Count > 0;
         }
 
@@ -420,7 +420,7 @@ namespace PowerPointLabs.ZoomLab
             Globals.ThisAddIn.Application.ActiveWindow.Selection.Unselect();
             Globals.ThisAddIn.Application.ActiveWindow.View.GotoSlide(addedSlide.Index);
 
-            var copiedShapes = new List<PowerPoint.Shape>();
+            List<PowerPoint.Shape> copiedShapes = new List<PowerPoint.Shape>();
             foreach (PowerPoint.Shape sh in previousSlide.Shapes)
             {
                 if (!previousSlide.HasExitAnimation(sh) && !ShapeUtil.IsHidden(sh))

--- a/PowerPointLabs/PowerPointLabs/ZoomLab/ZoomToArea.cs
+++ b/PowerPointLabs/PowerPointLabs/ZoomLab/ZoomToArea.cs
@@ -23,17 +23,17 @@ namespace PowerPointLabs.ZoomLab
 
             try
             {
-                var currentSlide = PowerPointCurrentPresentationInfo.CurrentSlide;
+                PowerPointSlide currentSlide = PowerPointCurrentPresentationInfo.CurrentSlide;
                 DeleteExistingZoomToAreaSlides(currentSlide);
                 currentSlide.Name = "PPTLabsZoomToAreaSlide" + DateTime.Now.ToString("yyyyMMddHHmmssffff");
 
-                var selectedShapes = Globals.ThisAddIn.Application.ActiveWindow.Selection.ShapeRange;
-                var zoomRectangles = ReplaceWithZoomRectangleImages(currentSlide, selectedShapes);
+                PowerPoint.ShapeRange selectedShapes = Globals.ThisAddIn.Application.ActiveWindow.Selection.ShapeRange;
+                List<PowerPoint.Shape> zoomRectangles = ReplaceWithZoomRectangleImages(currentSlide, selectedShapes);
 
                 MakeInvisible(zoomRectangles);
                 List<PowerPoint.Shape> editedSelectedShapes = GetEditedShapesForZoomToArea(currentSlide, zoomRectangles);
 
-                var addedSlides = AddMultiSlideZoomToArea(currentSlide, editedSelectedShapes);
+                List<PowerPointSlide> addedSlides = AddMultiSlideZoomToArea(currentSlide, editedSelectedShapes);
                 if (!ZoomLabSettings.MultiSlideZoomChecked)
                 {
                     SlideUtil.SquashSlides(addedSlides);
@@ -58,7 +58,7 @@ namespace PowerPointLabs.ZoomLab
 
         private static List<PowerPointSlide> AddMultiSlideZoomToArea(PowerPointSlide currentSlide, List<PowerPoint.Shape> shapesToZoom)
         {
-            var addedSlides = new List<PowerPointSlide>();
+            List<PowerPointSlide> addedSlides = new List<PowerPointSlide>();
 
             int shapeCount = 1;
             PowerPointSlide lastMagnifiedSlide = null;
@@ -119,11 +119,11 @@ namespace PowerPointLabs.ZoomLab
 
         private static List<PowerPoint.Shape> ReplaceWithZoomRectangleImages(PowerPointSlide currentSlide, PowerPoint.ShapeRange shapeRange)
         {
-            var zoomRectangles = new List<PowerPoint.Shape>();
+            List<PowerPoint.Shape> zoomRectangles = new List<PowerPoint.Shape>();
             int shapeCount = 1;
             foreach (PowerPoint.Shape zoomShape in shapeRange)
             {
-                var zoomRectangle = currentSlide.Shapes.AddShape(Office.MsoAutoShapeType.msoShapeRectangle,
+                PowerPoint.Shape zoomRectangle = currentSlide.Shapes.AddShape(Office.MsoAutoShapeType.msoShapeRectangle,
                                                                 zoomShape.Left,
                                                                 zoomShape.Top,
                                                                 zoomShape.Width,
@@ -211,7 +211,7 @@ namespace PowerPointLabs.ZoomLab
 
         private static void MakeInvisible(IEnumerable<PowerPoint.Shape> zoomRectangles)
         {
-            foreach (var sh in zoomRectangles)
+            foreach (PowerPoint.Shape sh in zoomRectangles)
             {
                 sh.Visible = Office.MsoTriState.msoFalse;
             }
@@ -219,7 +219,7 @@ namespace PowerPointLabs.ZoomLab
 
         private static void MakeVisible(IEnumerable<PowerPoint.Shape> zoomRectangles)
         {
-            foreach (var sh in zoomRectangles)
+            foreach (PowerPoint.Shape sh in zoomRectangles)
             {
                 sh.Visible = Office.MsoTriState.msoTrue;
             }
@@ -227,7 +227,7 @@ namespace PowerPointLabs.ZoomLab
 
         private static bool IsSelectingShapes()
         {
-            var selection = Globals.ThisAddIn.Application.ActiveWindow.Selection;
+            PowerPoint.Selection selection = Globals.ThisAddIn.Application.ActiveWindow.Selection;
             return selection.Type == PowerPoint.PpSelectionType.ppSelectionShapes && selection.ShapeRange.Count > 0;
         }
 

--- a/PowerPointLabs/Test/FunctionalTest/AgendaLabBeamSyncTest.cs
+++ b/PowerPointLabs/Test/FunctionalTest/AgendaLabBeamSyncTest.cs
@@ -1,5 +1,8 @@
 ﻿using System;
+using System.Collections.Generic;
+
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+
 using Test.Util;
 
 namespace Test.FunctionalTest
@@ -50,8 +53,8 @@ namespace Test.FunctionalTest
             PpOperations.SelectSlide(8);
             PplFeatures.SynchronizeAgenda();
 
-            var actualSlides = PpOperations.FetchCurrentPresentationData();
-            var expectedSlides = PpOperations.FetchPresentationData(
+            List<TestInterface.ISlideData> actualSlides = PpOperations.FetchCurrentPresentationData();
+            List<TestInterface.ISlideData> expectedSlides = PpOperations.FetchPresentationData(
                 PathUtil.GetDocTestPresentationPath("AgendaLab\\AgendaSlidesBeamAfterSync.pptx"));
             PresentationUtil.AssertEqual(expectedSlides, actualSlides);
         }
@@ -59,7 +62,7 @@ namespace Test.FunctionalTest
         public void NoHighlightedTextUnsuccessful()
         {
             PpOperations.SelectSlide(1);
-            var highlightedText = PpOperations.RecursiveGetShapeWithPrefix("PptLabsAgenda_&^@BeamShapeMainGroup",              
+            Microsoft.Office.Interop.PowerPoint.Shape highlightedText = PpOperations.RecursiveGetShapeWithPrefix("PptLabsAgenda_&^@BeamShapeMainGroup",              
                                                                            "PptLabsAgenda_&^@BeamShapeHighlightedText");
             highlightedText.Delete();
 
@@ -72,7 +75,7 @@ namespace Test.FunctionalTest
         public void NoBeamUnsuccessful()
         {
             PpOperations.SelectSlide(1);
-            var beamShape = PpOperations.SelectShapesByPrefix("PptLabsAgenda_&^@BeamShapeMainGroup")[1];
+            Microsoft.Office.Interop.PowerPoint.Shape beamShape = PpOperations.SelectShapesByPrefix("PptLabsAgenda_&^@BeamShapeMainGroup")[1];
             beamShape.Delete();
 
             MessageBoxUtil.ExpectMessageBoxWillPopUp(
@@ -83,7 +86,7 @@ namespace Test.FunctionalTest
 
         public void NoRefSlideUnsuccessful()
         {
-            var refSlide = PpOperations.SelectSlide(1);
+            Microsoft.Office.Interop.PowerPoint.Slide refSlide = PpOperations.SelectSlide(1);
             refSlide.Delete();
 
             MessageBoxUtil.ExpectMessageBoxWillPopUp(
@@ -97,7 +100,7 @@ namespace Test.FunctionalTest
             PpOperations.SelectSlide(1);
             for (int i = 0; i < 5; ++i)
             {
-                var beamText = PpOperations.RecursiveGetShapeWithPrefix("PptLabsAgenda_&^@BeamShapeMainGroup",
+                Microsoft.Office.Interop.PowerPoint.Shape beamText = PpOperations.RecursiveGetShapeWithPrefix("PptLabsAgenda_&^@BeamShapeMainGroup",
                     "PptLabsAgenda_&^@BeamShapeText");
                 beamText.Delete();
             }
@@ -122,12 +125,12 @@ namespace Test.FunctionalTest
         // When unfocused, only sync (so selectedSlide (doesn't have agenda) remains the same).
         private static void ClickOnSlideThumbnailsPanel()
         {
-            var pptPanel = NativeUtil.FindWindow("PPTFrameClass", null);
-            var mdiPanel = NativeUtil.FindWindowEx(pptPanel, IntPtr.Zero, "MDIClient", null);
-            var mdiPanel2 = NativeUtil.FindWindowEx(mdiPanel, IntPtr.Zero, "mdiClass", null);
+            IntPtr pptPanel = NativeUtil.FindWindow("PPTFrameClass", null);
+            IntPtr mdiPanel = NativeUtil.FindWindowEx(pptPanel, IntPtr.Zero, "MDIClient", null);
+            IntPtr mdiPanel2 = NativeUtil.FindWindowEx(mdiPanel, IntPtr.Zero, "mdiClass", null);
             if (PpOperations.IsOffice2010())
             {
-                var thumbnailsPanel = NativeUtil.FindWindowEx(mdiPanel2, IntPtr.Zero, "paneClassDC", "Thumbnails");
+                IntPtr thumbnailsPanel = NativeUtil.FindWindowEx(mdiPanel2, IntPtr.Zero, "paneClassDC", "Thumbnails");
                 NativeUtil.SendMessage(thumbnailsPanel, 0x0201 /*left button down*/, IntPtr.Zero, IntPtr.Zero);
             } 
             else // Office2013 or Higher

--- a/PowerPointLabs/Test/FunctionalTest/AgendaLabGenerateTest.cs
+++ b/PowerPointLabs/Test/FunctionalTest/AgendaLabGenerateTest.cs
@@ -47,8 +47,8 @@ namespace Test.FunctionalTest
             MessageBoxUtil.ExpectMessageBoxWillPopUp(AgendaExistsTitle, AgendaExistsContent,
                 PplFeatures.GenerateVisualAgenda, buttonNameToClick: "OK");
 
-            var actualSlides = PpOperations.FetchCurrentPresentationData();
-            var expectedSlides = PpOperations.FetchPresentationData(
+            System.Collections.Generic.List<TestInterface.ISlideData> actualSlides = PpOperations.FetchCurrentPresentationData();
+            System.Collections.Generic.List<TestInterface.ISlideData> expectedSlides = PpOperations.FetchPresentationData(
                 PathUtil.GetDocTestPresentationPath("AgendaLab\\AgendaSlidesVisualDefault.pptx"));
             PresentationUtil.AssertEqual(expectedSlides, actualSlides);
         }
@@ -59,8 +59,8 @@ namespace Test.FunctionalTest
             MessageBoxUtil.ExpectMessageBoxWillPopUp(AgendaExistsTitle, AgendaExistsContent,
                 PplFeatures.GenerateBeamAgenda, buttonNameToClick: "OK");
 
-            var actualSlides = PpOperations.FetchCurrentPresentationData();
-            var expectedSlides = PpOperations.FetchPresentationData(
+            System.Collections.Generic.List<TestInterface.ISlideData> actualSlides = PpOperations.FetchCurrentPresentationData();
+            System.Collections.Generic.List<TestInterface.ISlideData> expectedSlides = PpOperations.FetchPresentationData(
                 PathUtil.GetDocTestPresentationPath("AgendaLab\\AgendaSlidesBeamDefault.pptx"));
             PresentationUtil.AssertEqual(expectedSlides, actualSlides);
         }
@@ -69,8 +69,8 @@ namespace Test.FunctionalTest
         {
             PplFeatures.GenerateTextAgenda();
 
-            var actualSlides = PpOperations.FetchCurrentPresentationData();
-            var expectedSlides = PpOperations.FetchPresentationData(
+            System.Collections.Generic.List<TestInterface.ISlideData> actualSlides = PpOperations.FetchCurrentPresentationData();
+            System.Collections.Generic.List<TestInterface.ISlideData> expectedSlides = PpOperations.FetchPresentationData(
                 PathUtil.GetDocTestPresentationPath("AgendaLab\\AgendaSlidesTextDefault.pptx"));
             PresentationUtil.AssertEqual(expectedSlides, actualSlides);
         }
@@ -79,8 +79,8 @@ namespace Test.FunctionalTest
         {
             PplFeatures.RemoveAgenda();
 
-            var actualSlides = PpOperations.FetchCurrentPresentationData();
-            var expectedSlides = PpOperations.FetchPresentationData(
+            System.Collections.Generic.List<TestInterface.ISlideData> actualSlides = PpOperations.FetchCurrentPresentationData();
+            System.Collections.Generic.List<TestInterface.ISlideData> expectedSlides = PpOperations.FetchPresentationData(
                 PathUtil.GetDocTestPresentationPath("AgendaLab\\AgendaSlidesDefault.pptx"));
             PresentationUtil.AssertEqual(expectedSlides, actualSlides);
         }
@@ -96,11 +96,11 @@ namespace Test.FunctionalTest
 
         public void EmptySectionUnsuccessful(bool isTestingSynchronize)
         {
-            var slide = PpOperations.SelectSlide(27);
+            Microsoft.Office.Interop.PowerPoint.Slide slide = PpOperations.SelectSlide(27);
             slide.Delete();
 
-            var title = "Unable to execute action";
-            var message = "Presentation contains empty section(s). Please fill them up or remove them.";
+            string title = "Unable to execute action";
+            string message = "Presentation contains empty section(s). Please fill them up or remove them.";
 
             if (isTestingSynchronize)
             {
@@ -123,8 +123,8 @@ namespace Test.FunctionalTest
             string longName = new string('x', 200);
             PpOperations.RenameSection(2, longName);
 
-            var title = "Unable to execute action";
-            var message = "One of the section names exceeds the maximum size allowed by Agenda Lab. Please rename the section accordingly.";
+            string title = "Unable to execute action";
+            string message = "One of the section names exceeds the maximum size allowed by Agenda Lab. Please rename the section accordingly.";
 
             if (isTestingSynchronize)
             {
@@ -147,8 +147,8 @@ namespace Test.FunctionalTest
             PpOperations.DeleteSection(3, false);
             PpOperations.DeleteSection(2, false);
 
-            var title = "Unable to execute action";
-            var message = "Please divide the slides into two or more sections.";
+            string title = "Unable to execute action";
+            string message = "Please divide the slides into two or more sections.";
 
             if (isTestingSynchronize)
             {
@@ -166,8 +166,8 @@ namespace Test.FunctionalTest
         {
             PpOperations.DeleteSection(1, false);
 
-            var title = "Unable to execute action";
-            var message = "Please group the slides into sections before generating agenda.";
+            string title = "Unable to execute action";
+            string message = "Please group the slides into sections before generating agenda.";
 
             if (isTestingSynchronize)
             {

--- a/PowerPointLabs/Test/FunctionalTest/AgendaLabTextSyncTest.cs
+++ b/PowerPointLabs/Test/FunctionalTest/AgendaLabTextSyncTest.cs
@@ -27,14 +27,14 @@ namespace Test.FunctionalTest
             PplFeatures.SynchronizeAgenda();
 
             // Duplicate template slide and delete original template slide. It should use the duplicate as the new template slide.
-            var firstSlide = PpOperations.SelectSlide(1);
+            Microsoft.Office.Interop.PowerPoint.Slide firstSlide = PpOperations.SelectSlide(1);
 
             PpOperations.SelectShape("PptLabsAgenda_&^@ContentShape_&^@2015061916283877850").TextFrame2.TextRange.Paragraphs[3].Text = " ";
 
             PplFeatures.SynchronizeAgenda();
 
-            var actualSlides = PpOperations.FetchCurrentPresentationData();
-            var expectedSlides = PpOperations.FetchPresentationData(
+            System.Collections.Generic.List<TestInterface.ISlideData> actualSlides = PpOperations.FetchCurrentPresentationData();
+            System.Collections.Generic.List<TestInterface.ISlideData> expectedSlides = PpOperations.FetchPresentationData(
                 PathUtil.GetDocTestPresentationPath("AgendaLab\\AgendaSlidesTextAfterSyncHideUnvisited.pptx"));
             PresentationUtil.AssertEqual(expectedSlides, actualSlides);
 
@@ -55,15 +55,15 @@ namespace Test.FunctionalTest
             PplFeatures.SynchronizeAgenda();
 
             // Duplicate template slide and delete original template slide. It should use the duplicate as the new template slide.
-            var firstSlide = PpOperations.SelectSlide(1);
+            Microsoft.Office.Interop.PowerPoint.Slide firstSlide = PpOperations.SelectSlide(1);
             PpOperations.SelectShape("PPTTemplateMarker").Delete();
             firstSlide.Duplicate();
             firstSlide.Delete();
 
             PplFeatures.SynchronizeAgenda();
 
-            var actualSlides = PpOperations.FetchCurrentPresentationData();
-            var expectedSlides = PpOperations.FetchPresentationData(
+            System.Collections.Generic.List<TestInterface.ISlideData> actualSlides = PpOperations.FetchCurrentPresentationData();
+            System.Collections.Generic.List<TestInterface.ISlideData> expectedSlides = PpOperations.FetchPresentationData(
                 PathUtil.GetDocTestPresentationPath("AgendaLab\\AgendaSlidesTextAfterSync.pptx"));
             PresentationUtil.AssertEqual(expectedSlides, actualSlides);
         }
@@ -72,7 +72,7 @@ namespace Test.FunctionalTest
         public void NoContentShapeUnsuccessful()
         {
             PpOperations.SelectSlide(1);
-            var contentShape = PpOperations.SelectShapesByPrefix("PptLabsAgenda_&^@ContentShape")[1];
+            Microsoft.Office.Interop.PowerPoint.Shape contentShape = PpOperations.SelectShapesByPrefix("PptLabsAgenda_&^@ContentShape")[1];
             contentShape.Delete();
 
             MessageBoxUtil.ExpectMessageBoxWillPopUp(
@@ -83,7 +83,7 @@ namespace Test.FunctionalTest
 
         public void NoRefSlideUnsuccessful()
         {
-            var refSlide = PpOperations.SelectSlide(1);
+            Microsoft.Office.Interop.PowerPoint.Slide refSlide = PpOperations.SelectSlide(1);
             refSlide.Delete();
 
             MessageBoxUtil.ExpectMessageBoxWillPopUp(

--- a/PowerPointLabs/Test/FunctionalTest/AgendaLabVisualSyncTest.cs
+++ b/PowerPointLabs/Test/FunctionalTest/AgendaLabVisualSyncTest.cs
@@ -21,8 +21,8 @@ namespace Test.FunctionalTest
         public void VisualSyncSuccessful()
         {
             PplFeatures.SynchronizeAgenda();
-            var actualSlides = PpOperations.FetchCurrentPresentationData();
-            var expectedSlides = PpOperations.FetchPresentationData(
+            System.Collections.Generic.List<TestInterface.ISlideData> actualSlides = PpOperations.FetchCurrentPresentationData();
+            System.Collections.Generic.List<TestInterface.ISlideData> expectedSlides = PpOperations.FetchPresentationData(
                 PathUtil.GetDocTestPresentationPath("AgendaLab\\AgendaSlidesVisualAfterSync.pptx"));
             PresentationUtil.AssertEqual(expectedSlides, actualSlides);
         }

--- a/PowerPointLabs/Test/FunctionalTest/AgendaLabWithSlideNumberGenerateTest.cs
+++ b/PowerPointLabs/Test/FunctionalTest/AgendaLabWithSlideNumberGenerateTest.cs
@@ -30,8 +30,8 @@ namespace Test.FunctionalTest
             PpOperations.ShowAllSlideNumbers();
             PplFeatures.GenerateTextAgenda();
 
-            var actualSlides = PpOperations.FetchCurrentPresentationData();
-            var expectedSlides = PpOperations.FetchPresentationData(
+            System.Collections.Generic.List<TestInterface.ISlideData> actualSlides = PpOperations.FetchCurrentPresentationData();
+            System.Collections.Generic.List<TestInterface.ISlideData> expectedSlides = PpOperations.FetchPresentationData(
                 PathUtil.GetDocTestPresentationPath("AgendaLab\\AgendaSlidesTextWithSlideNumberDefault.pptx"));
             PresentationUtil.AssertEqual(expectedSlides, actualSlides);
         }
@@ -43,8 +43,8 @@ namespace Test.FunctionalTest
             MessageBoxUtil.ExpectMessageBoxWillPopUp(AgendaExistsTitle, AgendaExistsContent,
                 PplFeatures.GenerateBeamAgenda, buttonNameToClick: "OK");
 
-            var actualSlides = PpOperations.FetchCurrentPresentationData();
-            var expectedSlides = PpOperations.FetchPresentationData(
+            System.Collections.Generic.List<TestInterface.ISlideData> actualSlides = PpOperations.FetchCurrentPresentationData();
+            System.Collections.Generic.List<TestInterface.ISlideData> expectedSlides = PpOperations.FetchPresentationData(
                 PathUtil.GetDocTestPresentationPath("AgendaLab\\AgendaSlidesBeamWithSlideNumberDefault.pptx"));
             PresentationUtil.AssertEqual(expectedSlides, actualSlides);
         }
@@ -55,8 +55,8 @@ namespace Test.FunctionalTest
             MessageBoxUtil.ExpectMessageBoxWillPopUp(AgendaExistsTitle, AgendaExistsContent,
                 PplFeatures.GenerateVisualAgenda, buttonNameToClick: "OK");
 
-            var actualSlides = PpOperations.FetchCurrentPresentationData();
-            var expectedSlides = PpOperations.FetchPresentationData(
+            System.Collections.Generic.List<TestInterface.ISlideData> actualSlides = PpOperations.FetchCurrentPresentationData();
+            System.Collections.Generic.List<TestInterface.ISlideData> expectedSlides = PpOperations.FetchPresentationData(
                 PathUtil.GetDocTestPresentationPath("AgendaLab\\AgendaSlidesVisualWithSlideNumberDefault.pptx"));
             PresentationUtil.AssertEqual(expectedSlides, actualSlides);
         }

--- a/PowerPointLabs/Test/FunctionalTest/AnimateInSlideTest.cs
+++ b/PowerPointLabs/Test/FunctionalTest/AnimateInSlideTest.cs
@@ -21,8 +21,8 @@ namespace Test.FunctionalTest
 
             PplFeatures.AnimateInSlide();
 
-            var actualSlide = PpOperations.SelectSlide(4);
-            var expSlide = PpOperations.SelectSlide(5);
+            Microsoft.Office.Interop.PowerPoint.Slide actualSlide = PpOperations.SelectSlide(4);
+            Microsoft.Office.Interop.PowerPoint.Slide expSlide = PpOperations.SelectSlide(5);
 
             // remove text "Expected"
             PpOperations.SelectShape("text 3")[1].Delete();
@@ -41,8 +41,8 @@ namespace Test.FunctionalTest
 
             PplFeatures.AnimateInSlide();
 
-            var actualSlide = PpOperations.SelectSlide(21);
-            var expSlide = PpOperations.SelectSlide(22);
+            Microsoft.Office.Interop.PowerPoint.Slide actualSlide = PpOperations.SelectSlide(21);
+            Microsoft.Office.Interop.PowerPoint.Slide expSlide = PpOperations.SelectSlide(22);
 
             // remove text "Expected"
             PpOperations.SelectShape("Text Label Expected Output")[1].Delete();
@@ -63,8 +63,8 @@ namespace Test.FunctionalTest
             PpOperations.SelectShapes(new List<string> { "Bolt 1a", "Bolt 1b" });
             PplFeatures.AnimateInSlide();
 
-            var actualSlide = PpOperations.SelectSlide(10);
-            var expSlide = PpOperations.SelectSlide(11);
+            Microsoft.Office.Interop.PowerPoint.Slide actualSlide = PpOperations.SelectSlide(10);
+            Microsoft.Office.Interop.PowerPoint.Slide expSlide = PpOperations.SelectSlide(11);
 
             // remove text "Expected"
             PpOperations.SelectShape("text 3")[1].Delete();

--- a/PowerPointLabs/Test/FunctionalTest/AutoAnimateTest.cs
+++ b/PowerPointLabs/Test/FunctionalTest/AutoAnimateTest.cs
@@ -41,11 +41,11 @@ namespace Test.FunctionalTest
 
             PplFeatures.AutoAnimate();
 
-            var actualSlide = PpOperations.SelectSlide(5);
+            Microsoft.Office.Interop.PowerPoint.Slide actualSlide = PpOperations.SelectSlide(5);
             // remove elements that affect comparing slides
             PpOperations.SelectShapesByPrefix("text").Delete();
 
-            var expSlide = PpOperations.SelectSlide(7);
+            Microsoft.Office.Interop.PowerPoint.Slide expSlide = PpOperations.SelectSlide(7);
             // remove elements that affect comparing slides
             PpOperations.SelectShapesByPrefix("text").Delete();
 
@@ -64,9 +64,9 @@ namespace Test.FunctionalTest
 
             Assert.IsNotNull(PpOperations.SelectShape("Notched Right Arrow"), 
                 "Copy-Paste failed, this task is flaky so please re-run.");
-            var sh1 = PpOperations.SelectShape("Notched Right Arrow")[1];
+            Shape sh1 = PpOperations.SelectShape("Notched Right Arrow")[1];
             sh1.Rotation += 90;
-            var sh2 = PpOperations.SelectShape("Group")[1];
+            Shape sh2 = PpOperations.SelectShape("Group")[1];
             sh2.Rotation += 90;
 
             // go back to slide 8
@@ -74,11 +74,11 @@ namespace Test.FunctionalTest
 
             PplFeatures.AutoAnimate();
 
-            var actualSlide = PpOperations.SelectSlide(9);
+            Slide actualSlide = PpOperations.SelectSlide(9);
             // remove elements that affect comparing slides
             PpOperations.SelectShapesByPrefix("text").Delete();
 
-            var expSlide = PpOperations.SelectSlide(11);
+            Slide expSlide = PpOperations.SelectSlide(11);
             // remove elements that affect comparing slides
             PpOperations.SelectShapesByPrefix("text").Delete();
 
@@ -93,11 +93,11 @@ namespace Test.FunctionalTest
 
             PplFeatures.AutoAnimate();
 
-            var actualSlide = PpOperations.SelectSlide(39);
+            Slide actualSlide = PpOperations.SelectSlide(39);
             // remove elements that affect comparing slides
             PpOperations.SelectShape("Text Label Initial Slide")[1].Delete();
 
-            var expSlide = PpOperations.SelectSlide(41);
+            Slide expSlide = PpOperations.SelectSlide(41);
             // remove elements that affect comparing slides
             PpOperations.SelectShape("Text Label Expected Output")[1].Delete();
 
@@ -107,8 +107,8 @@ namespace Test.FunctionalTest
 
         private void AssertIsSame(int actualSlideIndex, int expectedSlideIndex)
         {
-            var actualSlide = PpOperations.SelectSlide(actualSlideIndex);
-            var expectedSlide = PpOperations.SelectSlide(expectedSlideIndex);
+            Slide actualSlide = PpOperations.SelectSlide(actualSlideIndex);
+            Slide expectedSlide = PpOperations.SelectSlide(expectedSlideIndex);
             SlideUtil.IsSameLooking(expectedSlide, actualSlide);
             SlideUtil.IsSameAnimations(expectedSlide, actualSlide);
         }

--- a/PowerPointLabs/Test/FunctionalTest/AutoCaptionsTest.cs
+++ b/PowerPointLabs/Test/FunctionalTest/AutoCaptionsTest.cs
@@ -18,12 +18,12 @@ namespace Test.FunctionalTest
         [TestCategory("FT")]
         public void FT_AutoCaptionsTest()
         {
-            var actualSlide = PpOperations.SelectSlide(4);
+            Microsoft.Office.Interop.PowerPoint.Slide actualSlide = PpOperations.SelectSlide(4);
             ThreadUtil.WaitFor(1000);
 
             PplFeatures.AutoCaptions();
 
-            var expSlide = PpOperations.SelectSlide(5);
+            Microsoft.Office.Interop.PowerPoint.Slide expSlide = PpOperations.SelectSlide(5);
             PpOperations.SelectShape("text 3").Delete();
 
             SlideUtil.IsSameAnimations(expSlide, actualSlide);
@@ -34,7 +34,7 @@ namespace Test.FunctionalTest
         [TestCategory("FT")]
         public void FT_CaptionsMessageOneEmptySlide()
         {
-            var actualSlide = PpOperations.SelectSlide(6);
+            Microsoft.Office.Interop.PowerPoint.Slide actualSlide = PpOperations.SelectSlide(6);
             ThreadUtil.WaitFor(1000);
 
             MessageBoxUtil.ExpectMessageBoxWillPopUp(

--- a/PowerPointLabs/Test/FunctionalTest/AutoCropTest.cs
+++ b/PowerPointLabs/Test/FunctionalTest/AutoCropTest.cs
@@ -33,19 +33,19 @@ namespace Test.FunctionalTest
 
         public void CropOneShapeSuccessfully()
         {
-            var actualSlide = PpOperations.SelectSlide(4);
+            Microsoft.Office.Interop.PowerPoint.Slide actualSlide = PpOperations.SelectSlide(4);
             PpOperations.SelectShape("selectMe");
 
             // Execute the Crop To Shape feature
             PplFeatures.AutoCrop();
 
-            var resultShape = PpOperations.SelectShapesByPrefix("selectMe")[1];
-            var resultShapeInPic = PpOperations.ExportSelectedShapes();
+            Microsoft.Office.Interop.PowerPoint.Shape resultShape = PpOperations.SelectShapesByPrefix("selectMe")[1];
+            System.IO.FileInfo resultShapeInPic = PpOperations.ExportSelectedShapes();
 
-            var expSlide = PpOperations.SelectSlide(5);
+            Microsoft.Office.Interop.PowerPoint.Slide expSlide = PpOperations.SelectSlide(5);
 
-            var expShape = PpOperations.SelectShapesByPrefix("selectMe")[1];
-            var expShapeInPic = PpOperations.ExportSelectedShapes();
+            Microsoft.Office.Interop.PowerPoint.Shape expShape = PpOperations.SelectShapesByPrefix("selectMe")[1];
+            System.IO.FileInfo expShapeInPic = PpOperations.ExportSelectedShapes();
 
             // remove elements that affect comparing slides
             // e.g. "Expected" textbox
@@ -57,8 +57,8 @@ namespace Test.FunctionalTest
 
         public void CropMultipleShapesSuccessfully()
         {
-            var actualSlide = PpOperations.SelectSlide(7);
-            var shapesBeforeCrop = PpOperations.SelectShapesByPrefix("selectMe");
+            Microsoft.Office.Interop.PowerPoint.Slide actualSlide = PpOperations.SelectSlide(7);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange shapesBeforeCrop = PpOperations.SelectShapesByPrefix("selectMe");
             Assert.AreEqual(6, shapesBeforeCrop.Count);
 
             // Execute the Crop To Shape feature
@@ -66,13 +66,13 @@ namespace Test.FunctionalTest
 
             // the result shape after crop multiple shapes will have name starts with
             // Group
-            var resultShape = PpOperations.SelectShapesByPrefix("Group")[1];
-            var resultShapeInPic = PpOperations.ExportSelectedShapes();
+            Microsoft.Office.Interop.PowerPoint.Shape resultShape = PpOperations.SelectShapesByPrefix("Group")[1];
+            System.IO.FileInfo resultShapeInPic = PpOperations.ExportSelectedShapes();
 
-            var expSlide = PpOperations.SelectSlide(8);
+            Microsoft.Office.Interop.PowerPoint.Slide expSlide = PpOperations.SelectSlide(8);
 
-            var expShape = PpOperations.SelectShapesByPrefix("Group")[1];
-            var expShapeInPic = PpOperations.ExportSelectedShapes();
+            Microsoft.Office.Interop.PowerPoint.Shape expShape = PpOperations.SelectShapesByPrefix("Group")[1];
+            System.IO.FileInfo expShapeInPic = PpOperations.ExportSelectedShapes();
 
             // remove elements that affect comparing slides
             // e.g. "Expected" textbox
@@ -84,19 +84,19 @@ namespace Test.FunctionalTest
 
         private void CropRotatedShapeSuccessfully()
         {
-            var actualSlide = PpOperations.SelectSlide(10);
+            Microsoft.Office.Interop.PowerPoint.Slide actualSlide = PpOperations.SelectSlide(10);
             PpOperations.SelectShape("selectMe");
 
             // Execute the Crop To Shape feature
             PplFeatures.AutoCrop();
 
-            var resultShape = PpOperations.SelectShapesByPrefix("selectMe")[1];
-            var resultShapeInPic = PpOperations.ExportSelectedShapes();
+            Microsoft.Office.Interop.PowerPoint.Shape resultShape = PpOperations.SelectShapesByPrefix("selectMe")[1];
+            System.IO.FileInfo resultShapeInPic = PpOperations.ExportSelectedShapes();
 
-            var expSlide = PpOperations.SelectSlide(11);
+            Microsoft.Office.Interop.PowerPoint.Slide expSlide = PpOperations.SelectSlide(11);
 
-            var expShape = PpOperations.SelectShapesByPrefix("selectMe")[1];
-            var expShapeInPic = PpOperations.ExportSelectedShapes();
+            Microsoft.Office.Interop.PowerPoint.Shape expShape = PpOperations.SelectShapesByPrefix("selectMe")[1];
+            System.IO.FileInfo expShapeInPic = PpOperations.ExportSelectedShapes();
 
             // remove elements that affect comparing slides
             // e.g. "Expected" textbox

--- a/PowerPointLabs/Test/FunctionalTest/AutoNarrationTest.cs
+++ b/PowerPointLabs/Test/FunctionalTest/AutoNarrationTest.cs
@@ -15,11 +15,11 @@ namespace Test.FunctionalTest
         [TestCategory("FT")]
         public void FT_AutoNarrationTest()
         {
-            var actualSlide = PpOperations.SelectSlide(7);
+            Microsoft.Office.Interop.PowerPoint.Slide actualSlide = PpOperations.SelectSlide(7);
 
             PplFeatures.AutoNarrate();
 
-            var expSlide = PpOperations.SelectSlide(8);
+            Microsoft.Office.Interop.PowerPoint.Slide expSlide = PpOperations.SelectSlide(8);
             SlideUtil.IsSameAnimations(expSlide, actualSlide);
         }
     }

--- a/PowerPointLabs/Test/FunctionalTest/AutoZoomTest.cs
+++ b/PowerPointLabs/Test/FunctionalTest/AutoZoomTest.cs
@@ -78,7 +78,7 @@ namespace Test.FunctionalTest
 
         private void TestDrillDownUnsuccessful()
         {
-            var slide = PpOperations.SelectSlide(34);
+            Microsoft.Office.Interop.PowerPoint.Slide slide = PpOperations.SelectSlide(34);
             slide.MoveTo(35);
             PpOperations.SelectShape("Zoom This Shape");
             MessageBoxUtil.ExpectMessageBoxWillPopUp(
@@ -89,7 +89,7 @@ namespace Test.FunctionalTest
 
         private void TestStepBackUnsuccessful()
         {
-            var slide = PpOperations.SelectSlide(35);
+            Microsoft.Office.Interop.PowerPoint.Slide slide = PpOperations.SelectSlide(35);
             slide.MoveTo(1);
             PpOperations.SelectShape("Zoom This Shape");
             MessageBoxUtil.ExpectMessageBoxWillPopUp(
@@ -101,8 +101,8 @@ namespace Test.FunctionalTest
 
         private void AssertIsSame(int actualSlideIndex, int expectedSlideIndex)
         {
-            var actualSlide = PpOperations.SelectSlide(actualSlideIndex);
-            var expectedSlide = PpOperations.SelectSlide(expectedSlideIndex);
+            Microsoft.Office.Interop.PowerPoint.Slide actualSlide = PpOperations.SelectSlide(actualSlideIndex);
+            Microsoft.Office.Interop.PowerPoint.Slide expectedSlide = PpOperations.SelectSlide(expectedSlideIndex);
             SlideUtil.IsSameLooking(expectedSlide, actualSlide);
             SlideUtil.IsSameAnimations(expectedSlide, actualSlide);
         }

--- a/PowerPointLabs/Test/FunctionalTest/BaseFunctionalTest.cs
+++ b/PowerPointLabs/Test/FunctionalTest/BaseFunctionalTest.cs
@@ -66,7 +66,7 @@ namespace Test.FunctionalTest
         private void ConnectPpl()
         {
             const int waitTime = 3000;
-            var retryCount = 5;
+            int retryCount = 5;
             while (retryCount > 0)
             {
                 // if already connected, break
@@ -77,7 +77,7 @@ namespace Test.FunctionalTest
                 // otherwise keep trying to connect for some times
                 try
                 {
-                    var ftInstance = (IPowerPointLabsFT) Activator.GetObject(typeof (IPowerPointLabsFT),
+                    IPowerPointLabsFT ftInstance = (IPowerPointLabsFT) Activator.GetObject(typeof (IPowerPointLabsFT),
                         "ipc://PowerPointLabsFT/PowerPointLabsFT");
                     PplFeatures = ftInstance.GetFeatures();
                     PpOperations = ftInstance.GetOperations();
@@ -105,7 +105,7 @@ namespace Test.FunctionalTest
 
         private void OpenSlideForTest(String slideName)
         {
-            var pptProcess = new Process
+            Process pptProcess = new Process
             {
                 StartInfo =
                 {
@@ -118,7 +118,7 @@ namespace Test.FunctionalTest
 
         private void CloseActivePpInstance()
         {
-            var processes = Process.GetProcessesByName("POWERPNT");
+            Process[] processes = Process.GetProcessesByName("POWERPNT");
             if (processes.Length > 0)
             {
                 foreach (Process p in processes)
@@ -133,7 +133,7 @@ namespace Test.FunctionalTest
 
         private void WaitForPpInstanceToClose()
         {
-            var retry = 5;
+            int retry = 5;
             while (Process.GetProcessesByName("POWERPNT").Length > 0
                 && retry > 0)
             {
@@ -143,7 +143,7 @@ namespace Test.FunctionalTest
 
             if (Process.GetProcessesByName("POWERPNT").Length > 0)
             {
-                foreach (var process in Process.GetProcessesByName("POWERPNT"))
+                foreach (Process process in Process.GetProcessesByName("POWERPNT"))
                 {
                     process.Kill();
                 }

--- a/PowerPointLabs/Test/FunctionalTest/ColorsLabTest.cs
+++ b/PowerPointLabs/Test/FunctionalTest/ColorsLabTest.cs
@@ -23,7 +23,7 @@ namespace Test.FunctionalTest
         {
             // if not maximized, some elements in Colors pane may not be seen
             PpOperations.MaximizeWindow();
-            var colorsLab = PplFeatures.ColorsLab;
+            IColorsLabController colorsLab = PplFeatures.ColorsLab;
             colorsLab.OpenPane();
 
             TestApplyingColors(colorsLab);
@@ -39,10 +39,10 @@ namespace Test.FunctionalTest
             {
                 infoDialog = colorsLab.ShowMoreColorInfo(colorsLab.GetMonoPanel1().BackColor);
                 // rgb text is like "RGB: 163, 192, 242"
-                var rgbColor = infoDialog.GetRgbText().Substring(5).Split(',');
-                var r = Int32.Parse(rgbColor[0].Trim());
-                var g = Int32.Parse(rgbColor[1].Trim());
-                var b = Int32.Parse(rgbColor[2].Trim());
+                string[] rgbColor = infoDialog.GetRgbText().Substring(5).Split(',');
+                int r = Int32.Parse(rgbColor[0].Trim());
+                int g = Int32.Parse(rgbColor[1].Trim());
+                int b = Int32.Parse(rgbColor[2].Trim());
                 // rgb values can have errors within threshold 2
                 Assert.IsTrue(Math.Abs(r - 163) <= 2);
                 Assert.IsTrue(Math.Abs(g - 192) <= 2);
@@ -56,18 +56,18 @@ namespace Test.FunctionalTest
 
         private void TestFavoriteColors(IColorsLabController colorsLab)
         {
-            var favPanel1 = colorsLab.GetFavColorPanel1();
-            var originalFavColor = favPanel1.BackColor;
+            Panel favPanel1 = colorsLab.GetFavColorPanel1();
+            Color originalFavColor = favPanel1.BackColor;
 
             try
             {
                 // empty fav colors
                 colorsLab.GetEmptyFavColorsButton().PerformClick();
-                var colorAftReset = favPanel1.BackColor;
+                Color colorAftReset = favPanel1.BackColor;
                 AssertEqual(Color.White, colorAftReset);
 
                 // set mono panel1's color as fav color
-                var monoPanel1 = colorsLab.GetMonoPanel1();
+                Panel monoPanel1 = colorsLab.GetMonoPanel1();
                 ApplyColor(monoPanel1, favPanel1);
                 AssertEqual(monoPanel1.BackColor, favPanel1.BackColor);
             }
@@ -81,27 +81,27 @@ namespace Test.FunctionalTest
 
         private void TestRecommendedColors(IColorsLabController colorsLab)
         {
-            var actualSlide = PpOperations.SelectSlide(3);
+            Slide actualSlide = PpOperations.SelectSlide(3);
             PpOperations.SelectShape("selectMe");
 
             // mono panel7's color will become main color now
             Click(colorsLab.GetMonoPanel7());
             ApplyColor(colorsLab.GetFillColorButton(), colorsLab.GetDropletPanel());
 
-            var expSlide = PpOperations.SelectSlide(5);
+            Slide expSlide = PpOperations.SelectSlide(5);
             SlideUtil.IsSameLooking(expSlide, actualSlide);
         }
 
         private void TestApplyingColors(IColorsLabController colorsLab)
         {
-            var actualSlide = PpOperations.SelectSlide(3);
+            Slide actualSlide = PpOperations.SelectSlide(3);
 
-            var fontColorShape = PpOperations.SelectShape("fontColor")[1];
-            var lineColorShape = PpOperations.SelectShape("lineColor")[1];
-            var fillColorShape = PpOperations.SelectShape("fillColor")[1];
+            Shape fontColorShape = PpOperations.SelectShape("fontColor")[1];
+            Shape lineColorShape = PpOperations.SelectShape("lineColor")[1];
+            Shape fillColorShape = PpOperations.SelectShape("fillColor")[1];
             PpOperations.SelectShape("selectMe");
 
-            var dropletPanel = colorsLab.GetDropletPanel();
+            Panel dropletPanel = colorsLab.GetDropletPanel();
 
             // get main color from fontColorShape
             // then apply main color to font color of target shape
@@ -116,7 +116,7 @@ namespace Test.FunctionalTest
             ApplyColor(dropletPanel, fillColorShape);
             ApplyColor(colorsLab.GetFillColorButton(), dropletPanel);
 
-            var expSlide = PpOperations.SelectSlide(4);
+            Slide expSlide = PpOperations.SelectSlide(4);
             SlideUtil.IsSameLooking(expSlide, actualSlide);
         }
 
@@ -124,8 +124,8 @@ namespace Test.FunctionalTest
         // mouse drag & drop from Control to Shape to apply color
         private void ApplyColor(Control from, Shape to)
         {
-            var startPt = from.PointToScreen(new Point(from.Width/2, from.Height/2));
-            var endPt = new Point(
+            Point startPt = from.PointToScreen(new Point(from.Width/2, from.Height/2));
+            Point endPt = new Point(
                 PpOperations.PointsToScreenPixelsX(to.Left + to.Width/2),
                 PpOperations.PointsToScreenPixelsY(to.Top + to.Height/2));
             DragAndDrop(startPt, endPt);
@@ -134,8 +134,8 @@ namespace Test.FunctionalTest
         // mouse drag & drop from control to another control to apply color
         private void ApplyColor(Control from, Control to)
         {
-            var startPt = from.PointToScreen(new Point(from.Width / 2, from.Height / 2));
-            var endPt = to.PointToScreen(new Point(to.Width / 2, to.Height / 2));
+            Point startPt = from.PointToScreen(new Point(from.Width / 2, from.Height / 2));
+            Point endPt = to.PointToScreen(new Point(to.Width / 2, to.Height / 2));
             DragAndDrop(startPt, endPt);
         }
 
@@ -147,7 +147,7 @@ namespace Test.FunctionalTest
 
         private void Click(Control target)
         {
-            var pt = target.PointToScreen(new Point(target.Width / 2, target.Height / 2));
+            Point pt = target.PointToScreen(new Point(target.Width / 2, target.Height / 2));
             MouseUtil.SendMouseLeftClick(pt.X, pt.Y);
         }
 

--- a/PowerPointLabs/Test/FunctionalTest/ConvertToPictureTest.cs
+++ b/PowerPointLabs/Test/FunctionalTest/ConvertToPictureTest.cs
@@ -23,30 +23,30 @@ namespace Test.FunctionalTest
 
         private void CovertGroupObjToPicture()
         {
-            var actualSlide = PpOperations.SelectSlide(7);
+            Microsoft.Office.Interop.PowerPoint.Slide actualSlide = PpOperations.SelectSlide(7);
             PpOperations.SelectShape("pic");
 
             PplFeatures.ConvertToPic();
 
-            var sh = PpOperations.SelectShapesByPrefix("Picture")[1] as Shape;
+            Shape sh = PpOperations.SelectShapesByPrefix("Picture")[1] as Shape;
             Assert.AreEqual(MsoShapeType.msoPicture, sh.Type);
 
-            var expSlide = PpOperations.SelectSlide(8);
+            Microsoft.Office.Interop.PowerPoint.Slide expSlide = PpOperations.SelectSlide(8);
             PpOperations.SelectShape("text 3")[1].Delete();
             SlideUtil.IsSameLooking(expSlide, actualSlide);
         }
 
         private static void ConvertSingleObjToPicture()
         {
-            var actualSlide = PpOperations.SelectSlide(4);
+            Microsoft.Office.Interop.PowerPoint.Slide actualSlide = PpOperations.SelectSlide(4);
             PpOperations.SelectShape("pic");
 
             PplFeatures.ConvertToPic();
 
-            var sh = PpOperations.SelectShapesByPrefix("Picture")[1] as Shape;
+            Shape sh = PpOperations.SelectShapesByPrefix("Picture")[1] as Shape;
             Assert.AreEqual(MsoShapeType.msoPicture, sh.Type);
 
-            var expSlide = PpOperations.SelectSlide(5);
+            Microsoft.Office.Interop.PowerPoint.Slide expSlide = PpOperations.SelectSlide(5);
             PpOperations.SelectShape("text 3")[1].Delete();
             SlideUtil.IsSameLooking(expSlide, actualSlide);
         }

--- a/PowerPointLabs/Test/FunctionalTest/CropToSlideTest.cs
+++ b/PowerPointLabs/Test/FunctionalTest/CropToSlideTest.cs
@@ -73,18 +73,18 @@ namespace Test.FunctionalTest
 
         public void CropAndCompare(int testSlideNo, int expectedSlideNo)
         {
-            var actualSlide = PpOperations.SelectSlide(testSlideNo);
+            Microsoft.Office.Interop.PowerPoint.Slide actualSlide = PpOperations.SelectSlide(testSlideNo);
             PpOperations.SelectShapesByPrefix("selectMe");
 
             // Execute the Crop To Slide feature
             PplFeatures.CropToSlide();
-            var resultShapes = PpOperations.SelectShapesByPrefix("selectMe")[1];
-            var resultShapesInPic = PpOperations.ExportSelectedShapes();
+            Microsoft.Office.Interop.PowerPoint.Shape resultShapes = PpOperations.SelectShapesByPrefix("selectMe")[1];
+            System.IO.FileInfo resultShapesInPic = PpOperations.ExportSelectedShapes();
 
-            var expSlide = PpOperations.SelectSlide(expectedSlideNo);
+            Microsoft.Office.Interop.PowerPoint.Slide expSlide = PpOperations.SelectSlide(expectedSlideNo);
 
-            var expShape = PpOperations.SelectShapesByPrefix("selectMe")[1];
-            var expShapeInPic = PpOperations.ExportSelectedShapes();
+            Microsoft.Office.Interop.PowerPoint.Shape expShape = PpOperations.SelectShapesByPrefix("selectMe")[1];
+            System.IO.FileInfo expShapeInPic = PpOperations.ExportSelectedShapes();
 
             // remove elements that affect comparing slides
             // e.g. "Expected" textbox

--- a/PowerPointLabs/Test/FunctionalTest/EffectsLabTest.cs
+++ b/PowerPointLabs/Test/FunctionalTest/EffectsLabTest.cs
@@ -93,8 +93,8 @@ namespace Test.FunctionalTest
 
         private void AssertIsSame(int actualSlideIndex, int expectedSlideIndex)
         {
-            var actualSlide = PpOperations.SelectSlide(actualSlideIndex);
-            var expectedSlide = PpOperations.SelectSlide(expectedSlideIndex);
+            Microsoft.Office.Interop.PowerPoint.Slide actualSlide = PpOperations.SelectSlide(actualSlideIndex);
+            Microsoft.Office.Interop.PowerPoint.Slide expectedSlide = PpOperations.SelectSlide(expectedSlideIndex);
             SlideUtil.IsSameLooking(expectedSlide, actualSlide, 0.999);
             SlideUtil.IsSameAnimations(expectedSlide, actualSlide);
         }

--- a/PowerPointLabs/Test/FunctionalTest/HighlightBulletsTest.cs
+++ b/PowerPointLabs/Test/FunctionalTest/HighlightBulletsTest.cs
@@ -89,8 +89,8 @@ namespace Test.FunctionalTest
 
         private void AssertIsSame(int actualSlideIndex, int expectedSlideIndex)
         {
-            var actualSlide = PpOperations.SelectSlide(actualSlideIndex);
-            var expectedSlide = PpOperations.SelectSlide(expectedSlideIndex);
+            Microsoft.Office.Interop.PowerPoint.Slide actualSlide = PpOperations.SelectSlide(actualSlideIndex);
+            Microsoft.Office.Interop.PowerPoint.Slide expectedSlide = PpOperations.SelectSlide(expectedSlideIndex);
             SlideUtil.IsSameLooking(expectedSlide, actualSlide);
             SlideUtil.IsSameAnimations(expectedSlide, actualSlide);
         }

--- a/PowerPointLabs/Test/FunctionalTest/NarrationsLabTest.cs
+++ b/PowerPointLabs/Test/FunctionalTest/NarrationsLabTest.cs
@@ -24,7 +24,7 @@ namespace Test.FunctionalTest
         {
             // ensure that the audio type detection is
             // backwards-compatible with older versions
-            var shape = PpOperations.SelectShape("Record")[1];
+            Shape shape = PpOperations.SelectShape("Record")[1];
             Assert.AreEqual(Audio.AudioType.Record, Audio.GetShapeAudioType(shape));
             shape = PpOperations.SelectShape("Auto")[1];
             Assert.AreEqual(Audio.AudioType.Auto, Audio.GetShapeAudioType(shape));

--- a/PowerPointLabs/Test/FunctionalTest/PasteLabTest.cs
+++ b/PowerPointLabs/Test/FunctionalTest/PasteLabTest.cs
@@ -63,7 +63,7 @@ namespace Test.FunctionalTest
 
         private void PasteToFillSlide(int originalSlideNo, int expSlideNo)
         {
-            var shapes = GetShapesByPrefix(originalSlideNo, ShapeToCopyPrefix);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange shapes = GetShapesByPrefix(originalSlideNo, ShapeToCopyPrefix);
             shapes.Cut();
 
             PplFeatures.PasteToFillSlide();
@@ -73,7 +73,7 @@ namespace Test.FunctionalTest
 
         private void PasteAtCursorPosition(int originalSlideNo, int expSlideNo)
         {
-            var shapes = GetShapesByPrefix(originalSlideNo, ShapeToCopyPrefix);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange shapes = GetShapesByPrefix(originalSlideNo, ShapeToCopyPrefix);
             shapes.Cut();
 
             RightClick(GetShapesByPrefix(originalSlideNo, ShapeToClick)[1]);
@@ -86,7 +86,7 @@ namespace Test.FunctionalTest
 
         private void PasteAtOriginalPosition(int originalSlideNo, int expSlideNo)
         {
-            var shapes = GetShapesByPrefix(originalSlideNo, ShapeToCopyPrefix);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange shapes = GetShapesByPrefix(originalSlideNo, ShapeToCopyPrefix);
             shapes.Cut();
 
             PplFeatures.PasteAtOriginalPosition();
@@ -96,7 +96,7 @@ namespace Test.FunctionalTest
 
         private void ReplaceWithClipboard(int originalSlideNo, int expSlideNo)
         {
-            var shapes = GetShapesByPrefix(originalSlideNo, ShapeToCopyPrefix);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange shapes = GetShapesByPrefix(originalSlideNo, ShapeToCopyPrefix);
             shapes.Cut();
 
             PpOperations.SelectShapes(new List<string> { ShapeToReplace });
@@ -107,7 +107,7 @@ namespace Test.FunctionalTest
 
         private void PasteIntoGroup(int originalSlideNo, int expSlideNo)
         {
-            var shapes = GetShapesByPrefix(originalSlideNo, ShapeToCopyPrefix);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange shapes = GetShapesByPrefix(originalSlideNo, ShapeToCopyPrefix);
             shapes.Cut();
 
             PpOperations.SelectShape(GroupToPaste);
@@ -118,8 +118,8 @@ namespace Test.FunctionalTest
 
         private void AssertIsSame(int actualSlideNo, int expectedSlideNo)
         {
-            var actualSlide = PpOperations.SelectSlide(actualSlideNo);
-            var expectedSlide = PpOperations.SelectSlide(expectedSlideNo);
+            Microsoft.Office.Interop.PowerPoint.Slide actualSlide = PpOperations.SelectSlide(actualSlideNo);
+            Microsoft.Office.Interop.PowerPoint.Slide expectedSlide = PpOperations.SelectSlide(expectedSlideNo);
 
             SlideUtil.IsSameLooking(expectedSlide, actualSlide);
             SlideUtil.IsSameAnimations(expectedSlide, actualSlide);
@@ -133,7 +133,7 @@ namespace Test.FunctionalTest
 
         private void RightClick(Shape target)
         {
-            var pt = new Point(
+            Point pt = new Point(
                 PpOperations.PointsToScreenPixelsX(target.Left + target.Width / 2),
                 PpOperations.PointsToScreenPixelsY(target.Top + target.Height / 2));
             MouseUtil.SendMouseRightClick(pt.X, pt.Y);

--- a/PowerPointLabs/Test/FunctionalTest/PositionsLabDuplicateAndRotateTest.cs
+++ b/PowerPointLabs/Test/FunctionalTest/PositionsLabDuplicateAndRotateTest.cs
@@ -40,7 +40,7 @@ namespace Test.FunctionalTest
         public void FT_PositionsLabDuplicateAndRotateTest()
         {
             PpOperations.MaximizeWindow();
-            var positionsLab = PplFeatures.PositionsLab;
+            IPositionsLabController positionsLab = PplFeatures.PositionsLab;
             positionsLab.OpenPane();
 
             TestOneShapeFixed(positionsLab);
@@ -51,7 +51,7 @@ namespace Test.FunctionalTest
 
         private void TestOneShapeFixed(IPositionsLabController positionsLab)
         {
-            var actualSlide = PpOperations.SelectSlide(OriginalShapesSlideNoTestOneFixed);
+            Slide actualSlide = PpOperations.SelectSlide(OriginalShapesSlideNoTestOneFixed);
 
             _shapeNames = new List<string> { Rectangle, Oval };
             Shape shapeStart = PpOperations.SelectShape(Oval)[1];
@@ -63,13 +63,13 @@ namespace Test.FunctionalTest
 
             RotateShape(shapeStart, shapeEnd);
 
-            var expSlide = PpOperations.SelectSlide(ExpectedShapesSlideNoTestOneFixed);
+            Slide expSlide = PpOperations.SelectSlide(ExpectedShapesSlideNoTestOneFixed);
             SlideUtil.IsSameLooking(expSlide, actualSlide);
         }
 
         private void TestOneShapeDynamic(IPositionsLabController positionsLab)
         {
-            var actualSlide = PpOperations.SelectSlide(OriginalShapesSlideNoTestOneDynamic);
+            Slide actualSlide = PpOperations.SelectSlide(OriginalShapesSlideNoTestOneDynamic);
 
             _shapeNames = new List<string> { Rectangle, Triangle };
             Shape shapeStart = PpOperations.SelectShape(Triangle)[1];
@@ -81,13 +81,13 @@ namespace Test.FunctionalTest
 
             RotateShape(shapeStart, shapeEnd);
 
-            var expSlide = PpOperations.SelectSlide(ExpectedShapesSlideNoTestOneDynamic);
+            Slide expSlide = PpOperations.SelectSlide(ExpectedShapesSlideNoTestOneDynamic);
             SlideUtil.IsSameLooking(expSlide, actualSlide);
         }
 
         private void TestMultipleShapesFixed(IPositionsLabController positionsLab)
         {
-            var actualSlide = PpOperations.SelectSlide(OriginalShapesSlideNoTestMultipleFixed);
+            Slide actualSlide = PpOperations.SelectSlide(OriginalShapesSlideNoTestMultipleFixed);
 
             _shapeNames = new List<string> { Rectangle, Oval, Triangle };
             Shape shapeStart = PpOperations.SelectShape(Oval)[1];
@@ -99,13 +99,13 @@ namespace Test.FunctionalTest
 
             RotateShape(shapeStart, shapeEnd);
 
-            var expSlide = PpOperations.SelectSlide(ExpectedShapesSlideNoTestMultipleFixed);
+            Slide expSlide = PpOperations.SelectSlide(ExpectedShapesSlideNoTestMultipleFixed);
             SlideUtil.IsSameLooking(expSlide, actualSlide);
         }
 
         private void TestMultipleShapesDynamic(IPositionsLabController positionsLab)
         {
-            var actualSlide = PpOperations.SelectSlide(OriginalShapesSlideNoTestMultipleDynamic);
+            Slide actualSlide = PpOperations.SelectSlide(OriginalShapesSlideNoTestMultipleDynamic);
 
             _shapeNames = new List<string> { Rectangle, Oval, Triangle };
             Shape shapeStart = PpOperations.SelectShape(Oval)[1];
@@ -117,7 +117,7 @@ namespace Test.FunctionalTest
 
             RotateShape(shapeStart, shapeEnd);
 
-            var expSlide = PpOperations.SelectSlide(ExpectedShapesSlideNoTestMultipleDynamic);
+            Slide expSlide = PpOperations.SelectSlide(ExpectedShapesSlideNoTestMultipleDynamic);
             SlideUtil.IsSameLooking(expSlide, actualSlide);
         }
 
@@ -125,10 +125,10 @@ namespace Test.FunctionalTest
         // mouse drag & drop from Control to Shape to apply color
         private void RotateShape(Shape from, Shape to)
         {
-            var startPt = new Point(
+            Point startPt = new Point(
                 PpOperations.PointsToScreenPixelsX(from.Left + from.Width / 2),
                 PpOperations.PointsToScreenPixelsY(from.Top + from.Height / 2));
-            var endPt = new Point(
+            Point endPt = new Point(
                 PpOperations.PointsToScreenPixelsX(to.Left + to.Width/2),
                 PpOperations.PointsToScreenPixelsY(to.Top + to.Height/2));
             DragAndDrop(startPt, endPt);
@@ -147,7 +147,7 @@ namespace Test.FunctionalTest
 
         private void Click(Control target)
         {
-            var pt = target.PointToScreen(new Point(target.Width / 2, target.Height / 2));
+            Point pt = target.PointToScreen(new Point(target.Width / 2, target.Height / 2));
         }
         # endregion
     }

--- a/PowerPointLabs/Test/FunctionalTest/QuickPropertyTest.cs
+++ b/PowerPointLabs/Test/FunctionalTest/QuickPropertyTest.cs
@@ -18,10 +18,10 @@ namespace Test.FunctionalTest
         {
             PpOperations.SelectSlide(4);
 
-            var shape = PpOperations.SelectShape("ffs")[1];
+            Microsoft.Office.Interop.PowerPoint.Shape shape = PpOperations.SelectShape("ffs")[1];
 
-            var x = PpOperations.PointsToScreenPixelsX(shape.Left + shape.Width / 2);
-            var y = PpOperations.PointsToScreenPixelsY(shape.Top + shape.Height / 2);
+            int x = PpOperations.PointsToScreenPixelsX(shape.Left + shape.Width / 2);
+            int y = PpOperations.PointsToScreenPixelsY(shape.Top + shape.Height / 2);
             MouseUtil.SendMouseDoubleClick(x, y);
 
             ThreadUtil.WaitFor(2000);
@@ -29,7 +29,7 @@ namespace Test.FunctionalTest
             if (PpOperations.IsOffice2010())
             {
                 // AKA property handle
-                var formatObjHandle = NativeUtil.FindWindow("NUIDialog", "Format Shape");
+                IntPtr formatObjHandle = NativeUtil.FindWindow("NUIDialog", "Format Shape");
                 Assert.AreNotEqual(IntPtr.Zero, formatObjHandle, "Failed to find Property handle.");
                 
                 NativeUtil.SendMessage(formatObjHandle, 0x10 /*WM_CLOSE*/, IntPtr.Zero, IntPtr.Zero);
@@ -37,15 +37,15 @@ namespace Test.FunctionalTest
             else // for Office 2013 or higher
             {
                 // Spy++ helps to look into the handles
-                var pptHandle = NativeUtil.FindWindow("PPTFrameClass", null);
+                IntPtr pptHandle = NativeUtil.FindWindow("PPTFrameClass", null);
                 Assert.AreNotEqual(IntPtr.Zero, pptHandle, "Failed to find PowerPoint handle.");
 
-                var dockRightHandle =
+                IntPtr dockRightHandle =
                     NativeUtil.FindWindowEx(pptHandle, IntPtr.Zero, "MsoCommandBarDock", "MsoDockRight");
                 Assert.AreNotEqual(IntPtr.Zero, dockRightHandle, "Failed to find Dock Right handle.");
 
                 // AKA property handle
-                var formatObjHandle =
+                IntPtr formatObjHandle =
                     NativeUtil.FindWindowEx(dockRightHandle, IntPtr.Zero, "MsoCommandBar", "Format Object");
                 Assert.AreNotEqual(IntPtr.Zero, formatObjHandle, "Failed to find Property handle.");
             }

--- a/PowerPointLabs/Test/FunctionalTest/ShapesLabTest.cs
+++ b/PowerPointLabs/Test/FunctionalTest/ShapesLabTest.cs
@@ -29,7 +29,7 @@ namespace Test.FunctionalTest
         public void FT_ShapesLabTest()
         {
             PpOperations.MaximizeWindow();
-            var shapesLab = PplFeatures.ShapesLab;
+            IShapesLabController shapesLab = PplFeatures.ShapesLab;
             shapesLab.OpenPane();
 
             TestSaveShapesToShapesLab(shapesLab);
@@ -42,8 +42,8 @@ namespace Test.FunctionalTest
                 PathUtil.GetDocTestPresentationPath("ShapesLab\\LibraryToImport.pptlabsshapes"));
             shapesLab.ImportLibrary(
                 PathUtil.GetDocTestPresentationPath("ShapesLab\\ShapeToImport.pptlabsshape"));
-            var actualShapeDataAfterImport = shapesLab.FetchShapeGalleryPresentationData();
-            var expShapeDataAfterImport = PpOperations.FetchPresentationData(
+            System.Collections.Generic.List<ISlideData> actualShapeDataAfterImport = shapesLab.FetchShapeGalleryPresentationData();
+            System.Collections.Generic.List<ISlideData> expShapeDataAfterImport = PpOperations.FetchPresentationData(
                 PathUtil.GetDocTestPresentationPath(ExpectedShapeGalleryFileName()));
             PresentationUtil.AssertEqual(expShapeDataAfterImport, actualShapeDataAfterImport);
         }
@@ -67,16 +67,16 @@ namespace Test.FunctionalTest
             // save shapes
             shapesLab.SaveSelectedShapes();
 
-            var actualSlide = PpOperations.SelectSlide(4);
-            var addedThumbnail = shapesLab.GetLabeledThumbnail("selectMe1");
+            Microsoft.Office.Interop.PowerPoint.Slide actualSlide = PpOperations.SelectSlide(4);
+            IShapesLabLabeledThumbnail addedThumbnail = shapesLab.GetLabeledThumbnail("selectMe1");
             addedThumbnail.FinishNameEdit();
             // add shapes back
             DoubleClick(addedThumbnail as Control);
-            var shapes = PpOperations.SelectShapesByPrefix("Group selectMe1");
+            Microsoft.Office.Interop.PowerPoint.ShapeRange shapes = PpOperations.SelectShapesByPrefix("Group selectMe1");
             Assert.IsTrue(shapes.Count > 0, "Failed to add shapes from Shapes Lab." +
                                             "UI test is flaky, pls re-run.");
 
-            var expSlide = PpOperations.SelectSlide(5);
+            Microsoft.Office.Interop.PowerPoint.Slide expSlide = PpOperations.SelectSlide(5);
 
             SlideUtil.IsSameLooking(expSlide, actualSlide);
             SlideUtil.IsSameAnimations(expSlide, actualSlide);
@@ -84,7 +84,7 @@ namespace Test.FunctionalTest
 
         private void DoubleClick(Control target)
         {
-            var pt = target.PointToScreen(new Point(target.Width/2, target.Height/2));
+            Point pt = target.PointToScreen(new Point(target.Width/2, target.Height/2));
             MouseUtil.SendMouseDoubleClick(pt.X, pt.Y);
         }
     }

--- a/PowerPointLabs/Test/FunctionalTest/SpotlightTest.cs
+++ b/PowerPointLabs/Test/FunctionalTest/SpotlightTest.cs
@@ -39,10 +39,10 @@ namespace Test.FunctionalTest
             PpOperations.SelectShape("Spotlight Me");
             PplFeatures.Spotlight();
 
-            var actualSlide1 = PpOperations.SelectSlide(4);
-            var actualSlide2 = PpOperations.SelectSlide(5);
-            var expSlide1 = PpOperations.SelectSlide(6);
-            var expSlide2 = PpOperations.SelectSlide(7);
+            Microsoft.Office.Interop.PowerPoint.Slide actualSlide1 = PpOperations.SelectSlide(4);
+            Microsoft.Office.Interop.PowerPoint.Slide actualSlide2 = PpOperations.SelectSlide(5);
+            Microsoft.Office.Interop.PowerPoint.Slide expSlide1 = PpOperations.SelectSlide(6);
+            Microsoft.Office.Interop.PowerPoint.Slide expSlide2 = PpOperations.SelectSlide(7);
             SlideUtil.IsSameLooking(expSlide1, actualSlide1);
             SlideUtil.IsSameLooking(expSlide2, actualSlide2);
         }
@@ -64,11 +64,11 @@ namespace Test.FunctionalTest
 
             PplFeatures.Spotlight();
 
-            var actualSlide1 = PpOperations.SelectSlide(8);
-            var actualSlide2 = PpOperations.SelectSlide(9);
-            var expSlide1 = PpOperations.SelectSlide(10);
+            Microsoft.Office.Interop.PowerPoint.Slide actualSlide1 = PpOperations.SelectSlide(8);
+            Microsoft.Office.Interop.PowerPoint.Slide actualSlide2 = PpOperations.SelectSlide(9);
+            Microsoft.Office.Interop.PowerPoint.Slide expSlide1 = PpOperations.SelectSlide(10);
             PpOperations.SelectShape("text 3")[1].Delete();
-            var expSlide2 = PpOperations.SelectSlide(11);
+            Microsoft.Office.Interop.PowerPoint.Slide expSlide2 = PpOperations.SelectSlide(11);
             PpOperations.SelectShape("text 3")[1].Delete();
             SlideUtil.IsSameLooking(expSlide1, actualSlide1);
             SlideUtil.IsSameLooking(expSlide2, actualSlide2);
@@ -94,14 +94,14 @@ namespace Test.FunctionalTest
             NativeUtil.SendMessage(transparencyDialog, 0x000C /*WM_SETTEXT*/, IntPtr.Zero, "1");
 
             // try to get class's build id
-            var actualContentBuilder = new StringBuilder(1024);
+            StringBuilder actualContentBuilder = new StringBuilder(1024);
             NativeUtil.GetClassName(spotlightDialog, actualContentBuilder, 1024);
-            var classBuildId = actualContentBuilder.ToString().Split('.').Last();
+            string classBuildId = actualContentBuilder.ToString().Split('.').Last();
 
-            var fadeComboBox = NativeUtil.FindWindowEx(spotlightDialog, IntPtr.Zero, "WindowsForms10.COMBOBOX.app.0." + classBuildId, null);
+            IntPtr fadeComboBox = NativeUtil.FindWindowEx(spotlightDialog, IntPtr.Zero, "WindowsForms10.COMBOBOX.app.0." + classBuildId, null);
             Assert.AreNotEqual(IntPtr.Zero, fadeComboBox, "Failed to find Fade Dialog.");
 
-            var sb = new StringBuilder(256, 256);
+            StringBuilder sb = new StringBuilder(256, 256);
             NativeUtil.SendMessage(fadeComboBox, 0x0148 /*CB_GETLBTEXT*/, (IntPtr)2, sb);
 
             // Set combo box

--- a/PowerPointLabs/Test/FunctionalTest/SyncLabTest.cs
+++ b/PowerPointLabs/Test/FunctionalTest/SyncLabTest.cs
@@ -41,7 +41,7 @@ namespace Test.FunctionalTest
         [TestCategory("FT")]
         public void FT_SyncLabTest()
         {
-            var syncLab = PplFeatures.SyncLab;
+            ISyncLabController syncLab = PplFeatures.SyncLab;
             syncLab.OpenPane();
 
             TestSync(syncLab);
@@ -99,10 +99,10 @@ namespace Test.FunctionalTest
 
         private void IsSame(int originalSlideNo, int expectedSlideNo, string shapeToCheck)
         {
-            var actualSlide = PpOperations.SelectSlide(originalSlideNo);
-            var actualShape = PpOperations.SelectShape(shapeToCheck)[1];
-            var expectedSlide = PpOperations.SelectSlide(expectedSlideNo);
-            var expectedShape = PpOperations.SelectShape(shapeToCheck)[1];
+            Microsoft.Office.Interop.PowerPoint.Slide actualSlide = PpOperations.SelectSlide(originalSlideNo);
+            Microsoft.Office.Interop.PowerPoint.Shape actualShape = PpOperations.SelectShape(shapeToCheck)[1];
+            Microsoft.Office.Interop.PowerPoint.Slide expectedSlide = PpOperations.SelectSlide(expectedSlideNo);
+            Microsoft.Office.Interop.PowerPoint.Shape expectedShape = PpOperations.SelectShape(shapeToCheck)[1];
             SlideUtil.IsSameLooking(expectedSlide, actualSlide);
             SlideUtil.IsSameShape(expectedShape, actualShape);
         }

--- a/PowerPointLabs/Test/FunctionalTest/TextFragmentsTest.cs
+++ b/PowerPointLabs/Test/FunctionalTest/TextFragmentsTest.cs
@@ -18,7 +18,7 @@ namespace Test.FunctionalTest
         public void FT_TextFragmentsTest()
         {
             PpOperations.SelectSlide(3);
-            var fragments = new[]
+            int[][] fragments = new[]
             {
                 new[] {17, 37},
                 new[] {45, 114},
@@ -33,7 +33,7 @@ namespace Test.FunctionalTest
                 new[] {370, 388},
             };
 
-            foreach (var fragment in fragments)
+            foreach (int[] fragment in fragments)
             {
                 PpOperations.SelectTextInShape(ShapeName, fragment[0], fragment[1]);
                 PplFeatures.HighlightFragments();
@@ -44,8 +44,8 @@ namespace Test.FunctionalTest
 
         private void AssertIsSame(int actualSlideIndex, int expectedSlideIndex)
         {
-            var actualSlide = PpOperations.SelectSlide(actualSlideIndex);
-            var expectedSlide = PpOperations.SelectSlide(expectedSlideIndex);
+            Microsoft.Office.Interop.PowerPoint.Slide actualSlide = PpOperations.SelectSlide(actualSlideIndex);
+            Microsoft.Office.Interop.PowerPoint.Slide expectedSlide = PpOperations.SelectSlide(expectedSlideIndex);
             SlideUtil.IsSameLooking(expectedSlide, actualSlide);
             SlideUtil.IsSameAnimations(expectedSlide, actualSlide);
         }

--- a/PowerPointLabs/Test/FunctionalTest/TimerLabTest.cs
+++ b/PowerPointLabs/Test/FunctionalTest/TimerLabTest.cs
@@ -40,7 +40,7 @@ namespace Test.FunctionalTest
         [TestCategory("FT")]
         public void FT_TimerLabTest()
         {
-            var timerLab = PplFeatures.TimerLab;
+            ITimerLabController timerLab = PplFeatures.TimerLab;
             timerLab.OpenPane();
 
             TestCreateInitialTimer(timerLab);
@@ -79,7 +79,7 @@ namespace Test.FunctionalTest
         private void TestDeleteTimerBody(ITimerLabController timerLab)
         {
             PpOperations.SelectSlide(OriginalSlideNo);
-            var shapes = PpOperations.SelectShape(TimerBody);
+            ShapeRange shapes = PpOperations.SelectShape(TimerBody);
             shapes.Delete();
 
             MessageBoxUtil.ExpectMessageBoxWillPopUp("Error",
@@ -93,9 +93,9 @@ namespace Test.FunctionalTest
             int expectedColor = PpOperations.SelectShape(TimerLineMarkerGroup)[1].Line.ForeColor.RGB;
 
             PpOperations.SelectSlide(OriginalSlideNo);
-            var lineMarkerGroup = PpOperations.SelectShape(TimerLineMarkerGroup);
+            ShapeRange lineMarkerGroup = PpOperations.SelectShape(TimerLineMarkerGroup);
             lineMarkerGroup.Line.ForeColor.RGB = expectedColor;
-            var timeMarkerGroup = PpOperations.SelectShape(TimerTimeMarkerGroup);
+            ShapeRange timeMarkerGroup = PpOperations.SelectShape(TimerTimeMarkerGroup);
             timeMarkerGroup.Delete();
 
             MessageBoxUtil.ExpectMessageBoxWillPopUp("Error",
@@ -116,10 +116,10 @@ namespace Test.FunctionalTest
             int expectedColor = PpOperations.SelectShape(TimerTimeMarkerGroup)[1].TextFrame.TextRange.Font.Color.RGB;
 
             PpOperations.SelectSlide(OriginalSlideNo);
-            var timeMarkerGroup = PpOperations.SelectShape(TimerTimeMarkerGroup);
+            ShapeRange timeMarkerGroup = PpOperations.SelectShape(TimerTimeMarkerGroup);
             timeMarkerGroup.TextFrame.TextRange.Font.Color.RGB = expectedColor;
             List<string> sliderComponentNames = new List<string> { TimerSliderHead, TimerSliderBody };
-            var sliderComponents = PpOperations.SelectShapes(sliderComponentNames);
+            ShapeRange sliderComponents = PpOperations.SelectShapes(sliderComponentNames);
             sliderComponents.Delete();
 
             MessageBoxUtil.ExpectMessageBoxWillPopUp("Error",
@@ -146,8 +146,8 @@ namespace Test.FunctionalTest
 
         private void AssertIsSame(int actualSlideNo, int expectedSlideNo)
         {
-            var actualSlide = PpOperations.SelectSlide(actualSlideNo);
-            var expectedSlide = PpOperations.SelectSlide(expectedSlideNo);
+            Slide actualSlide = PpOperations.SelectSlide(actualSlideNo);
+            Slide expectedSlide = PpOperations.SelectSlide(expectedSlideNo);
 
             SlideUtil.IsSameShapes(expectedSlide, actualSlide);
             SlideUtil.IsSameAnimations(expectedSlide, actualSlide);

--- a/PowerPointLabs/Test/FunctionalTest/ZoomToAreaTest.cs
+++ b/PowerPointLabs/Test/FunctionalTest/ZoomToAreaTest.cs
@@ -100,8 +100,8 @@ namespace Test.FunctionalTest
 
         private void AssertIsSame(int actualSlideIndex, int expectedSlideIndex)
         {
-            var actualSlide = PpOperations.SelectSlide(actualSlideIndex);
-            var expectedSlide = PpOperations.SelectSlide(expectedSlideIndex);
+            Microsoft.Office.Interop.PowerPoint.Slide actualSlide = PpOperations.SelectSlide(actualSlideIndex);
+            Microsoft.Office.Interop.PowerPoint.Slide expectedSlide = PpOperations.SelectSlide(expectedSlideIndex);
             SlideUtil.IsSameLooking(expectedSlide, actualSlide);
             SlideUtil.IsSameAnimations(expectedSlide, actualSlide);
         }

--- a/PowerPointLabs/Test/UnitTest/CropLab/BaseCropLabTest.cs
+++ b/PowerPointLabs/Test/UnitTest/CropLab/BaseCropLabTest.cs
@@ -24,7 +24,7 @@ namespace Test.UnitTest.CropLab
         {
             foreach (PowerPoint.Shape actualShape in actualShapes)
             {
-                var isFound = false;
+                bool isFound = false;
 
                 foreach (PowerPoint.Shape expectedShape in expectedShapes)
                 {

--- a/PowerPointLabs/Test/UnitTest/CropLab/CropOutPaddingTest.cs
+++ b/PowerPointLabs/Test/UnitTest/CropLab/CropOutPaddingTest.cs
@@ -32,10 +32,10 @@ namespace Test.UnitTest.CropLab
         [TestCategory("UT")]
         public void CropOutPaddingOnePicture()
         {
-            var actualShapes = GetShapes(SlideNumberOnePictureActual, selectOneShapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange actualShapes = GetShapes(SlideNumberOnePictureActual, selectOneShapeNames);
             actualShapes = CropOutPadding.Crop(actualShapes);
 
-            var expectedShapes = GetShapes(SlideNumberOnePictureExpected, selectOneShapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange expectedShapes = GetShapes(SlideNumberOnePictureExpected, selectOneShapeNames);
             CheckShapes(expectedShapes, actualShapes);
         }
 
@@ -43,10 +43,10 @@ namespace Test.UnitTest.CropLab
         [TestCategory("UT")]
         public void CropOutPaddingMultiplePictures()
         {
-            var actualShapes = GetShapes(SlideNumberMultiplePicturesActual, selectMultipleShapesNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange actualShapes = GetShapes(SlideNumberMultiplePicturesActual, selectMultipleShapesNames);
             actualShapes = CropOutPadding.Crop(actualShapes);
 
-            var expectedShapes = GetShapes(SlideNumberMultiplePicturesExpected, selectMultipleShapesNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange expectedShapes = GetShapes(SlideNumberMultiplePicturesExpected, selectMultipleShapesNames);
             CheckShapes(expectedShapes, actualShapes);
         }
 
@@ -54,10 +54,10 @@ namespace Test.UnitTest.CropLab
         [TestCategory("UT")]
         public void CropOutPaddingRotatedPicture()
         {
-            var actualShapes = GetShapes(SlideNumberRotatedPictureActual, selectOneShapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange actualShapes = GetShapes(SlideNumberRotatedPictureActual, selectOneShapeNames);
             actualShapes = CropOutPadding.Crop(actualShapes);
 
-            var expectedShapes = GetShapes(SlideNumberRotatedPictureExpected, selectOneShapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange expectedShapes = GetShapes(SlideNumberRotatedPictureExpected, selectOneShapeNames);
             CheckShapes(expectedShapes, actualShapes);
         }
 
@@ -65,10 +65,10 @@ namespace Test.UnitTest.CropLab
         [TestCategory("UT")]
         public void CropOutPaddingOneChildPicture()
         {
-            var actualShapes = GetShapes(SlideNumberOneChildPictureActual, selectOneShapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange actualShapes = GetShapes(SlideNumberOneChildPictureActual, selectOneShapeNames);
             actualShapes = CropOutPadding.Crop(actualShapes);
 
-            var expectedShapes = GetShapes(SlideNumberOneChildPictureExpected, selectOneShapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange expectedShapes = GetShapes(SlideNumberOneChildPictureExpected, selectOneShapeNames);
             CheckShapes(expectedShapes, actualShapes);
         }
 
@@ -76,10 +76,10 @@ namespace Test.UnitTest.CropLab
         [TestCategory("UT")]
         public void CropOutPaddingMultipleChildPictures()
         {
-            var actualShapes = GetShapes(SlideNumberMultipleChildPicturesActual, selectMultipleShapesNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange actualShapes = GetShapes(SlideNumberMultipleChildPicturesActual, selectMultipleShapesNames);
             actualShapes = CropOutPadding.Crop(actualShapes);
 
-            var expectedShapes = GetShapes(SlideNumberMultipleChildPicturesExpected, selectMultipleShapesNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange expectedShapes = GetShapes(SlideNumberMultipleChildPicturesExpected, selectMultipleShapesNames);
             CheckShapes(expectedShapes, actualShapes);
         }
     }

--- a/PowerPointLabs/Test/UnitTest/CropLab/CropToAspectRatioTest.cs
+++ b/PowerPointLabs/Test/UnitTest/CropLab/CropToAspectRatioTest.cs
@@ -28,10 +28,10 @@ namespace Test.UnitTest.CropLab
         [TestCategory("UT")]
         public void CropToAspectRatioOnePicture()
         {
-            var actualShapes = GetShapes(SlideNumberOnePictureActual, selectOneShapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange actualShapes = GetShapes(SlideNumberOnePictureActual, selectOneShapeNames);
             actualShapes = CropToAspectRatio.Crop(actualShapes, 0.1f);
 
-            var expectedShapes = GetShapes(SlideNumberOnePictureExpected, selectOneShapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange expectedShapes = GetShapes(SlideNumberOnePictureExpected, selectOneShapeNames);
             CheckShapes(expectedShapes, actualShapes);
         }
 
@@ -39,10 +39,10 @@ namespace Test.UnitTest.CropLab
         [TestCategory("UT")]
         public void CropToAspectRatioMultiplePictures()
         {
-            var actualShapes = GetShapes(SlideNumberMultiplePicturesActual, selectMultipleShapesNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange actualShapes = GetShapes(SlideNumberMultiplePicturesActual, selectMultipleShapesNames);
             actualShapes = CropToAspectRatio.Crop(actualShapes, 0.1f);
 
-            var expectedShapes = GetShapes(SlideNumberMultiplePicturesExpected, selectMultipleShapesNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange expectedShapes = GetShapes(SlideNumberMultiplePicturesExpected, selectMultipleShapesNames);
             CheckShapes(expectedShapes, actualShapes);
         }
 
@@ -50,10 +50,10 @@ namespace Test.UnitTest.CropLab
         [TestCategory("UT")]
         public void CropToAspectRatioRotatedPicture()
         {
-            var actualShapes = GetShapes(SlideNumberRotatedPictureActual, selectOneShapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange actualShapes = GetShapes(SlideNumberRotatedPictureActual, selectOneShapeNames);
             actualShapes = CropToAspectRatio.Crop(actualShapes, 0.1f);
 
-            var expectedShapes = GetShapes(SlideNumberRotatedPictureExpected, selectOneShapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange expectedShapes = GetShapes(SlideNumberRotatedPictureExpected, selectOneShapeNames);
             CheckShapes(expectedShapes, actualShapes);
         }
 

--- a/PowerPointLabs/Test/UnitTest/CropLab/CropToSameDimTest.cs
+++ b/PowerPointLabs/Test/UnitTest/CropLab/CropToSameDimTest.cs
@@ -77,8 +77,8 @@ namespace Test.UnitTest.CropLab
         public void CropAndCompare(int testSlideNo, int expectedSlideNo)
         {
             // Execute the Crop To Same feature
-            var testShapes = GetShapes(testSlideNo, selectMultipleShapesNames);
-            var expShapes = GetShapes(expectedSlideNo, selectMultipleShapesNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange testShapes = GetShapes(testSlideNo, selectMultipleShapesNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange expShapes = GetShapes(expectedSlideNo, selectMultipleShapesNames);
             CropToSame.CropSelection(testShapes);
 
             testShapes = GetShapes(testSlideNo, selectMultipleShapesNames);

--- a/PowerPointLabs/Test/UnitTest/FitToSlideTest.cs
+++ b/PowerPointLabs/Test/UnitTest/FitToSlideTest.cs
@@ -15,15 +15,15 @@ namespace Test.UnitTest
         [TestCategory("UT")]
         public void FitToWidth()
         {
-            var slideWidth = Pres.PageSetup.SlideWidth;
-            var slideHeight = Pres.PageSetup.SlideHeight;
+            float slideWidth = Pres.PageSetup.SlideWidth;
+            float slideHeight = Pres.PageSetup.SlideHeight;
 
             PpOperations.SelectSlide(4);
-            var actualShape = PpOperations.SelectShape("pic")[1];
+            Microsoft.Office.Interop.PowerPoint.Shape actualShape = PpOperations.SelectShape("pic")[1];
             PowerPointLabs.FitToSlide.FitToWidth(actualShape, slideWidth, slideHeight);
 
             PpOperations.SelectSlide(5);
-            var expectedResultForFitToWidth = PpOperations.SelectShape("pic")[1];
+            Microsoft.Office.Interop.PowerPoint.Shape expectedResultForFitToWidth = PpOperations.SelectShape("pic")[1];
 
             SlideUtil.IsSameShape(expectedResultForFitToWidth, actualShape);
         }
@@ -32,16 +32,16 @@ namespace Test.UnitTest
         [TestCategory("UT")]
         public void FitToHeight()
         {
-            var slideWidth = Pres.PageSetup.SlideWidth;
-            var slideHeight = Pres.PageSetup.SlideHeight;
+            float slideWidth = Pres.PageSetup.SlideWidth;
+            float slideHeight = Pres.PageSetup.SlideHeight;
 
             PpOperations.SelectSlide(4);
-            var actualShape = PpOperations.SelectShape("pic")[1];
+            Microsoft.Office.Interop.PowerPoint.Shape actualShape = PpOperations.SelectShape("pic")[1];
 
             PowerPointLabs.FitToSlide.FitToHeight(actualShape, slideWidth, slideHeight);
 
             PpOperations.SelectSlide(6);
-            var expectedResultForFitToHeight = PpOperations.SelectShape("pic")[1];
+            Microsoft.Office.Interop.PowerPoint.Shape expectedResultForFitToHeight = PpOperations.SelectShape("pic")[1];
 
             SlideUtil.IsSameShape(expectedResultForFitToHeight, actualShape);
         }
@@ -50,15 +50,15 @@ namespace Test.UnitTest
         [TestCategory("UT")]
         public void FitToWidthRotated()
         {
-            var slideWidth = Pres.PageSetup.SlideWidth;
-            var slideHeight = Pres.PageSetup.SlideHeight;
+            float slideWidth = Pres.PageSetup.SlideWidth;
+            float slideHeight = Pres.PageSetup.SlideHeight;
 
             PpOperations.SelectSlide(8);
-            var actualShape = PpOperations.SelectShape("pic")[1];
+            Microsoft.Office.Interop.PowerPoint.Shape actualShape = PpOperations.SelectShape("pic")[1];
             PowerPointLabs.FitToSlide.FitToWidth(actualShape, slideWidth, slideHeight);
 
             PpOperations.SelectSlide(9);
-            var expectedResultForFitToWidth = PpOperations.SelectShape("pic")[1];
+            Microsoft.Office.Interop.PowerPoint.Shape expectedResultForFitToWidth = PpOperations.SelectShape("pic")[1];
 
             SlideUtil.IsSameShape(expectedResultForFitToWidth, actualShape);
         }
@@ -67,15 +67,15 @@ namespace Test.UnitTest
         [TestCategory("UT")]
         public void FitToHeightRotated()
         {
-            var slideWidth = Pres.PageSetup.SlideWidth;
-            var slideHeight = Pres.PageSetup.SlideHeight;
+            float slideWidth = Pres.PageSetup.SlideWidth;
+            float slideHeight = Pres.PageSetup.SlideHeight;
 
             PpOperations.SelectSlide(8);
-            var actualShape = PpOperations.SelectShape("pic")[1];
+            Microsoft.Office.Interop.PowerPoint.Shape actualShape = PpOperations.SelectShape("pic")[1];
             PowerPointLabs.FitToSlide.FitToHeight(actualShape, slideWidth, slideHeight);
 
             PpOperations.SelectSlide(10);
-            var expectedResultForFitToHeight = PpOperations.SelectShape("pic")[1];
+            Microsoft.Office.Interop.PowerPoint.Shape expectedResultForFitToHeight = PpOperations.SelectShape("pic")[1];
 
             SlideUtil.IsSameShape(expectedResultForFitToHeight, actualShape);
         }

--- a/PowerPointLabs/Test/UnitTest/HighlightLab/RemoveHighlightTest.cs
+++ b/PowerPointLabs/Test/UnitTest/HighlightLab/RemoveHighlightTest.cs
@@ -40,15 +40,15 @@ namespace Test.UnitTest.HighlightLab
         private void RemoveHighlightAndCompare(int testSlideNo, int expectedSlideNo)
         {
             PpOperations.SelectSlide(testSlideNo);
-            var currentSlide = PowerPointSlide.FromSlideFactory(PpOperations.GetCurrentSlide());
+            PowerPointSlide currentSlide = PowerPointSlide.FromSlideFactory(PpOperations.GetCurrentSlide());
             RemoveHighlighting.RemoveHighlight(currentSlide);
             AssertIsSame(testSlideNo, expectedSlideNo);
         }
 
         private void AssertIsSame(int actualSlideIndex, int expectedSlideIndex)
         {
-            var actualSlide = PpOperations.SelectSlide(actualSlideIndex);
-            var expectedSlide = PpOperations.SelectSlide(expectedSlideIndex);
+            Microsoft.Office.Interop.PowerPoint.Slide actualSlide = PpOperations.SelectSlide(actualSlideIndex);
+            Microsoft.Office.Interop.PowerPoint.Slide expectedSlide = PpOperations.SelectSlide(expectedSlideIndex);
             SlideUtil.IsSameLooking(expectedSlide, actualSlide);
             SlideUtil.IsSameAnimations(expectedSlide, actualSlide);
         }

--- a/PowerPointLabs/Test/UnitTest/PictureSlidesLab/Model/ImageItemTest.cs
+++ b/PowerPointLabs/Test/UnitTest/PictureSlidesLab/Model/ImageItemTest.cs
@@ -22,7 +22,7 @@ namespace Test.UnitTest.PictureSlidesLab.Model
         [TestCategory("UT")]
         public void ImageFileNotification()
         {
-            var notified = false;
+            bool notified = false;
             item.PropertyChanged += (sender, args) =>
             {
                 if (args.PropertyName == "ImageFile")
@@ -38,7 +38,7 @@ namespace Test.UnitTest.PictureSlidesLab.Model
         [TestCategory("UT")]
         public void ToolTipNotification()
         {
-            var notified = false;
+            bool notified = false;
             item.PropertyChanged += (sender, args) =>
             {
                 if (args.PropertyName == "Tooltip")
@@ -56,7 +56,7 @@ namespace Test.UnitTest.PictureSlidesLab.Model
         {
             StoragePath.InitPersistentFolder();
             StoragePath.CleanPersistentFolder(new List<string>());
-            var imagePath = PathUtil.GetDocTestPath() + "PictureSlidesLab\\koala.jpg";
+            string imagePath = PathUtil.GetDocTestPath() + "PictureSlidesLab\\koala.jpg";
             item.UpdateDownloadedImage(imagePath);
             Assert.AreEqual(imagePath, item.FullSizeImageFile);
             Assert.IsFalse(string.IsNullOrEmpty(item.ImageFile));

--- a/PowerPointLabs/Test/UnitTest/PictureSlidesLab/Model/ObservableFontTest.cs
+++ b/PowerPointLabs/Test/UnitTest/PictureSlidesLab/Model/ObservableFontTest.cs
@@ -12,8 +12,8 @@ namespace Test.UnitTest.PictureSlidesLab.Model
         [TestCategory("UT")]
         public void FontNotification()
         {
-            var font = new ObservableFont();
-            var isNotified = false;
+            ObservableFont font = new ObservableFont();
+            bool isNotified = false;
             font.PropertyChanged += (sender, args) =>
             {
                 if (args.PropertyName == "Font")

--- a/PowerPointLabs/Test/UnitTest/PictureSlidesLab/Model/ObservableImageItemTest.cs
+++ b/PowerPointLabs/Test/UnitTest/PictureSlidesLab/Model/ObservableImageItemTest.cs
@@ -11,8 +11,8 @@ namespace Test.UnitTest.PictureSlidesLab.Model
         [TestCategory("UT")]
         public void ImageItemNotification()
         {
-            var item = new ObservableImageItem();
-            var isNotified = false;
+            ObservableImageItem item = new ObservableImageItem();
+            bool isNotified = false;
             item.PropertyChanged += (sender, args) =>
             {
                 if (args.PropertyName == "ImageItem")

--- a/PowerPointLabs/Test/UnitTest/PictureSlidesLab/Model/StyleOptionsTest.cs
+++ b/PowerPointLabs/Test/UnitTest/PictureSlidesLab/Model/StyleOptionsTest.cs
@@ -22,7 +22,7 @@ namespace Test.UnitTest.PictureSlidesLab.Model
         {
             option.OptionName = "Test Option Name";
             option.Save(PathUtil.GetDocTestPath() + "PictureSlidesLab\\option.user");
-            var loadedOption = StyleOption.Load(PathUtil.GetDocTestPath() + "PictureSlidesLab\\option.user");
+            StyleOption loadedOption = StyleOption.Load(PathUtil.GetDocTestPath() + "PictureSlidesLab\\option.user");
             Assert.AreEqual("Test Option Name", loadedOption.OptionName);
         }
 

--- a/PowerPointLabs/Test/UnitTest/PictureSlidesLab/Model/StyleVariantsTest.cs
+++ b/PowerPointLabs/Test/UnitTest/PictureSlidesLab/Model/StyleVariantsTest.cs
@@ -21,7 +21,7 @@ namespace Test.UnitTest.PictureSlidesLab.Model
         public void TestApply()
         {
             variant.Set("OptionName", "test option name");
-            var option = new StyleOption();
+            StyleOption option = new StyleOption();
             variant.Apply(option);
             Assert.AreEqual("test option name", option.OptionName);
         }
@@ -34,7 +34,7 @@ namespace Test.UnitTest.PictureSlidesLab.Model
             variant.Set("OptionName", "test option name");
             variant = variant.Copy(new StyleOption());
 
-            var option = new StyleOption();
+            StyleOption option = new StyleOption();
             option.TextBoxPosition = 999;
             option.OptionName = "test option name";
 
@@ -50,7 +50,7 @@ namespace Test.UnitTest.PictureSlidesLab.Model
             variant.Set("TextBoxPosition", 999);
             variant.Set("OptionName", "test option name");
 
-            var option = new StyleOption();
+            StyleOption option = new StyleOption();
             option.TextBoxPosition = 999;
             option.OptionName = "test option name";
 

--- a/PowerPointLabs/Test/UnitTest/PictureSlidesLab/ModelFactory/StyleOptionsFactoryTest.cs
+++ b/PowerPointLabs/Test/UnitTest/PictureSlidesLab/ModelFactory/StyleOptionsFactoryTest.cs
@@ -24,7 +24,7 @@ namespace Test.UnitTest.PictureSlidesLab.ModelFactory
         [TestCategory("UT")]
         public void TestGetAllVariationStyleOptions()
         {
-            var allOptions = _factory.GetAllStylesVariationOptions();
+            List<List<StyleOption>> allOptions = _factory.GetAllStylesVariationOptions();
             Assert.IsTrue(allOptions.Count > 0);
         }
 
@@ -32,7 +32,7 @@ namespace Test.UnitTest.PictureSlidesLab.ModelFactory
         [TestCategory("UT")]
         public void TestGetAllPreviewStyleOptions()
         {
-            var allOptions = _factory.GetAllStylesPreviewOptions();
+            List<StyleOption> allOptions = _factory.GetAllStylesPreviewOptions();
             Assert.IsTrue(allOptions.Count > 0);
         }
 
@@ -40,10 +40,10 @@ namespace Test.UnitTest.PictureSlidesLab.ModelFactory
         [TestCategory("UT")]
         public void TestGetDirectTextOptions()
         {
-            var option = _factory.GetStylesPreviewOption(PictureSlidesLabText.StyleNameDirectText);
+            StyleOption option = _factory.GetStylesPreviewOption(PictureSlidesLabText.StyleNameDirectText);
             Assert.AreEqual(PictureSlidesLabText.StyleNameDirectText, option.StyleName);
 
-            var options = GetOptions(PictureSlidesLabText.StyleNameDirectText);
+            List<StyleOption> options = GetOptions(PictureSlidesLabText.StyleNameDirectText);
             Assert.AreEqual(8, 
                 GetExpectedCount(
                     GetOptionsProperty(options, "IsUseOverlayStyle"), true));
@@ -54,11 +54,11 @@ namespace Test.UnitTest.PictureSlidesLab.ModelFactory
         [TestCategory("UT")]
         public void TestGetBlurOptions()
         {
-            var option = _factory.GetStylesPreviewOption(PictureSlidesLabText.StyleNameBlur);
+            StyleOption option = _factory.GetStylesPreviewOption(PictureSlidesLabText.StyleNameBlur);
             Assert.AreEqual(PictureSlidesLabText.StyleNameBlur, option.StyleName);
             Assert.IsTrue(option.IsUseBlurStyle);
-            
-            var options = GetOptions(PictureSlidesLabText.StyleNameBlur);
+
+            List<StyleOption> options = GetOptions(PictureSlidesLabText.StyleNameBlur);
             Assert.AreEqual(8,
                 GetExpectedCount(
                     GetOptionsProperty(options, "IsUseBlurStyle"), true));
@@ -69,11 +69,11 @@ namespace Test.UnitTest.PictureSlidesLab.ModelFactory
         [TestCategory("UT")]
         public void TestGetTextBoxOptions()
         {
-            var option = _factory.GetStylesPreviewOption(PictureSlidesLabText.StyleNameTextBox);
+            StyleOption option = _factory.GetStylesPreviewOption(PictureSlidesLabText.StyleNameTextBox);
             Assert.AreEqual(PictureSlidesLabText.StyleNameTextBox, option.StyleName);
             Assert.IsTrue(option.IsUseTextBoxStyle);
 
-            var options = GetOptions(PictureSlidesLabText.StyleNameTextBox);
+            List<StyleOption> options = GetOptions(PictureSlidesLabText.StyleNameTextBox);
             Assert.AreEqual(8,
                 GetExpectedCount(
                     GetOptionsProperty(options, "IsUseTextBoxStyle"), true));
@@ -84,11 +84,11 @@ namespace Test.UnitTest.PictureSlidesLab.ModelFactory
         [TestCategory("UT")]
         public void TestGetBannerOptions()
         {
-            var option = _factory.GetStylesPreviewOption(PictureSlidesLabText.StyleNameBanner);
+            StyleOption option = _factory.GetStylesPreviewOption(PictureSlidesLabText.StyleNameBanner);
             Assert.AreEqual(PictureSlidesLabText.StyleNameBanner, option.StyleName);
             Assert.IsTrue(option.IsUseBannerStyle);
 
-            var options = GetOptions(PictureSlidesLabText.StyleNameBanner);
+            List<StyleOption> options = GetOptions(PictureSlidesLabText.StyleNameBanner);
             Assert.AreEqual(8,
                 GetExpectedCount(
                     GetOptionsProperty(options, "IsUseBannerStyle"), true));
@@ -99,11 +99,11 @@ namespace Test.UnitTest.PictureSlidesLab.ModelFactory
         [TestCategory("UT")]
         public void TestGetSpecialEffectOptions()
         {
-            var option = _factory.GetStylesPreviewOption(PictureSlidesLabText.StyleNameSpecialEffect);
+            StyleOption option = _factory.GetStylesPreviewOption(PictureSlidesLabText.StyleNameSpecialEffect);
             Assert.AreEqual(PictureSlidesLabText.StyleNameSpecialEffect, option.StyleName);
             Assert.IsTrue(option.IsUseSpecialEffectStyle);
 
-            var options = GetOptions(PictureSlidesLabText.StyleNameSpecialEffect);
+            List<StyleOption> options = GetOptions(PictureSlidesLabText.StyleNameSpecialEffect);
             Assert.AreEqual(8,
                 GetExpectedCount(
                     GetOptionsProperty(options, "IsUseSpecialEffectStyle"), true));
@@ -114,11 +114,11 @@ namespace Test.UnitTest.PictureSlidesLab.ModelFactory
         [TestCategory("UT")]
         public void TestGetOverlayOptions()
         {
-            var option = _factory.GetStylesPreviewOption(PictureSlidesLabText.StyleNameOverlay);
+            StyleOption option = _factory.GetStylesPreviewOption(PictureSlidesLabText.StyleNameOverlay);
             Assert.AreEqual(PictureSlidesLabText.StyleNameOverlay, option.StyleName);
             Assert.IsTrue(option.IsUseOverlayStyle);
 
-            var options = GetOptions(PictureSlidesLabText.StyleNameOverlay);
+            List<StyleOption> options = GetOptions(PictureSlidesLabText.StyleNameOverlay);
             Assert.AreEqual(8,
                 GetExpectedCount(
                     GetOptionsProperty(options, "IsUseOverlayStyle"), true));
@@ -132,11 +132,11 @@ namespace Test.UnitTest.PictureSlidesLab.ModelFactory
         [TestCategory("UT")]
         public void TestGetOutlineOptions()
         {
-            var option = _factory.GetStylesPreviewOption(PictureSlidesLabText.StyleNameOutline);
+            StyleOption option = _factory.GetStylesPreviewOption(PictureSlidesLabText.StyleNameOutline);
             Assert.AreEqual(PictureSlidesLabText.StyleNameOutline, option.StyleName);
             Assert.IsTrue(option.IsUseOutlineStyle);
 
-            var options = GetOptions(PictureSlidesLabText.StyleNameOutline);
+            List<StyleOption> options = GetOptions(PictureSlidesLabText.StyleNameOutline);
             Assert.AreEqual(8,
                 GetExpectedCount(
                     GetOptionsProperty(options, "IsUseOutlineStyle"), true));
@@ -147,11 +147,11 @@ namespace Test.UnitTest.PictureSlidesLab.ModelFactory
         [TestCategory("UT")]
         public void TestGetFrameOptions()
         {
-            var option = _factory.GetStylesPreviewOption(PictureSlidesLabText.StyleNameFrame);
+            StyleOption option = _factory.GetStylesPreviewOption(PictureSlidesLabText.StyleNameFrame);
             Assert.AreEqual(PictureSlidesLabText.StyleNameFrame, option.StyleName);
             Assert.IsTrue(option.IsUseFrameStyle);
 
-            var options = GetOptions(PictureSlidesLabText.StyleNameFrame);
+            List<StyleOption> options = GetOptions(PictureSlidesLabText.StyleNameFrame);
             Assert.AreEqual(8,
                 GetExpectedCount(
                     GetOptionsProperty(options, "IsUseFrameStyle"), true));
@@ -162,11 +162,11 @@ namespace Test.UnitTest.PictureSlidesLab.ModelFactory
         [TestCategory("UT")]
         public void TestGetCircleOptions()
         {
-            var option = _factory.GetStylesPreviewOption(PictureSlidesLabText.StyleNameCircle);
+            StyleOption option = _factory.GetStylesPreviewOption(PictureSlidesLabText.StyleNameCircle);
             Assert.AreEqual(PictureSlidesLabText.StyleNameCircle, option.StyleName);
             Assert.IsTrue(option.IsUseCircleStyle);
 
-            var options = GetOptions(PictureSlidesLabText.StyleNameCircle);
+            List<StyleOption> options = GetOptions(PictureSlidesLabText.StyleNameCircle);
             Assert.AreEqual(8,
                 GetExpectedCount(
                     GetOptionsProperty(options, "IsUseCircleStyle"), true));
@@ -177,11 +177,11 @@ namespace Test.UnitTest.PictureSlidesLab.ModelFactory
         [TestCategory("UT")]
         public void TestGetTriangleOptions()
         {
-            var option = _factory.GetStylesPreviewOption(PictureSlidesLabText.StyleNameTriangle);
+            StyleOption option = _factory.GetStylesPreviewOption(PictureSlidesLabText.StyleNameTriangle);
             Assert.AreEqual(PictureSlidesLabText.StyleNameTriangle, option.StyleName);
             Assert.IsTrue(option.IsUseTriangleStyle);
 
-            var options = GetOptions(PictureSlidesLabText.StyleNameTriangle);
+            List<StyleOption> options = GetOptions(PictureSlidesLabText.StyleNameTriangle);
             Assert.AreEqual(8,
                 GetExpectedCount(
                     GetOptionsProperty(options, "IsUseTriangleStyle"), true));
@@ -190,10 +190,10 @@ namespace Test.UnitTest.PictureSlidesLab.ModelFactory
 
         private List<StyleOption> GetOptions(string styleName)
         {
-            var options = _factory.GetStylesVariationOptions(styleName);
-            var variants = new StyleVariantsFactory().GetVariants(styleName);
+            List<StyleOption> options = _factory.GetStylesVariationOptions(styleName);
+            Dictionary<string, List<StyleVariant>> variants = new StyleVariantsFactory().GetVariants(styleName);
 
-            for (var i = 0; i < options.Count; i++)
+            for (int i = 0; i < options.Count; i++)
             {
                 variants[variants.Keys.First()][i].Apply(options[i]);
             }
@@ -203,12 +203,12 @@ namespace Test.UnitTest.PictureSlidesLab.ModelFactory
 
         private static List<object> GetOptionsProperty(List<StyleOption> options, string propertyName)
         {
-            var propList = new List<object>();
-            foreach (var option in options)
+            List<object> propList = new List<object>();
+            foreach (StyleOption option in options)
             {
-                var type = option.GetType();
-                var prop = type.GetProperty(propertyName);
-                var propValue = prop.GetValue(option, null);
+                System.Type type = option.GetType();
+                System.Reflection.PropertyInfo prop = type.GetProperty(propertyName);
+                object propValue = prop.GetValue(option, null);
                 propList.Add(propValue);
             }
             return propList;
@@ -216,8 +216,8 @@ namespace Test.UnitTest.PictureSlidesLab.ModelFactory
 
         private static int GetExpectedCount(List<object> list, object expected)
         {
-            var result = 0;
-            foreach (var item in list)
+            int result = 0;
+            foreach (object item in list)
             {
                 if (item.Equals(expected))
                 {

--- a/PowerPointLabs/Test/UnitTest/PictureSlidesLab/ModelFactory/StyleVariantsFactoryTest.cs
+++ b/PowerPointLabs/Test/UnitTest/PictureSlidesLab/ModelFactory/StyleVariantsFactoryTest.cs
@@ -106,14 +106,14 @@ namespace Test.UnitTest.PictureSlidesLab.ModelFactory
         [TestCategory("UT")]
         public void VerifyVariantsKeysCount()
         {
-            var allVariants =
+            IEnumerable<PowerPointLabs.PictureSlidesLab.ModelFactory.Variants.Interface.IStyleVariants> allVariants =
                 _variantsFactory.GetAllStyleVariants();
-            foreach (var styleVariants in allVariants)
+            foreach (PowerPointLabs.PictureSlidesLab.ModelFactory.Variants.Interface.IStyleVariants styleVariants in allVariants)
             {
                 foreach (IEnumerable<StyleVariant> styleVariant in styleVariants.GetVariantsForStyle().Values)
                 {
-                    var expectedKeyCount = styleVariant.First().GetVariants().Keys.Count;
-                    foreach (var variant in styleVariant)
+                    int expectedKeyCount = styleVariant.First().GetVariants().Keys.Count;
+                    foreach (StyleVariant variant in styleVariant)
                     {
                         Assert.AreEqual(expectedKeyCount, variant.GetVariants().Keys.Count,
                             "Keys Count should be same for a VariantWorker.");
@@ -124,21 +124,21 @@ namespace Test.UnitTest.PictureSlidesLab.ModelFactory
 
         private void VerifyVariants(string styleName)
         {
-            var variants =
+            Dictionary<string, List<StyleVariant>> variants =
                 _variantsFactory.GetVariants(styleName);
-            var option =
+            StyleOption option =
                 _optionsFactory.GetStylesPreviewOption(styleName);
 
-            var numberOfNoEffectVariant = 0;
-            foreach (var key in variants.Keys)
+            int numberOfNoEffectVariant = 0;
+            foreach (string key in variants.Keys)
             {
                 if (key == PictureSlidesLabText.VariantCategoryFontFamily)
                     continue;
 
-                var variant = variants[key];
+                List<StyleVariant> variant = variants[key];
                 Assert.AreEqual(8, variant.Count,
                     "Each variant/category/aspect/dimension should have 8 variations");
-                foreach (var styleVariants in variant)
+                foreach (StyleVariant styleVariants in variant)
                 {
                     if (styleVariants.IsNoEffect(option))
                     {
@@ -154,26 +154,26 @@ namespace Test.UnitTest.PictureSlidesLab.ModelFactory
 
         private void VerifyVariants2(string styleName)
         {
-            var variants =
+            Dictionary<string, List<StyleVariant>> variants =
                 _variantsFactory.GetVariants(styleName);
-            var options =
+            List<StyleOption> options =
                 _optionsFactory.GetStylesVariationOptions(styleName);
 
-            for (var i = 0; i < options.Count; i++)
+            for (int i = 0; i < options.Count; i++)
             {
                 variants[variants.Keys.First()][i].Apply(options[i]);
             }
 
-            var numberOfNoEffectVariant = 0;
-            foreach (var key in variants.Keys)
+            int numberOfNoEffectVariant = 0;
+            foreach (string key in variants.Keys)
             {
                 if (key == PictureSlidesLabText.VariantCategoryFontFamily)
                     continue;
 
-                var variant = variants[key];
-                foreach (var styleVariants in variant)
+                List<StyleVariant> variant = variants[key];
+                foreach (StyleVariant styleVariants in variant)
                 {
-                    foreach (var option in options)
+                    foreach (StyleOption option in options)
                     {
                         if (styleVariants.IsNoEffect(option))
                         {

--- a/PowerPointLabs/Test/UnitTest/PictureSlidesLab/Service/Effect/TextBoxesTest.cs
+++ b/PowerPointLabs/Test/UnitTest/PictureSlidesLab/Service/Effect/TextBoxesTest.cs
@@ -16,10 +16,10 @@ namespace Test.UnitTest.PictureSlidesLab.Service.Effect
         [TestCategory("UT")]
         public void TestGetTextBoxInfoForEmptyTextBoxes()
         {
-            var shapes = PpOperations.SelectShapesByPrefix("TextBox");
-            var textBoxes = new TextBoxes(shapes, 
+            Microsoft.Office.Interop.PowerPoint.ShapeRange shapes = PpOperations.SelectShapesByPrefix("TextBox");
+            TextBoxes textBoxes = new TextBoxes(shapes, 
                 Pres.PageSetup.SlideWidth, Pres.PageSetup.SlideHeight);
-            var textBoxInfo = textBoxes.GetTextBoxesInfo();
+            TextBoxInfo textBoxInfo = textBoxes.GetTextBoxesInfo();
             Assert.AreEqual(null, textBoxInfo);
         }
 
@@ -28,10 +28,10 @@ namespace Test.UnitTest.PictureSlidesLab.Service.Effect
         public void TestGetTextBoxInfo()
         {
             PpOperations.SelectSlide(2);
-            var shapes = PpOperations.SelectShapesByPrefix("TextBox");
-            var textBoxes = new TextBoxes(shapes,
+            Microsoft.Office.Interop.PowerPoint.ShapeRange shapes = PpOperations.SelectShapesByPrefix("TextBox");
+            TextBoxes textBoxes = new TextBoxes(shapes,
                 Pres.PageSetup.SlideWidth, Pres.PageSetup.SlideHeight);
-            var textBoxInfo = textBoxes.GetTextBoxesInfo();
+            TextBoxInfo textBoxInfo = textBoxes.GetTextBoxesInfo();
 
             Assert.IsTrue(SlideUtil.IsRoughlySame(57.5200043f, textBoxInfo.Height));
             Assert.IsTrue(SlideUtil.IsRoughlySame(68.2f, textBoxInfo.Left));
@@ -50,15 +50,15 @@ namespace Test.UnitTest.PictureSlidesLab.Service.Effect
         public void TestStartBoxing()
         {
             PpOperations.SelectSlide(2);
-            var shapes = PpOperations.SelectShapesByPrefix("TextBox");
-            var textBoxes = new TextBoxes(shapes,
+            Microsoft.Office.Interop.PowerPoint.ShapeRange shapes = PpOperations.SelectShapesByPrefix("TextBox");
+            TextBoxes textBoxes = new TextBoxes(shapes,
                 Pres.PageSetup.SlideWidth, Pres.PageSetup.SlideHeight);
 
             textBoxes
                 .SetAlignment(Alignment.Centre)
                 .SetPosition(Position.Left)
                 .StartBoxing();
-            var textBoxInfo = textBoxes.GetTextBoxesInfo();
+            TextBoxInfo textBoxInfo = textBoxes.GetTextBoxesInfo();
             Assert.IsTrue(SlideUtil.IsRoughlySame(57.5200043f, textBoxInfo.Height));
             Assert.IsTrue(SlideUtil.IsRoughlySame(25f, textBoxInfo.Left));
             Assert.IsTrue(SlideUtil.IsRoughlySame(241.240036f, textBoxInfo.Top));
@@ -102,8 +102,8 @@ namespace Test.UnitTest.PictureSlidesLab.Service.Effect
         public void TestStartBoxingWithTextWrapping()
         {
             PpOperations.SelectSlide(2);
-            var shapes = PpOperations.SelectShapesByPrefix("TextBox");
-            var textBoxes = new TextBoxes(shapes,
+            Microsoft.Office.Interop.PowerPoint.ShapeRange shapes = PpOperations.SelectShapesByPrefix("TextBox");
+            TextBoxes textBoxes = new TextBoxes(shapes,
                 Pres.PageSetup.SlideWidth, Pres.PageSetup.SlideHeight);
 
             textBoxes.StartTextWrapping();
@@ -113,7 +113,7 @@ namespace Test.UnitTest.PictureSlidesLab.Service.Effect
                 .SetPosition(Position.Left)
                 .StartBoxing();
 
-            var textBoxInfo = textBoxes.GetTextBoxesInfo();
+            TextBoxInfo textBoxInfo = textBoxes.GetTextBoxesInfo();
             Assert.IsTrue(SlideUtil.IsRoughlySame(105.040009f, textBoxInfo.Height));
             Assert.IsTrue(SlideUtil.IsRoughlySame(25.00004f, textBoxInfo.Left));
             Assert.IsTrue(SlideUtil.IsRoughlySame(217.480042f, textBoxInfo.Top));

--- a/PowerPointLabs/Test/UnitTest/PictureSlidesLab/Service/EffectsDesignerTest.cs
+++ b/PowerPointLabs/Test/UnitTest/PictureSlidesLab/Service/EffectsDesignerTest.cs
@@ -46,7 +46,7 @@ namespace Test.UnitTest.PictureSlidesLab.Service
         public void TestInsertImageReference()
         {
             // constructor for producing preview image
-            var ed = new EffectsDesigner(_processingSlide);
+            EffectsDesigner ed = new EffectsDesigner(_processingSlide);
             ed.PreparePreviewing(
                 _contentSlide, 
                 Pres.PageSetup.SlideWidth, Pres.PageSetup.SlideHeight, 
@@ -62,7 +62,7 @@ namespace Test.UnitTest.PictureSlidesLab.Service
                 .Contains(Link));
 
             ed.ApplyImageReferenceInsertion(Link, "Calibri", "#000000", 14, "", Alignment.Left);
-            var refShape = PpOperations.SelectShapesByPrefix(
+            Microsoft.Office.Interop.PowerPoint.ShapeRange refShape = PpOperations.SelectShapesByPrefix(
                 EffectsDesigner.ShapeNamePrefix + "_" + EffectName.ImageReference);
             Assert.IsTrue(
                 refShape.TextFrame2.TextRange.Text.Contains(Link));
@@ -72,7 +72,7 @@ namespace Test.UnitTest.PictureSlidesLab.Service
         [TestCategory("UT")]
         public void TestInsertBackground()
         {
-            var bgShape = _designer.ApplyBackgroundEffect();
+            Microsoft.Office.Interop.PowerPoint.Shape bgShape = _designer.ApplyBackgroundEffect();
             Assert.IsTrue(bgShape.Name.StartsWith(
                 EffectsDesigner.ShapeNamePrefix + "_" + EffectName.BackGround));
             Assert.AreEqual(MsoShapeType.msoPicture, bgShape.Type);
@@ -88,8 +88,8 @@ namespace Test.UnitTest.PictureSlidesLab.Service
         {
             _designer.ApplyTextEffect("Tahoma", "#123456", 3, 0);
             PpOperations.SelectSlide(1);
-            var shape = PpOperations.SelectShapesByPrefix("Title");
-            var originalTextSize = float.Parse(shape.Tags[Tag.OriginalFontSize]);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange shape = PpOperations.SelectShapesByPrefix("Title");
+            float originalTextSize = float.Parse(shape.Tags[Tag.OriginalFontSize]);
 
             Assert.AreEqual("Tahoma", shape.TextEffect.FontName);
             Assert.AreEqual(originalTextSize + 3, shape.TextEffect.FontSize);
@@ -100,7 +100,7 @@ namespace Test.UnitTest.PictureSlidesLab.Service
         public void TestTextPositionAndAlignment()
         {
             _designer.ApplyTextPositionAndAlignment(Position.Left, Alignment.Auto);
-            var tbInfo = new TextBoxes(
+            TextBoxInfo tbInfo = new TextBoxes(
                 _contentSlide.Shapes.Range(), 
                 Pres.PageSetup.SlideWidth, 
                 Pres.PageSetup.SlideHeight)
@@ -126,7 +126,7 @@ namespace Test.UnitTest.PictureSlidesLab.Service
         [TestCategory("UT")]
         public void TestOverlayEffect()
         {
-            var shape = _designer.ApplyOverlayEffect("#000000", 35);
+            Microsoft.Office.Interop.PowerPoint.Shape shape = _designer.ApplyOverlayEffect("#000000", 35);
             Assert.IsTrue(shape.Name.StartsWith(
                 EffectsDesigner.ShapeNamePrefix + "_" + EffectName.Overlay));
             Assert.AreEqual(MsoShapeType.msoAutoShape, shape.Type);
@@ -141,7 +141,7 @@ namespace Test.UnitTest.PictureSlidesLab.Service
         public void TestBlurEffect()
         {
             TempPath.InitTempFolder();
-            var shape = _designer.ApplyBlurEffect();
+            Microsoft.Office.Interop.PowerPoint.Shape shape = _designer.ApplyBlurEffect();
 
             Assert.IsTrue(shape.Name.StartsWith(
                 EffectsDesigner.ShapeNamePrefix + "_" + EffectName.Blur));
@@ -155,7 +155,7 @@ namespace Test.UnitTest.PictureSlidesLab.Service
         {
             _designer.ApplyTextboxEffect("#000000", 35, 0);
             PpOperations.SelectSlide(1);
-            var shapeRange = PpOperations.SelectShapesByPrefix(
+            Microsoft.Office.Interop.PowerPoint.ShapeRange shapeRange = PpOperations.SelectShapesByPrefix(
                 EffectsDesigner.ShapeNamePrefix + "_" + EffectName.TextBox);
 
             Assert.AreEqual(1, shapeRange.Count);
@@ -166,7 +166,7 @@ namespace Test.UnitTest.PictureSlidesLab.Service
         [TestCategory("UT")]
         public void TestCircleRingsEffect()
         {
-            var shape = _designer.ApplyCircleRingsEffect("#000000", 35);
+            Microsoft.Office.Interop.PowerPoint.Shape shape = _designer.ApplyCircleRingsEffect("#000000", 35);
             Assert.IsTrue(shape.Name.StartsWith(
                 EffectsDesigner.ShapeNamePrefix + "_" + EffectName.Overlay));
             Assert.AreEqual(MsoShapeType.msoGroup, shape.Type);
@@ -177,7 +177,7 @@ namespace Test.UnitTest.PictureSlidesLab.Service
         [TestCategory("UT")]
         public void TestRectBannerEffect()
         {
-            var shape = _designer.ApplyRectBannerEffect(BannerDirection.Auto, Position.Left,
+            Microsoft.Office.Interop.PowerPoint.Shape shape = _designer.ApplyRectBannerEffect(BannerDirection.Auto, Position.Left,
                 null, "#000000", 35);
             Assert.IsTrue(shape.Name.StartsWith(
                 EffectsDesigner.ShapeNamePrefix + "_" + EffectName.Banner));
@@ -188,7 +188,7 @@ namespace Test.UnitTest.PictureSlidesLab.Service
         [TestCategory("UT")]
         public void TestRectOutlineEffect()
         {
-            var shape = _designer.ApplyRectOutlineEffect(null, "#000000", 35);
+            Microsoft.Office.Interop.PowerPoint.Shape shape = _designer.ApplyRectOutlineEffect(null, "#000000", 35);
             Assert.IsTrue(shape.Name.StartsWith(
                 EffectsDesigner.ShapeNamePrefix + "_" + EffectName.Banner));
             Assert.AreEqual(MsoShapeType.msoAutoShape, shape.Type);
@@ -198,7 +198,7 @@ namespace Test.UnitTest.PictureSlidesLab.Service
         [TestCategory("UT")]
         public void TestFrameEffect()
         {
-            var shape = _designer.ApplyAlbumFrameEffect("#000000", 35);
+            Microsoft.Office.Interop.PowerPoint.Shape shape = _designer.ApplyAlbumFrameEffect("#000000", 35);
             Assert.IsTrue(shape.Name.StartsWith(
                 EffectsDesigner.ShapeNamePrefix + "_" + EffectName.Overlay));
             Assert.AreEqual(MsoShapeType.msoAutoShape, shape.Type);
@@ -208,7 +208,7 @@ namespace Test.UnitTest.PictureSlidesLab.Service
         [TestCategory("UT")]
         public void TestTriangleEffect()
         {
-            var shape = _designer.ApplyTriangleEffect("#FFFFFF", "#000000", 35);
+            Microsoft.Office.Interop.PowerPoint.Shape shape = _designer.ApplyTriangleEffect("#FFFFFF", "#000000", 35);
             Assert.IsTrue(shape.Name.StartsWith(
                 EffectsDesigner.ShapeNamePrefix + "_" + EffectName.Overlay));
             Assert.AreEqual(MsoShapeType.msoGroup, shape.Type);
@@ -220,7 +220,7 @@ namespace Test.UnitTest.PictureSlidesLab.Service
         public void TestSpecialEffectsEffect()
         {
             TempPath.InitTempFolder();
-            var shape = _designer.ApplySpecialEffectEffect(MatrixFilters.GreyScale, true);
+            Microsoft.Office.Interop.PowerPoint.Shape shape = _designer.ApplySpecialEffectEffect(MatrixFilters.GreyScale, true);
             Assert.IsTrue(shape.Name.StartsWith(
                 EffectsDesigner.ShapeNamePrefix + "_" + EffectName.SpecialEffect));
             Assert.AreEqual(MsoShapeType.msoPicture, shape.Type);

--- a/PowerPointLabs/Test/UnitTest/PictureSlidesLab/Service/StylesDesignerTest.cs
+++ b/PowerPointLabs/Test/UnitTest/PictureSlidesLab/Service/StylesDesignerTest.cs
@@ -47,9 +47,9 @@ namespace Test.UnitTest.PictureSlidesLab.Service
         public void TestPreviewStyle()
         {
             TempPath.InitTempFolder();
-            foreach (var style in _factory.GetAllStylesPreviewOptions())
+            foreach (StyleOption style in _factory.GetAllStylesPreviewOptions())
             {
-                var previewInfo = _designer.PreviewApplyStyle(_sourceImage, _contentSlide,
+                PowerPointLabs.PictureSlidesLab.Service.Preview.PreviewInfo previewInfo = _designer.PreviewApplyStyle(_sourceImage, _contentSlide,
                     Pres.PageSetup.SlideWidth, Pres.PageSetup.SlideHeight, style);
                 SlideUtil.IsSameLooking(
                     new FileInfo(PathUtil.GetDocTestPath() +
@@ -64,11 +64,11 @@ namespace Test.UnitTest.PictureSlidesLab.Service
         public void TestApplyStyle()
         {
             TempPath.InitTempFolder();
-            foreach (var style in _factory.GetAllStylesPreviewOptions())
+            foreach (StyleOption style in _factory.GetAllStylesPreviewOptions())
             {
                 _designer.ApplyStyle(_sourceImage, _contentSlide,
                     Pres.PageSetup.SlideWidth, Pres.PageSetup.SlideHeight, style);
-                var imgPath = TempPath.GetPath("applystyle-" +
+                string imgPath = TempPath.GetPath("applystyle-" +
                                                Guid.NewGuid().ToString().Substring(0, 7) +
                                                "-" + DateTime.Now.GetHashCode());
                 _contentSlide.Export(imgPath, "JPG");

--- a/PowerPointLabs/Test/UnitTest/PictureSlidesLab/Util/ImageUtilTest.cs
+++ b/PowerPointLabs/Test/UnitTest/PictureSlidesLab/Util/ImageUtilTest.cs
@@ -18,11 +18,11 @@ namespace Test.UnitTest.PictureSlidesLab.Util
         {
             StoragePath.InitPersistentFolder();
             StoragePath.CleanPersistentFolder(new List<string>());
-            var thumbnail = 
+            string thumbnail = 
                 ImageUtil.GetThumbnailFromFullSizeImg(
                     PathUtil.GetDocTestPath() + "PictureSlidesLab\\koala.jpg");
-            var thumbnailImage = new Bitmap(thumbnail);
-            var fullsizeImage = new Bitmap(
+            Bitmap thumbnailImage = new Bitmap(thumbnail);
+            Bitmap fullsizeImage = new Bitmap(
                 PathUtil.GetDocTestPath() + "PictureSlidesLab\\koala.jpg");
             Assert.IsTrue(thumbnailImage.Width < fullsizeImage.Width 
                 && thumbnailImage.Height < fullsizeImage.Height);
@@ -32,7 +32,7 @@ namespace Test.UnitTest.PictureSlidesLab.Util
         [TestCategory("UT")]
         public void TestGetWidthAndHeight()
         {
-            var result = ImageUtil.GetWidthAndHeight(
+            string result = ImageUtil.GetWidthAndHeight(
                 PathUtil.GetDocTestPath() + "PictureSlidesLab\\koala.jpg");
             Assert.AreEqual("500 x 375", result);
         }

--- a/PowerPointLabs/Test/UnitTest/PictureSlidesLab/Util/UrlUtilTest.cs
+++ b/PowerPointLabs/Test/UnitTest/PictureSlidesLab/Util/UrlUtilTest.cs
@@ -43,8 +43,8 @@ namespace Test.UnitTest.PictureSlidesLab.Util
         [TestCategory("UT")]
         public void TestGetMetaInfo()
         {
-            var imgItem = new ImageItem();
-            var link = _googleImgLink.Clone() as string;
+            ImageItem imgItem = new ImageItem();
+            string link = _googleImgLink.Clone() as string;
             UrlUtil.GetMetaInfo(ref link, imgItem);
             Assert.AreEqual("http://tctechcrunch2011.files.wordpress.com/2011/05/tcdisrupt_tc-9.jpg",
                 link);
@@ -56,8 +56,8 @@ namespace Test.UnitTest.PictureSlidesLab.Util
         [TestCategory("UT")]
         public void TestGetMetaInfoWithDecoding()
         {
-            var imgItem = new ImageItem();
-            var link = _googleImgLinkThatNeedDecode.Clone() as string;
+            ImageItem imgItem = new ImageItem();
+            string link = _googleImgLinkThatNeedDecode.Clone() as string;
             UrlUtil.GetMetaInfo(ref link, imgItem);
             Assert.AreEqual("http://www.virgin.com/sites/default/files/Articles/Entrepreneur%20Getty/Entrepreneur_breakfast_getty.jpg",
                 link);

--- a/PowerPointLabs/Test/UnitTest/PictureSlidesLab/ViewModel/PictureSlidesLabWindowViewModelTest.cs
+++ b/PowerPointLabs/Test/UnitTest/PictureSlidesLab/ViewModel/PictureSlidesLabWindowViewModelTest.cs
@@ -14,8 +14,8 @@ namespace Test.UnitTest.PictureSlidesLab.ViewModel
         [TestCategory("UT")]
         public void TestPersistence()
         {
-            var expectedString = "Test Images Persistence";
-            var pslViewModel = CreateViewModel();
+            string expectedString = "Test Images Persistence";
+            PictureSlidesLabWindowViewModel pslViewModel = CreateViewModel();
             pslViewModel.ImageSelectionList.Clear();
             // the first image item should be placeholder for `Choose Pictures`
             // so add a dummy item here
@@ -27,7 +27,7 @@ namespace Test.UnitTest.PictureSlidesLab.ViewModel
             });
             pslViewModel.CleanUp();
 
-            var pslViewModel2 = CreateViewModel();
+            PictureSlidesLabWindowViewModel pslViewModel2 = CreateViewModel();
             Assert.AreEqual(expectedString, 
                 pslViewModel2.ImageSelectionList[1].ImageFile);
             pslViewModel2.ImageSelectionList.Clear();
@@ -40,8 +40,8 @@ namespace Test.UnitTest.PictureSlidesLab.ViewModel
         [TestCategory("UT")]
         public void TestPersistenceWhenNoFullsizeImage()
         {
-            var expectedString = "Test Images Persistence";
-            var pslViewModel = CreateViewModel();
+            string expectedString = "Test Images Persistence";
+            PictureSlidesLabWindowViewModel pslViewModel = CreateViewModel();
             pslViewModel.ImageSelectionList.Clear();
             // the first image item should be placeholder for `Choose Pictures`
             // so add a dummy item here
@@ -53,7 +53,7 @@ namespace Test.UnitTest.PictureSlidesLab.ViewModel
             });
             pslViewModel.CleanUp();
 
-            var pslViewModel2 = CreateViewModel();
+            PictureSlidesLabWindowViewModel pslViewModel2 = CreateViewModel();
             Assert.AreEqual(1, pslViewModel2.ImageSelectionList.Count);
             pslViewModel2.ImageSelectionList.Clear();
             // create a dummy item in order to clean up
@@ -63,8 +63,8 @@ namespace Test.UnitTest.PictureSlidesLab.ViewModel
 
         private PictureSlidesLabWindowViewModel CreateViewModel()
         {
-            var viewMock = new Mock<IPictureSlidesLabWindowView>();
-            var stylesDesignerMock = new Mock<IStylesDesigner>();
+            Mock<IPictureSlidesLabWindowView> viewMock = new Mock<IPictureSlidesLabWindowView>();
+            Mock<IStylesDesigner> stylesDesignerMock = new Mock<IStylesDesigner>();
             return new PictureSlidesLabWindowViewModel(
                 viewMock.Object,
                 stylesDesignerMock.Object);

--- a/PowerPointLabs/Test/UnitTest/PositionsLab/BasePositionsLabTest.cs
+++ b/PowerPointLabs/Test/UnitTest/PositionsLab/BasePositionsLabTest.cs
@@ -28,8 +28,8 @@ namespace Test.UnitTest.PositionsLab
         {
             for (int i = 1; i <= selected.Count; i++)
             {
-                var selectedShape = selected[i];
-                var simulatedShape = simulatedShapes[i];
+                Shape selectedShape = selected[i];
+                Shape simulatedShape = simulatedShapes[i];
 
                 selectedShape.IncrementLeft(ShapeUtil.GetCenterPoint(simulatedShape).X - ShapeUtil.GetCenterPoint(selectedShape).X);
                 selectedShape.IncrementTop(ShapeUtil.GetCenterPoint(simulatedShape).Y - ShapeUtil.GetCenterPoint(selectedShape).Y);
@@ -41,8 +41,8 @@ namespace Test.UnitTest.PositionsLab
         {
             for (int i = 1; i <= selected.Count; i++)
             {
-                var selectedShape = selected[i];
-                var simulatedShape = simulatedShapes[i];
+                Shape selectedShape = selected[i];
+                Shape simulatedShape = simulatedShapes[i];
 
                 selectedShape.IncrementLeft(ShapeUtil.GetCenterPoint(simulatedShape).X - originalPositions[i - 1, Left]);
                 selectedShape.IncrementTop(ShapeUtil.GetCenterPoint(simulatedShape).Y - originalPositions[i - 1, Top]);
@@ -57,8 +57,8 @@ namespace Test.UnitTest.PositionsLab
 
             for (int i = 1; i <= range.Count; i++)
             {
-                var shape = range[i];
-                var duplicated = shape.Duplicate()[1];
+                Shape shape = range[i];
+                Shape duplicated = shape.Duplicate()[1];
                 duplicated.Name = shape.Id + "";
                 duplicated.Left = shape.Left;
                 duplicated.Top = shape.Top;
@@ -70,11 +70,11 @@ namespace Test.UnitTest.PositionsLab
 
         protected float[,] SaveOriginalPositions(List<PPShape> shapes)
         {
-            var initialPositions = new float[shapes.Count, 2];
-            for (var i = 0; i < shapes.Count; i++)
+            float[,] initialPositions = new float[shapes.Count, 2];
+            for (int i = 0; i < shapes.Count; i++)
             {
-                var s = shapes[i];
-                var pt = s.VisualCenter;
+                PPShape s = shapes[i];
+                System.Drawing.PointF pt = s.VisualCenter;
                 initialPositions[i, Left] = pt.X;
                 initialPositions[i, Top] = pt.Y;
             }
@@ -84,9 +84,9 @@ namespace Test.UnitTest.PositionsLab
 
         protected List<PPShape> ConvertShapeRangeToPPShapeList(PowerPoint.ShapeRange range, int index)
         {
-            var shapes = new List<PPShape>();
+            List<PPShape> shapes = new List<PPShape>();
 
-            for (var i = index; i <= range.Count; i++)
+            for (int i = index; i <= range.Count; i++)
             {
                 shapes.Add(new PPShape(range[i]));
             }
@@ -96,9 +96,9 @@ namespace Test.UnitTest.PositionsLab
 
         protected List<PowerPoint.Shape> ConvertShapeRangeToShapeList(PowerPoint.ShapeRange range, int index)
         {
-            var shapes = new List<PowerPoint.Shape>();
+            List<Shape> shapes = new List<PowerPoint.Shape>();
 
-            for (var i = index; i <= range.Count; i++)
+            for (int i = index; i <= range.Count; i++)
             {
                 shapes.Add(range[i]);
             }
@@ -126,8 +126,8 @@ namespace Test.UnitTest.PositionsLab
                 }
                 else if (isConvertPPShape)
                 {
-                    var simulatedPPShapes = ConvertShapeRangeToPPShapeList(simulatedShapes, 1);
-                    var initialPositions = SaveOriginalPositions(simulatedPPShapes);
+                    List<PPShape> simulatedPPShapes = ConvertShapeRangeToPPShapeList(simulatedShapes, 1);
+                    float[,] initialPositions = SaveOriginalPositions(simulatedPPShapes);
 
                     positionsAction.Invoke(simulatedShapes);
 
@@ -173,8 +173,8 @@ namespace Test.UnitTest.PositionsLab
                 }
                 else
                 {
-                    var simulatedPPShapes = ConvertShapeRangeToPPShapeList(simulatedShapes, 1);
-                    var initialPositions = SaveOriginalPositions(simulatedPPShapes);
+                    List<PPShape> simulatedPPShapes = ConvertShapeRangeToPPShapeList(simulatedShapes, 1);
+                    float[,] initialPositions = SaveOriginalPositions(simulatedPPShapes);
 
                     positionsAction.Invoke(simulatedShapes, dimension);
 
@@ -214,8 +214,8 @@ namespace Test.UnitTest.PositionsLab
                 }
                 else
                 {
-                    var simulatedPPShapes = ConvertShapeRangeToPPShapeList(simulatedShapes, 1);
-                    var initialPositions = SaveOriginalPositions(simulatedPPShapes);
+                    List<PPShape> simulatedPPShapes = ConvertShapeRangeToPPShapeList(simulatedShapes, 1);
+                    float[,] initialPositions = SaveOriginalPositions(simulatedPPShapes);
 
                     positionsAction.Invoke(simulatedShapes, dimension1, dimension2);
 
@@ -248,8 +248,8 @@ namespace Test.UnitTest.PositionsLab
             try
             {
                 simulatedShapes = DuplicateShapes(selectedShapes);
-                var simulatedPPShapes = ConvertShapeRangeToPPShapeList(simulatedShapes, 1);
-                var initialPositions = SaveOriginalPositions(simulatedPPShapes);
+                List<PPShape> simulatedPPShapes = ConvertShapeRangeToPPShapeList(simulatedShapes, 1);
+                float[,] initialPositions = SaveOriginalPositions(simulatedPPShapes);
 
                 positionsAction.Invoke(simulatedPPShapes);
 
@@ -288,8 +288,8 @@ namespace Test.UnitTest.PositionsLab
                     SwapZOrder(simulatedShapes[i], selectedShapes[i]);
                 }
 
-                var simulatedPPShapes = ConvertShapeRangeToPPShapeList(simulatedShapes, 1);
-                var initialPositions = SaveOriginalPositions(simulatedPPShapes);
+                List<PPShape> simulatedPPShapes = ConvertShapeRangeToPPShapeList(simulatedShapes, 1);
+                float[,] initialPositions = SaveOriginalPositions(simulatedPPShapes);
 
                 positionsAction.Invoke(simulatedPPShapes, booleanVal);
 
@@ -321,8 +321,8 @@ namespace Test.UnitTest.PositionsLab
             try
             {
                 simulatedShapes = DuplicateShapes(selectedShapes);
-                var simulatedPPShapes = ConvertShapeRangeToPPShapeList(simulatedShapes, 1);
-                var initialPositions = SaveOriginalPositions(simulatedPPShapes);
+                List<PPShape> simulatedPPShapes = ConvertShapeRangeToPPShapeList(simulatedShapes, 1);
+                float[,] initialPositions = SaveOriginalPositions(simulatedPPShapes);
 
                 positionsAction.Invoke(simulatedPPShapes, dimension);
 
@@ -354,8 +354,8 @@ namespace Test.UnitTest.PositionsLab
             try
             {
                 simulatedShapes = DuplicateShapes(selectedShapes);
-                var simulatedPPShapes = ConvertShapeRangeToPPShapeList(simulatedShapes, 1);
-                var initialPositions = SaveOriginalPositions(simulatedPPShapes);
+                List<PPShape> simulatedPPShapes = ConvertShapeRangeToPPShapeList(simulatedShapes, 1);
+                float[,] initialPositions = SaveOriginalPositions(simulatedPPShapes);
 
                 positionsAction.Invoke(simulatedPPShapes, dimension1, dimension2);
 
@@ -387,8 +387,8 @@ namespace Test.UnitTest.PositionsLab
             try
             {
                 simulatedShapes = DuplicateShapes(selectedShapes);
-                var simulatedPPShapes = ConvertShapeRangeToPPShapeList(simulatedShapes, 1);
-                var initialPositions = SaveOriginalPositions(simulatedPPShapes);
+                List<PPShape> simulatedPPShapes = ConvertShapeRangeToPPShapeList(simulatedShapes, 1);
+                float[,] initialPositions = SaveOriginalPositions(simulatedPPShapes);
 
                 positionsAction.Invoke(simulatedPPShapes, dimension1, dimension2);
 
@@ -417,7 +417,7 @@ namespace Test.UnitTest.PositionsLab
 
             try
             {
-                var shapes = ConvertShapeRangeToShapeList(selectedShapes, 1);
+                List<Shape> shapes = ConvertShapeRangeToShapeList(selectedShapes, 1);
 
                 positionsAction.Invoke(shapes);
 

--- a/PowerPointLabs/Test/UnitTest/PositionsLab/PositionsLabAdjoinTest.cs
+++ b/PowerPointLabs/Test/UnitTest/PositionsLab/PositionsLabAdjoinTest.cs
@@ -55,13 +55,13 @@ namespace Test.UnitTest.PositionsLab
         {
             PositionsLabMain.AdjoinWithoutAligning();
             _shapeNames = new List<string> { UnrotatedRectangle, Oval, RotatedArrow, RotatedRectangle };
-            var actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
+            PowerPoint.ShapeRange actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
 
             Action<List<PPShape>> positionsAction = (shapes) => PositionsLabMain.AdjoinHorizontal(shapes);
             ExecutePositionsAction(positionsAction, actualShapes);
 
             PpOperations.SelectSlide(AdjoinHorizontalWithoutAlignNo);
-            var expectedShapes = PpOperations.SelectShapes(_shapeNames);
+            PowerPoint.ShapeRange expectedShapes = PpOperations.SelectShapes(_shapeNames);
 
             CheckShapes(expectedShapes, actualShapes);
         }
@@ -72,13 +72,13 @@ namespace Test.UnitTest.PositionsLab
         {
             PositionsLabMain.AdjoinWithoutAligning();
             _shapeNames = new List<string> { UnrotatedRectangle, Oval, RotatedArrow, RotatedRectangle };
-            var actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
+            PowerPoint.ShapeRange actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
 
             Action<List<PPShape>> positionsAction = (shapes) => PositionsLabMain.AdjoinVertical(shapes);
             ExecutePositionsAction(positionsAction, actualShapes);
 
             PpOperations.SelectSlide(AdjoinVerticalWithoutAlignNo);
-            var expectedShapes = PpOperations.SelectShapes(_shapeNames);
+            PowerPoint.ShapeRange expectedShapes = PpOperations.SelectShapes(_shapeNames);
 
             CheckShapes(expectedShapes, actualShapes);
         }
@@ -89,13 +89,13 @@ namespace Test.UnitTest.PositionsLab
         {
             PositionsLabMain.AdjoinWithoutAligning();
             _shapeNames = new List<string> { RotatedRectangle, UnrotatedRectangle, Oval, RotatedArrow };
-            var actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
+            PowerPoint.ShapeRange actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
 
             Action<List<PPShape>> positionsAction = (shapes) => PositionsLabMain.AdjoinHorizontal(shapes);
             ExecutePositionsAction(positionsAction, actualShapes);
 
             PpOperations.SelectSlide(AdjoinHorizontalWithoutAlignWithRotatedRef);
-            var expectedShapes = PpOperations.SelectShapes(_shapeNames);
+            PowerPoint.ShapeRange expectedShapes = PpOperations.SelectShapes(_shapeNames);
 
             CheckShapes(expectedShapes, actualShapes);
         }
@@ -106,13 +106,13 @@ namespace Test.UnitTest.PositionsLab
         {
             PositionsLabMain.AdjoinWithoutAligning();
             _shapeNames = new List<string> { RotatedRectangle, UnrotatedRectangle, Oval, RotatedArrow };
-            var actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
+            PowerPoint.ShapeRange actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
 
             Action<List<PPShape>> positionsAction = (shapes) => PositionsLabMain.AdjoinVertical(shapes);
             ExecutePositionsAction(positionsAction, actualShapes);
 
             PpOperations.SelectSlide(AdjoinVerticalWithoutAlignWithRotatedRef);
-            var expectedShapes = PpOperations.SelectShapes(_shapeNames);
+            PowerPoint.ShapeRange expectedShapes = PpOperations.SelectShapes(_shapeNames);
 
             CheckShapes(expectedShapes, actualShapes);
         }
@@ -123,13 +123,13 @@ namespace Test.UnitTest.PositionsLab
         {
             PositionsLabMain.AdjoinWithAligning();
             _shapeNames = new List<string> { UnrotatedRectangle, Oval, RotatedArrow, RotatedRectangle };
-            var actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
+            PowerPoint.ShapeRange actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
 
             Action<List<PPShape>> positionsAction = (shapes) => PositionsLabMain.AdjoinHorizontal(shapes);
             ExecutePositionsAction(positionsAction, actualShapes);
 
             PpOperations.SelectSlide(AdjoinHorizontalWithAlignNo);
-            var expectedShapes = PpOperations.SelectShapes(_shapeNames);
+            PowerPoint.ShapeRange expectedShapes = PpOperations.SelectShapes(_shapeNames);
 
             CheckShapes(expectedShapes, actualShapes);
         }
@@ -140,13 +140,13 @@ namespace Test.UnitTest.PositionsLab
         {
             PositionsLabMain.AdjoinWithAligning();
             _shapeNames = new List<string> { UnrotatedRectangle, Oval, RotatedArrow, RotatedRectangle };
-            var actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
+            PowerPoint.ShapeRange actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
 
             Action<List<PPShape>> positionsAction = (shapes) => PositionsLabMain.AdjoinVertical(shapes);
             ExecutePositionsAction(positionsAction, actualShapes);
 
             PpOperations.SelectSlide(AdjoinVerticalWithAlignNo);
-            var expectedShapes = PpOperations.SelectShapes(_shapeNames);
+            PowerPoint.ShapeRange expectedShapes = PpOperations.SelectShapes(_shapeNames);
 
             CheckShapes(expectedShapes, actualShapes);
         }
@@ -157,13 +157,13 @@ namespace Test.UnitTest.PositionsLab
         {
             PositionsLabMain.AdjoinWithAligning();
             _shapeNames = new List<string> { RotatedRectangle, UnrotatedRectangle, Oval, RotatedArrow };
-            var actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
+            PowerPoint.ShapeRange actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
 
             Action<List<PPShape>> positionsAction = (shapes) => PositionsLabMain.AdjoinHorizontal(shapes);
             ExecutePositionsAction(positionsAction, actualShapes);
 
             PpOperations.SelectSlide(AdjoinHorizontalWithAlignWithRotatedRef);
-            var expectedShapes = PpOperations.SelectShapes(_shapeNames);
+            PowerPoint.ShapeRange expectedShapes = PpOperations.SelectShapes(_shapeNames);
 
             CheckShapes(expectedShapes, actualShapes);
         }
@@ -174,13 +174,13 @@ namespace Test.UnitTest.PositionsLab
         {
             PositionsLabMain.AdjoinWithAligning();
             _shapeNames = new List<string> { RotatedRectangle, UnrotatedRectangle, Oval, RotatedArrow };
-            var actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
+            PowerPoint.ShapeRange actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
 
             Action<List<PPShape>> positionsAction = (shapes) => PositionsLabMain.AdjoinVertical(shapes);
             ExecutePositionsAction(positionsAction, actualShapes);
 
             PpOperations.SelectSlide(AdjoinVerticalWithAlignWithRotatedRef);
-            var expectedShapes = PpOperations.SelectShapes(_shapeNames);
+            PowerPoint.ShapeRange expectedShapes = PpOperations.SelectShapes(_shapeNames);
 
             CheckShapes(expectedShapes, actualShapes);
         }

--- a/PowerPointLabs/Test/UnitTest/PositionsLab/PositionsLabAlignTest.cs
+++ b/PowerPointLabs/Test/UnitTest/PositionsLab/PositionsLabAlignTest.cs
@@ -78,13 +78,13 @@ namespace Test.UnitTest.PositionsLab
         {
             PositionsLabSettings.AlignReference = PositionsLabSettings.AlignReferenceObject.Slide;
             _shapeNames = new List<string> { UnrotatedRectangle, Oval, RotatedArrow, RotatedRectangle };
-            var actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
+            PowerPoint.ShapeRange actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
 
             Action<PowerPoint.ShapeRange> positionsAction = shapes => PositionsLabMain.AlignLeft(shapes);
             ExecutePositionsAction(positionsAction, actualShapes);
 
             PpOperations.SelectSlide(AlignShapesLeftToSlideNo);
-            var expectedShapes = PpOperations.SelectShapes(_shapeNames);
+            PowerPoint.ShapeRange expectedShapes = PpOperations.SelectShapes(_shapeNames);
 
             CheckShapes(expectedShapes, actualShapes);
         }
@@ -95,14 +95,14 @@ namespace Test.UnitTest.PositionsLab
         {
             PositionsLabSettings.AlignReference = PositionsLabSettings.AlignReferenceObject.Slide;
             _shapeNames = new List<string> { UnrotatedRectangle, Oval, RotatedArrow, RotatedRectangle };
-            var actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
-            var slideWidth = Pres.PageSetup.SlideWidth;
+            PowerPoint.ShapeRange actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
+            float slideWidth = Pres.PageSetup.SlideWidth;
 
             Action<PowerPoint.ShapeRange, float> positionsAction = (shapes, width) => PositionsLabMain.AlignRight(shapes, width);
             ExecutePositionsAction(positionsAction, actualShapes, slideWidth);
 
             PpOperations.SelectSlide(AlignShapesRightToSlideNo);
-            var expectedShapes = PpOperations.SelectShapes(_shapeNames);
+            PowerPoint.ShapeRange expectedShapes = PpOperations.SelectShapes(_shapeNames);
 
             CheckShapes(expectedShapes, actualShapes);
         }
@@ -113,13 +113,13 @@ namespace Test.UnitTest.PositionsLab
         {
             PositionsLabSettings.AlignReference = PositionsLabSettings.AlignReferenceObject.Slide;
             _shapeNames = new List<string> { UnrotatedRectangle, Oval, RotatedArrow, RotatedRectangle };
-            var actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
+            PowerPoint.ShapeRange actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
 
             Action<PowerPoint.ShapeRange> positionsAction = shapes => PositionsLabMain.AlignTop(shapes);
             ExecutePositionsAction(positionsAction, actualShapes);
 
             PpOperations.SelectSlide(AlignShapesTopToSlideNo);
-            var expectedShapes = PpOperations.SelectShapes(_shapeNames);
+            PowerPoint.ShapeRange expectedShapes = PpOperations.SelectShapes(_shapeNames);
 
             CheckShapes(expectedShapes, actualShapes);
         }
@@ -130,14 +130,14 @@ namespace Test.UnitTest.PositionsLab
         {
             PositionsLabSettings.AlignReference = PositionsLabSettings.AlignReferenceObject.Slide;
             _shapeNames = new List<string> { UnrotatedRectangle, Oval, RotatedArrow, RotatedRectangle };
-            var actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
-            var slideHeight = Pres.PageSetup.SlideHeight;
+            PowerPoint.ShapeRange actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
+            float slideHeight = Pres.PageSetup.SlideHeight;
 
             Action<PowerPoint.ShapeRange, float> positionsAction = (shapes, height) => PositionsLabMain.AlignBottom(shapes, height);
             ExecutePositionsAction(positionsAction, actualShapes, slideHeight);
 
             PpOperations.SelectSlide(AlignShapesBottomToSlideNo);
-            var expectedShapes = PpOperations.SelectShapes(_shapeNames);
+            PowerPoint.ShapeRange expectedShapes = PpOperations.SelectShapes(_shapeNames);
 
             CheckShapes(expectedShapes, actualShapes);
         }
@@ -148,14 +148,14 @@ namespace Test.UnitTest.PositionsLab
         {
             PositionsLabSettings.AlignReference = PositionsLabSettings.AlignReferenceObject.Slide;
             _shapeNames = new List<string> { UnrotatedRectangle, Oval, RotatedArrow, RotatedRectangle };
-            var actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
-            var slideHeight = Pres.PageSetup.SlideHeight;
+            PowerPoint.ShapeRange actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
+            float slideHeight = Pres.PageSetup.SlideHeight;
 
             Action<PowerPoint.ShapeRange, float> positionsAction = (shapes, height) => PositionsLabMain.AlignHorizontalCenter(shapes, height);
             ExecutePositionsAction(positionsAction, actualShapes, slideHeight);
 
             PpOperations.SelectSlide(AlignShapesHorizontalToSlideNo);
-            var expectedShapes = PpOperations.SelectShapes(_shapeNames);
+            PowerPoint.ShapeRange expectedShapes = PpOperations.SelectShapes(_shapeNames);
 
             CheckShapes(expectedShapes, actualShapes);
         }
@@ -166,14 +166,14 @@ namespace Test.UnitTest.PositionsLab
         {
             PositionsLabSettings.AlignReference = PositionsLabSettings.AlignReferenceObject.Slide;
             _shapeNames = new List<string> { UnrotatedRectangle, Oval, RotatedArrow, RotatedRectangle };
-            var actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
-            var slideWidth = Pres.PageSetup.SlideWidth;
+            PowerPoint.ShapeRange actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
+            float slideWidth = Pres.PageSetup.SlideWidth;
 
             Action<PowerPoint.ShapeRange, float> positionsAction = (shapes, width) => PositionsLabMain.AlignVerticalCenter(shapes, width);
             ExecutePositionsAction(positionsAction, actualShapes, slideWidth);
 
             PpOperations.SelectSlide(AlignShapesVerticalToSlideNo);
-            var expectedShapes = PpOperations.SelectShapes(_shapeNames);
+            PowerPoint.ShapeRange expectedShapes = PpOperations.SelectShapes(_shapeNames);
 
             CheckShapes(expectedShapes, actualShapes);
         }
@@ -184,15 +184,15 @@ namespace Test.UnitTest.PositionsLab
         {
             PositionsLabSettings.AlignReference = PositionsLabSettings.AlignReferenceObject.Slide;
             _shapeNames = new List<string> { UnrotatedRectangle, Oval, RotatedArrow, RotatedRectangle };
-            var actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
-            var slideHeight = Pres.PageSetup.SlideHeight;
-            var slideWidth = Pres.PageSetup.SlideWidth;
+            PowerPoint.ShapeRange actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
+            float slideHeight = Pres.PageSetup.SlideHeight;
+            float slideWidth = Pres.PageSetup.SlideWidth;
 
             Action<PowerPoint.ShapeRange, float, float> positionsAction = (shapes, height, width) => PositionsLabMain.AlignCenter(shapes, height, width);
             ExecutePositionsAction(positionsAction, actualShapes, slideHeight, slideWidth);
 
             PpOperations.SelectSlide(AlignShapesCenterToSlideNo);
-            var expectedShapes = PpOperations.SelectShapes(_shapeNames);
+            PowerPoint.ShapeRange expectedShapes = PpOperations.SelectShapes(_shapeNames);
 
             CheckShapes(expectedShapes, actualShapes);
         }
@@ -203,13 +203,13 @@ namespace Test.UnitTest.PositionsLab
         {
             PositionsLabSettings.AlignReference = PositionsLabSettings.AlignReferenceObject.SelectedShape;
             _shapeNames = new List<string> { RotatedRectangle, UnrotatedRectangle, Oval, RotatedArrow };
-            var actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
+            PowerPoint.ShapeRange actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
 
             Action<PowerPoint.ShapeRange> positionsAction = shapes => PositionsLabMain.AlignLeft(shapes);
             ExecutePositionsAction(positionsAction, actualShapes);
 
             PpOperations.SelectSlide(AlignShapesLeftToRefShapeNo);
-            var expectedShapes = PpOperations.SelectShapes(_shapeNames);
+            PowerPoint.ShapeRange expectedShapes = PpOperations.SelectShapes(_shapeNames);
 
             CheckShapes(expectedShapes, actualShapes);
         }
@@ -220,14 +220,14 @@ namespace Test.UnitTest.PositionsLab
         {
             PositionsLabSettings.AlignReference = PositionsLabSettings.AlignReferenceObject.SelectedShape;
             _shapeNames = new List<string> { RotatedRectangle, UnrotatedRectangle, Oval, RotatedArrow };
-            var actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
-            var slideWidth = Pres.PageSetup.SlideWidth;
+            PowerPoint.ShapeRange actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
+            float slideWidth = Pres.PageSetup.SlideWidth;
 
             Action<PowerPoint.ShapeRange, float> positionsAction = (shapes, width) => PositionsLabMain.AlignRight(shapes, width);
             ExecutePositionsAction(positionsAction, actualShapes, slideWidth);
 
             PpOperations.SelectSlide(AlignShapesRightToRefShapeNo);
-            var expectedShapes = PpOperations.SelectShapes(_shapeNames);
+            PowerPoint.ShapeRange expectedShapes = PpOperations.SelectShapes(_shapeNames);
 
             CheckShapes(expectedShapes, actualShapes);
         }
@@ -238,13 +238,13 @@ namespace Test.UnitTest.PositionsLab
         {
             PositionsLabSettings.AlignReference = PositionsLabSettings.AlignReferenceObject.SelectedShape;
             _shapeNames = new List<string> { RotatedRectangle, UnrotatedRectangle, Oval, RotatedArrow };
-            var actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
+            PowerPoint.ShapeRange actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
 
             Action<PowerPoint.ShapeRange> positionsAction = shapes => PositionsLabMain.AlignTop(shapes);
             ExecutePositionsAction(positionsAction, actualShapes);
 
             PpOperations.SelectSlide(AlignShapesTopToRefShapeNo);
-            var expectedShapes = PpOperations.SelectShapes(_shapeNames);
+            PowerPoint.ShapeRange expectedShapes = PpOperations.SelectShapes(_shapeNames);
 
             CheckShapes(expectedShapes, actualShapes);
         }
@@ -255,14 +255,14 @@ namespace Test.UnitTest.PositionsLab
         {
             PositionsLabSettings.AlignReference = PositionsLabSettings.AlignReferenceObject.SelectedShape;
             _shapeNames = new List<string> { RotatedRectangle, UnrotatedRectangle, Oval, RotatedArrow };
-            var actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
-            var slideHeight = Pres.PageSetup.SlideHeight;
+            PowerPoint.ShapeRange actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
+            float slideHeight = Pres.PageSetup.SlideHeight;
 
             Action<PowerPoint.ShapeRange, float> positionsAction = (shapes, height) => PositionsLabMain.AlignBottom(shapes, height);
             ExecutePositionsAction(positionsAction, actualShapes, slideHeight);
 
             PpOperations.SelectSlide(AlignShapesBottomToRefShapeNo);
-            var expectedShapes = PpOperations.SelectShapes(_shapeNames);
+            PowerPoint.ShapeRange expectedShapes = PpOperations.SelectShapes(_shapeNames);
 
             CheckShapes(expectedShapes, actualShapes);
         }
@@ -273,14 +273,14 @@ namespace Test.UnitTest.PositionsLab
         {
             PositionsLabSettings.AlignReference = PositionsLabSettings.AlignReferenceObject.SelectedShape;
             _shapeNames = new List<string> { RotatedRectangle, UnrotatedRectangle, Oval, RotatedArrow };
-            var actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
-            var slideHeight = Pres.PageSetup.SlideHeight;
+            PowerPoint.ShapeRange actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
+            float slideHeight = Pres.PageSetup.SlideHeight;
 
             Action<PowerPoint.ShapeRange, float> positionsAction = (shapes, height) => PositionsLabMain.AlignHorizontalCenter(shapes, height);
             ExecutePositionsAction(positionsAction, actualShapes, slideHeight);
 
             PpOperations.SelectSlide(AlignShapesHorizontalToRefShapeNo);
-            var expectedShapes = PpOperations.SelectShapes(_shapeNames);
+            PowerPoint.ShapeRange expectedShapes = PpOperations.SelectShapes(_shapeNames);
 
             CheckShapes(expectedShapes, actualShapes);
         }
@@ -291,14 +291,14 @@ namespace Test.UnitTest.PositionsLab
         {
             PositionsLabSettings.AlignReference = PositionsLabSettings.AlignReferenceObject.SelectedShape;
             _shapeNames = new List<string> { RotatedRectangle, UnrotatedRectangle, Oval, RotatedArrow };
-            var actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
-            var slideWidth = Pres.PageSetup.SlideWidth;
+            PowerPoint.ShapeRange actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
+            float slideWidth = Pres.PageSetup.SlideWidth;
 
             Action<PowerPoint.ShapeRange, float> positionsAction = (shapes, width) => PositionsLabMain.AlignVerticalCenter(shapes, width);
             ExecutePositionsAction(positionsAction, actualShapes, slideWidth);
 
             PpOperations.SelectSlide(AlignShapesVerticalToRefShapeNo);
-            var expectedShapes = PpOperations.SelectShapes(_shapeNames);
+            PowerPoint.ShapeRange expectedShapes = PpOperations.SelectShapes(_shapeNames);
 
             CheckShapes(expectedShapes, actualShapes);
         }
@@ -309,15 +309,15 @@ namespace Test.UnitTest.PositionsLab
         {
             PositionsLabSettings.AlignReference = PositionsLabSettings.AlignReferenceObject.SelectedShape;
             _shapeNames = new List<string> { RotatedRectangle, UnrotatedRectangle, Oval, RotatedArrow };
-            var actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
-            var slideHeight = Pres.PageSetup.SlideHeight;
-            var slideWidth = Pres.PageSetup.SlideWidth;
+            PowerPoint.ShapeRange actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
+            float slideHeight = Pres.PageSetup.SlideHeight;
+            float slideWidth = Pres.PageSetup.SlideWidth;
 
             Action<PowerPoint.ShapeRange, float, float> positionsAction = (shapes, height, width) => PositionsLabMain.AlignCenter(shapes, height, width);
             ExecutePositionsAction(positionsAction, actualShapes, slideHeight, slideWidth);
 
             PpOperations.SelectSlide(AlignShapesCenterToRefShapeNo);
-            var expectedShapes = PpOperations.SelectShapes(_shapeNames);
+            PowerPoint.ShapeRange expectedShapes = PpOperations.SelectShapes(_shapeNames);
 
             CheckShapes(expectedShapes, actualShapes);
         }
@@ -328,11 +328,11 @@ namespace Test.UnitTest.PositionsLab
         {
             PositionsLabSettings.AlignReference = PositionsLabSettings.AlignReferenceObject.PowerpointDefaults;
             _shapeNames = new List<string> { RotatedRectangle };
-            var actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
+            PowerPoint.ShapeRange actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
             PositionsLabMain.AlignLeft(actualShapes);
 
             PpOperations.SelectSlide(AlignOneShapeLeftDefaultNo);
-            var expectedShapes = PpOperations.SelectShapes(_shapeNames);
+            PowerPoint.ShapeRange expectedShapes = PpOperations.SelectShapes(_shapeNames);
 
             CheckShapes(expectedShapes, actualShapes);
         }
@@ -343,12 +343,12 @@ namespace Test.UnitTest.PositionsLab
         {
             PositionsLabSettings.AlignReference = PositionsLabSettings.AlignReferenceObject.PowerpointDefaults;
             _shapeNames = new List<string> { RotatedRectangle };
-            var actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
-            var slideWidth = Pres.PageSetup.SlideWidth;
+            PowerPoint.ShapeRange actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
+            float slideWidth = Pres.PageSetup.SlideWidth;
             PositionsLabMain.AlignRight(actualShapes, slideWidth);
 
             PpOperations.SelectSlide(AlignOneShapeRightDefaultNo);
-            var expectedShapes = PpOperations.SelectShapes(_shapeNames);
+            PowerPoint.ShapeRange expectedShapes = PpOperations.SelectShapes(_shapeNames);
 
             CheckShapes(expectedShapes, actualShapes);
         }
@@ -359,11 +359,11 @@ namespace Test.UnitTest.PositionsLab
         {
             PositionsLabSettings.AlignReference = PositionsLabSettings.AlignReferenceObject.PowerpointDefaults;
             _shapeNames = new List<string> { RotatedRectangle };
-            var actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
+            PowerPoint.ShapeRange actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
             PositionsLabMain.AlignTop(actualShapes);
 
             PpOperations.SelectSlide(AlignOneShapeTopDefaultNo);
-            var expectedShapes = PpOperations.SelectShapes(_shapeNames);
+            PowerPoint.ShapeRange expectedShapes = PpOperations.SelectShapes(_shapeNames);
 
             CheckShapes(expectedShapes, actualShapes);
         }
@@ -374,12 +374,12 @@ namespace Test.UnitTest.PositionsLab
         {
             PositionsLabSettings.AlignReference = PositionsLabSettings.AlignReferenceObject.PowerpointDefaults;
             _shapeNames = new List<string> { RotatedRectangle };
-            var actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
-            var slideHeight = Pres.PageSetup.SlideHeight;
+            PowerPoint.ShapeRange actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
+            float slideHeight = Pres.PageSetup.SlideHeight;
             PositionsLabMain.AlignBottom(actualShapes, slideHeight);
 
             PpOperations.SelectSlide(AlignOneShapeBottomDefaultNo);
-            var expectedShapes = PpOperations.SelectShapes(_shapeNames);
+            PowerPoint.ShapeRange expectedShapes = PpOperations.SelectShapes(_shapeNames);
 
             CheckShapes(expectedShapes, actualShapes);
         }
@@ -390,12 +390,12 @@ namespace Test.UnitTest.PositionsLab
         {
             PositionsLabSettings.AlignReference = PositionsLabSettings.AlignReferenceObject.PowerpointDefaults;
             _shapeNames = new List<string> { RotatedRectangle };
-            var actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
-            var slideHeight = Pres.PageSetup.SlideHeight;
+            PowerPoint.ShapeRange actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
+            float slideHeight = Pres.PageSetup.SlideHeight;
             PositionsLabMain.AlignHorizontalCenter(actualShapes, slideHeight);
 
             PpOperations.SelectSlide(AlignOneShapeHorizontalDefaultNo);
-            var expectedShapes = PpOperations.SelectShapes(_shapeNames);
+            PowerPoint.ShapeRange expectedShapes = PpOperations.SelectShapes(_shapeNames);
 
             CheckShapes(expectedShapes, actualShapes);
         }
@@ -406,12 +406,12 @@ namespace Test.UnitTest.PositionsLab
         {
             PositionsLabSettings.AlignReference = PositionsLabSettings.AlignReferenceObject.PowerpointDefaults;
             _shapeNames = new List<string> { RotatedRectangle };
-            var actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
-            var slideWidth = Pres.PageSetup.SlideWidth;
+            PowerPoint.ShapeRange actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
+            float slideWidth = Pres.PageSetup.SlideWidth;
             PositionsLabMain.AlignVerticalCenter(actualShapes, slideWidth);
 
             PpOperations.SelectSlide(AlignOneShapeVerticalDefaultNo);
-            var expectedShapes = PpOperations.SelectShapes(_shapeNames);
+            PowerPoint.ShapeRange expectedShapes = PpOperations.SelectShapes(_shapeNames);
 
             CheckShapes(expectedShapes, actualShapes);
         }
@@ -422,13 +422,13 @@ namespace Test.UnitTest.PositionsLab
         {
             PositionsLabSettings.AlignReference = PositionsLabSettings.AlignReferenceObject.PowerpointDefaults;
             _shapeNames = new List<string> { RotatedRectangle };
-            var actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
-            var slideHeight = Pres.PageSetup.SlideHeight;
-            var slideWidth = Pres.PageSetup.SlideWidth;
+            PowerPoint.ShapeRange actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
+            float slideHeight = Pres.PageSetup.SlideHeight;
+            float slideWidth = Pres.PageSetup.SlideWidth;
             PositionsLabMain.AlignCenter(actualShapes, slideHeight, slideWidth);
 
             PpOperations.SelectSlide(AlignOneShapeCenterDefaultNo);
-            var expectedShapes = PpOperations.SelectShapes(_shapeNames);
+            PowerPoint.ShapeRange expectedShapes = PpOperations.SelectShapes(_shapeNames);
 
             CheckShapes(expectedShapes, actualShapes);
         }
@@ -439,11 +439,11 @@ namespace Test.UnitTest.PositionsLab
         {
             PositionsLabSettings.AlignReference = PositionsLabSettings.AlignReferenceObject.PowerpointDefaults;
             _shapeNames = new List<string> { UnrotatedRectangle, Oval, RotatedArrow, RotatedRectangle };
-            var actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
+            PowerPoint.ShapeRange actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
             PositionsLabMain.AlignLeft(actualShapes);
 
             PpOperations.SelectSlide(AlignShapesLeftDefaultNo);
-            var expectedShapes = PpOperations.SelectShapes(_shapeNames);
+            PowerPoint.ShapeRange expectedShapes = PpOperations.SelectShapes(_shapeNames);
 
             CheckShapes(expectedShapes, actualShapes);
         }
@@ -454,12 +454,12 @@ namespace Test.UnitTest.PositionsLab
         {
             PositionsLabSettings.AlignReference = PositionsLabSettings.AlignReferenceObject.PowerpointDefaults;
             _shapeNames = new List<string> { UnrotatedRectangle, Oval, RotatedArrow, RotatedRectangle };
-            var actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
-            var slideWidth = Pres.PageSetup.SlideWidth;
+            PowerPoint.ShapeRange actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
+            float slideWidth = Pres.PageSetup.SlideWidth;
             PositionsLabMain.AlignRight(actualShapes, slideWidth);
 
             PpOperations.SelectSlide(AlignShapesRightDefaultNo);
-            var expectedShapes = PpOperations.SelectShapes(_shapeNames);
+            PowerPoint.ShapeRange expectedShapes = PpOperations.SelectShapes(_shapeNames);
 
             CheckShapes(expectedShapes, actualShapes);
         }
@@ -470,11 +470,11 @@ namespace Test.UnitTest.PositionsLab
         {
             PositionsLabSettings.AlignReference = PositionsLabSettings.AlignReferenceObject.PowerpointDefaults;
             _shapeNames = new List<string> { UnrotatedRectangle, Oval, RotatedArrow, RotatedRectangle };
-            var actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
+            PowerPoint.ShapeRange actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
             PositionsLabMain.AlignTop(actualShapes);
 
             PpOperations.SelectSlide(AlignShapesTopDefaultNo);
-            var expectedShapes = PpOperations.SelectShapes(_shapeNames);
+            PowerPoint.ShapeRange expectedShapes = PpOperations.SelectShapes(_shapeNames);
 
             CheckShapes(expectedShapes, actualShapes);
         }
@@ -485,12 +485,12 @@ namespace Test.UnitTest.PositionsLab
         {
             PositionsLabSettings.AlignReference = PositionsLabSettings.AlignReferenceObject.PowerpointDefaults;
             _shapeNames = new List<string> { UnrotatedRectangle, Oval, RotatedArrow, RotatedRectangle };
-            var actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
-            var slideHeight = Pres.PageSetup.SlideHeight;
+            PowerPoint.ShapeRange actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
+            float slideHeight = Pres.PageSetup.SlideHeight;
             PositionsLabMain.AlignBottom(actualShapes, slideHeight);
 
             PpOperations.SelectSlide(AlignShapesBottomDefaultNo);
-            var expectedShapes = PpOperations.SelectShapes(_shapeNames);
+            PowerPoint.ShapeRange expectedShapes = PpOperations.SelectShapes(_shapeNames);
 
             CheckShapes(expectedShapes, actualShapes);
         }
@@ -501,12 +501,12 @@ namespace Test.UnitTest.PositionsLab
         {
             PositionsLabSettings.AlignReference = PositionsLabSettings.AlignReferenceObject.PowerpointDefaults;
             _shapeNames = new List<string> { UnrotatedRectangle, Oval, RotatedArrow, RotatedRectangle };
-            var actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
-            var slideHeight = Pres.PageSetup.SlideHeight;
+            PowerPoint.ShapeRange actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
+            float slideHeight = Pres.PageSetup.SlideHeight;
             PositionsLabMain.AlignHorizontalCenter(actualShapes, slideHeight);
 
             PpOperations.SelectSlide(AlignShapesHorizontalDefaultNo);
-            var expectedShapes = PpOperations.SelectShapes(_shapeNames);
+            PowerPoint.ShapeRange expectedShapes = PpOperations.SelectShapes(_shapeNames);
 
             CheckShapes(expectedShapes, actualShapes);
         }
@@ -517,12 +517,12 @@ namespace Test.UnitTest.PositionsLab
         {
             PositionsLabSettings.AlignReference = PositionsLabSettings.AlignReferenceObject.PowerpointDefaults;
             _shapeNames = new List<string> { UnrotatedRectangle, Oval, RotatedArrow, RotatedRectangle };
-            var actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
-            var slideWidth = Pres.PageSetup.SlideWidth;
+            PowerPoint.ShapeRange actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
+            float slideWidth = Pres.PageSetup.SlideWidth;
             PositionsLabMain.AlignVerticalCenter(actualShapes, slideWidth);
 
             PpOperations.SelectSlide(AlignShapesVerticalDefaultNo);
-            var expectedShapes = PpOperations.SelectShapes(_shapeNames);
+            PowerPoint.ShapeRange expectedShapes = PpOperations.SelectShapes(_shapeNames);
 
             CheckShapes(expectedShapes, actualShapes);
         }
@@ -533,13 +533,13 @@ namespace Test.UnitTest.PositionsLab
         {
             PositionsLabSettings.AlignReference = PositionsLabSettings.AlignReferenceObject.PowerpointDefaults;
             _shapeNames = new List<string> { UnrotatedRectangle, Oval, RotatedArrow, RotatedRectangle };
-            var actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
-            var slideHeight = Pres.PageSetup.SlideHeight;
-            var slideWidth = Pres.PageSetup.SlideWidth;
+            PowerPoint.ShapeRange actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
+            float slideHeight = Pres.PageSetup.SlideHeight;
+            float slideWidth = Pres.PageSetup.SlideWidth;
             PositionsLabMain.AlignCenter(actualShapes, slideHeight, slideWidth);
 
             PpOperations.SelectSlide(AlignShapesCenterDefaultNo);
-            var expectedShapes = PpOperations.SelectShapes(_shapeNames);
+            PowerPoint.ShapeRange expectedShapes = PpOperations.SelectShapes(_shapeNames);
 
             CheckShapes(expectedShapes, actualShapes);
         }
@@ -548,13 +548,13 @@ namespace Test.UnitTest.PositionsLab
         [TestCategory("UT")]
         public void TestAlignRadial()
         {
-            var actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
+            PowerPoint.ShapeRange actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
 
             Action<PowerPoint.ShapeRange> positionsAction = (shapes) => PositionsLabMain.AlignRadial(shapes);
             ExecutePositionsAction(positionsAction, actualShapes, isConvertPPShape: false);
 
             PpOperations.SelectSlide(AlignShapesRadialNo);
-            var expectedShapes = PpOperations.SelectShapes(_shapeNames);
+            PowerPoint.ShapeRange expectedShapes = PpOperations.SelectShapes(_shapeNames);
 
             CheckShapes(expectedShapes, actualShapes);
         }

--- a/PowerPointLabs/Test/UnitTest/PositionsLab/PositionsLabDistributeGridTest.cs
+++ b/PowerPointLabs/Test/UnitTest/PositionsLab/PositionsLabDistributeGridTest.cs
@@ -80,13 +80,13 @@ namespace Test.UnitTest.PositionsLab
             PositionsLabSettings.DistributeGridAlignment = PositionsLabSettings.GridAlignment.AlignLeft;
 
             _shapeNames = new List<string> { Rect1, Rect2, Oval3, RoundRect4, Rect5, Rect6, Oval7, RoundRect8, Rect9, Rect10, Pic11, Pic12, Pic3, Rect16 };
-            var actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
+            PowerPoint.ShapeRange actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
 
             Action<List<PPShape>, int, int> positionsAction = (shapes, rowLength, colLength) => PositionsLabMain.DistributeGrid(shapes, rowLength, colLength);
             ExecutePositionsAction(positionsAction, actualShapes, 4, 4);
 
             PpOperations.SelectSlide(DistributeGridFirstCenter4x4Margin5Slide);
-            var expectedShapes = PpOperations.SelectShapes(_shapeNames);
+            PowerPoint.ShapeRange expectedShapes = PpOperations.SelectShapes(_shapeNames);
 
             CheckShapes(expectedShapes, actualShapes);
         }
@@ -104,13 +104,13 @@ namespace Test.UnitTest.PositionsLab
             PositionsLabSettings.DistributeGridAlignment = PositionsLabSettings.GridAlignment.AlignLeft;
 
             _shapeNames = new List<string> { Rect1, Rect2, Oval3, RoundRect4, Rect5, Rect6, Oval7, RoundRect8, Rect9, Rect10, Pic11, Pic12, Pic3, Rect16 };
-            var actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
+            PowerPoint.ShapeRange actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
 
             Action<List<PPShape>, int, int> positionsAction = (shapes, rowLength, colLength) => PositionsLabMain.DistributeGrid(shapes, rowLength, colLength);
             ExecutePositionsAction(positionsAction, actualShapes, 4, 4);
 
             PpOperations.SelectSlide(DistributeGridFirstCenter4x4Margin0LeftSlide);
-            var expectedShapes = PpOperations.SelectShapes(_shapeNames);
+            PowerPoint.ShapeRange expectedShapes = PpOperations.SelectShapes(_shapeNames);
 
             CheckShapes(expectedShapes, actualShapes);
         }
@@ -128,13 +128,13 @@ namespace Test.UnitTest.PositionsLab
             PositionsLabSettings.DistributeGridAlignment = PositionsLabSettings.GridAlignment.AlignCenter;
 
             _shapeNames = new List<string> { Rect1, Rect2, Oval3, RoundRect4, Rect5, Rect6, Oval7, RoundRect8, Rect9, Rect10, Pic11, Pic12, Pic3, Rect16 };
-            var actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
+            PowerPoint.ShapeRange actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
 
             Action<List<PPShape>, int, int> positionsAction = (shapes, rowLength, colLength) => PositionsLabMain.DistributeGrid(shapes, rowLength, colLength);
             ExecutePositionsAction(positionsAction, actualShapes, 4, 4);
 
             PpOperations.SelectSlide(DistributeGridFirstCenter4x4Margin0CenterSlide);
-            var expectedShapes = PpOperations.SelectShapes(_shapeNames);
+            PowerPoint.ShapeRange expectedShapes = PpOperations.SelectShapes(_shapeNames);
 
             CheckShapes(expectedShapes, actualShapes);
         }
@@ -152,13 +152,13 @@ namespace Test.UnitTest.PositionsLab
             PositionsLabSettings.DistributeGridAlignment = PositionsLabSettings.GridAlignment.AlignRight;
 
             _shapeNames = new List<string> { Rect1, Rect2, Oval3, RoundRect4, Rect5, Rect6, Oval7, RoundRect8, Rect9, Rect10, Pic11, Pic12, Pic3, Rect16 };
-            var actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
+            PowerPoint.ShapeRange actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
 
             Action<List<PPShape>, int, int> positionsAction = (shapes, rowLength, colLength) => PositionsLabMain.DistributeGrid(shapes, rowLength, colLength);
             ExecutePositionsAction(positionsAction, actualShapes, 4, 4);
 
             PpOperations.SelectSlide(DistributeGridFirstCenter4x4Margin0RightSlide);
-            var expectedShapes = PpOperations.SelectShapes(_shapeNames);
+            PowerPoint.ShapeRange expectedShapes = PpOperations.SelectShapes(_shapeNames);
 
             CheckShapes(expectedShapes, actualShapes);
         }
@@ -176,13 +176,13 @@ namespace Test.UnitTest.PositionsLab
             PositionsLabSettings.DistributeGridAlignment = PositionsLabSettings.GridAlignment.AlignLeft;
 
             _shapeNames = new List<string> { Rect1, Rect2, Oval3, RoundRect4, Rect5, Rect6, Oval7, RoundRect8, Rect9, Rect10, Pic11, Pic12, Pic3, Rect16 };
-            var actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
+            PowerPoint.ShapeRange actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
 
             Action<List<PPShape>, int, int> positionsAction = (shapes, rowLength, colLength) => PositionsLabMain.DistributeGrid(shapes, rowLength, colLength);
             ExecutePositionsAction(positionsAction, actualShapes, 6, 3);
 
             PpOperations.SelectSlide(DistributeGridFirstCenter6x3Margin0TopSlide);
-            var expectedShapes = PpOperations.SelectShapes(_shapeNames);
+            PowerPoint.ShapeRange expectedShapes = PpOperations.SelectShapes(_shapeNames);
 
             CheckShapes(expectedShapes, actualShapes);
         }
@@ -200,13 +200,13 @@ namespace Test.UnitTest.PositionsLab
             PositionsLabSettings.DistributeGridAlignment = PositionsLabSettings.GridAlignment.AlignCenter;
 
             _shapeNames = new List<string> { Rect1, Rect2, Oval3, RoundRect4, Rect5, Rect6, Oval7, RoundRect8, Rect9, Rect10, Pic11, Pic12, Pic3, Rect16 };
-            var actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
+            PowerPoint.ShapeRange actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
 
             Action<List<PPShape>, int, int> positionsAction = (shapes, rowLength, colLength) => PositionsLabMain.DistributeGrid(shapes, rowLength, colLength);
             ExecutePositionsAction(positionsAction, actualShapes, 6, 3);
 
             PpOperations.SelectSlide(DistributeGridFirstCenter6x3Margin0CenterSlide);
-            var expectedShapes = PpOperations.SelectShapes(_shapeNames);
+            PowerPoint.ShapeRange expectedShapes = PpOperations.SelectShapes(_shapeNames);
 
             CheckShapes(expectedShapes, actualShapes);
         }
@@ -224,13 +224,13 @@ namespace Test.UnitTest.PositionsLab
             PositionsLabSettings.DistributeGridAlignment = PositionsLabSettings.GridAlignment.AlignRight;
 
             _shapeNames = new List<string> { Rect1, Rect2, Oval3, RoundRect4, Rect5, Rect6, Oval7, RoundRect8, Rect9, Rect10, Pic11, Pic12, Pic3, Rect16 };
-            var actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
+            PowerPoint.ShapeRange actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
 
             Action<List<PPShape>, int, int> positionsAction = (shapes, rowLength, colLength) => PositionsLabMain.DistributeGrid(shapes, rowLength, colLength);
             ExecutePositionsAction(positionsAction, actualShapes, 6, 3);
 
             PpOperations.SelectSlide(DistributeGridFirstCenter6x3Margin0BtmSlide);
-            var expectedShapes = PpOperations.SelectShapes(_shapeNames);
+            PowerPoint.ShapeRange expectedShapes = PpOperations.SelectShapes(_shapeNames);
 
             CheckShapes(expectedShapes, actualShapes);
         }
@@ -248,13 +248,13 @@ namespace Test.UnitTest.PositionsLab
             PositionsLabSettings.DistributeGridAlignment = PositionsLabSettings.GridAlignment.AlignLeft;
 
             _shapeNames = new List<string> { Rect1, Rect2, Oval3, RoundRect4, Rect5, Rect6, Oval7, RoundRect8, Rect9, Rect10, Pic11, Pic12, Pic3, Rect16 };
-            var actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
+            PowerPoint.ShapeRange actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
 
             Action<List<PPShape>, int, int> positionsAction = (shapes, rowLength, colLength) => PositionsLabMain.DistributeGrid(shapes, rowLength, colLength);
             ExecutePositionsAction(positionsAction, actualShapes, 4, 4);
 
             PpOperations.SelectSlide(DistributeGridFirstEdge4x4Margin5Slide);
-            var expectedShapes = PpOperations.SelectShapes(_shapeNames);
+            PowerPoint.ShapeRange expectedShapes = PpOperations.SelectShapes(_shapeNames);
 
             CheckShapes(expectedShapes, actualShapes);
         }
@@ -272,13 +272,13 @@ namespace Test.UnitTest.PositionsLab
             PositionsLabSettings.DistributeGridAlignment = PositionsLabSettings.GridAlignment.AlignLeft;
 
             _shapeNames = new List<string> { Rect1, Rect2, Oval3, RoundRect4, Rect5, Rect6, Oval7, RoundRect8, Rect9, Rect10, Pic11, Pic12, Pic3, Rect16 };
-            var actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
+            PowerPoint.ShapeRange actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
 
             Action<List<PPShape>, int, int> positionsAction = (shapes, rowLength, colLength) => PositionsLabMain.DistributeGrid(shapes, rowLength, colLength);
             ExecutePositionsAction(positionsAction, actualShapes, 4, 4);
 
             PpOperations.SelectSlide(DistributeGridFirstEdge4x4Margin0Slide);
-            var expectedShapes = PpOperations.SelectShapes(_shapeNames);
+            PowerPoint.ShapeRange expectedShapes = PpOperations.SelectShapes(_shapeNames);
 
             CheckShapes(expectedShapes, actualShapes);
         }
@@ -296,13 +296,13 @@ namespace Test.UnitTest.PositionsLab
             PositionsLabSettings.DistributeGridAlignment = PositionsLabSettings.GridAlignment.AlignLeft;
 
             _shapeNames = new List<string> { Rect1, Rect2, Oval3, RoundRect4, Rect5, Rect6, Oval7, RoundRect8, Rect9, Rect10, Pic11, Pic12, Pic3, Rect16 };
-            var actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
+            PowerPoint.ShapeRange actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
 
             Action<List<PPShape>, int, int> positionsAction = (shapes, rowLength, colLength) => PositionsLabMain.DistributeGrid(shapes, rowLength, colLength);
             ExecutePositionsAction(positionsAction, actualShapes, 6, 3);
 
             PpOperations.SelectSlide(DistributeGridFirstEdge6x3Margin0Slide);
-            var expectedShapes = PpOperations.SelectShapes(_shapeNames);
+            PowerPoint.ShapeRange expectedShapes = PpOperations.SelectShapes(_shapeNames);
 
             CheckShapes(expectedShapes, actualShapes);
         }
@@ -320,13 +320,13 @@ namespace Test.UnitTest.PositionsLab
             PositionsLabSettings.DistributeGridAlignment = PositionsLabSettings.GridAlignment.AlignLeft;
 
             _shapeNames = new List<string> { Rect1, Rect16, Rect2, Oval3, RoundRect4, Rect5, Rect6, Oval7, RoundRect8, Rect9, Rect10, Pic11, Pic12, Pic3 };
-            var actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
+            PowerPoint.ShapeRange actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
 
             Action<List<PPShape>, int, int> positionsAction = (shapes, rowLength, colLength) => PositionsLabMain.DistributeGrid(shapes, rowLength, colLength);
             ExecutePositionsAction(positionsAction, actualShapes, 4, 4);
 
             PpOperations.SelectSlide(DistributeGridFirstAndSecondCenter4x4Slide);
-            var expectedShapes = PpOperations.SelectShapes(_shapeNames);
+            PowerPoint.ShapeRange expectedShapes = PpOperations.SelectShapes(_shapeNames);
 
             CheckShapes(expectedShapes, actualShapes);
         }
@@ -344,13 +344,13 @@ namespace Test.UnitTest.PositionsLab
             PositionsLabSettings.DistributeGridAlignment = PositionsLabSettings.GridAlignment.AlignLeft;
 
             _shapeNames = new List<string> { Rect1, Rect16, Rect2, Oval3, RoundRect4, Rect5, Rect6, Oval7, RoundRect8, Rect9, Rect10, Pic11, Pic12, Pic3 };
-            var actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
+            PowerPoint.ShapeRange actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
 
             Action<List<PPShape>, int, int> positionsAction = (shapes, rowLength, colLength) => PositionsLabMain.DistributeGrid(shapes, rowLength, colLength);
             ExecutePositionsAction(positionsAction, actualShapes, 6, 3);
 
             PpOperations.SelectSlide(DistributeGridFirstAndSecondCenter6x3Slide);
-            var expectedShapes = PpOperations.SelectShapes(_shapeNames);
+            PowerPoint.ShapeRange expectedShapes = PpOperations.SelectShapes(_shapeNames);
 
             CheckShapes(expectedShapes, actualShapes);
         }
@@ -368,13 +368,13 @@ namespace Test.UnitTest.PositionsLab
             PositionsLabSettings.DistributeGridAlignment = PositionsLabSettings.GridAlignment.AlignLeft;
 
             _shapeNames = new List<string> { Rect1, Rect16, Rect2, Oval3, RoundRect4, Rect5, Rect6, Oval7, RoundRect8, Rect9, Rect10, Pic11, Pic12, Pic3 };
-            var actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
+            PowerPoint.ShapeRange actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
 
             Action<List<PPShape>, int, int> positionsAction = (shapes, rowLength, colLength) => PositionsLabMain.DistributeGrid(shapes, rowLength, colLength);
             ExecutePositionsAction(positionsAction, actualShapes, 4, 4);
 
             PpOperations.SelectSlide(DistributeGridFirstAndSecondEdge4x4Slide);
-            var expectedShapes = PpOperations.SelectShapes(_shapeNames);
+            PowerPoint.ShapeRange expectedShapes = PpOperations.SelectShapes(_shapeNames);
 
             CheckShapes(expectedShapes, actualShapes);
         }
@@ -392,13 +392,13 @@ namespace Test.UnitTest.PositionsLab
             PositionsLabSettings.DistributeGridAlignment = PositionsLabSettings.GridAlignment.AlignLeft;
 
             _shapeNames = new List<string> { Rect1, Rect16, Rect2, Oval3, RoundRect4, Rect5, Rect6, Oval7, RoundRect8, Rect9, Rect10, Pic11, Pic12, Pic3 };
-            var actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
+            PowerPoint.ShapeRange actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
 
             Action<List<PPShape>, int, int> positionsAction = (shapes, rowLength, colLength) => PositionsLabMain.DistributeGrid(shapes, rowLength, colLength);
             ExecutePositionsAction(positionsAction, actualShapes, 6, 3);
 
             PpOperations.SelectSlide(DistributeGridFirstAndSecondEdge6x3Slide);
-            var expectedShapes = PpOperations.SelectShapes(_shapeNames);
+            PowerPoint.ShapeRange expectedShapes = PpOperations.SelectShapes(_shapeNames);
 
             CheckShapes(expectedShapes, actualShapes);
         }

--- a/PowerPointLabs/Test/UnitTest/PositionsLab/PositionsLabDistributeRadialTest.cs
+++ b/PowerPointLabs/Test/UnitTest/PositionsLab/PositionsLabDistributeRadialTest.cs
@@ -65,13 +65,13 @@ namespace Test.UnitTest.PositionsLab
             PositionsLabSettings.DistributeSpaceReference = PositionsLabSettings.DistributeSpaceReferenceObject.ObjectBoundary;
             PositionsLabSettings.DistributeShapeOrientation = PositionsLabSettings.RadialShapeOrientationObject.Fixed;
 
-            var actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
+            PowerPoint.ShapeRange actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
 
             Action<PowerPoint.ShapeRange> positionsAction = (shapes) => PositionsLabMain.DistributeRadial(shapes);
             ExecutePositionsAction(positionsAction, actualShapes, isConvertPPShape: false);
 
             PpOperations.SelectSlide(DistributeAngleAtSecondWithEdgesFixedShapeOrientationSlide);
-            var expectedShapes = PpOperations.SelectShapes(_shapeNames);
+            PowerPoint.ShapeRange expectedShapes = PpOperations.SelectShapes(_shapeNames);
 
             CheckShapes(expectedShapes, actualShapes);
         }
@@ -84,13 +84,13 @@ namespace Test.UnitTest.PositionsLab
             PositionsLabSettings.DistributeSpaceReference = PositionsLabSettings.DistributeSpaceReferenceObject.ObjectBoundary;
             PositionsLabSettings.DistributeShapeOrientation = PositionsLabSettings.RadialShapeOrientationObject.Dynamic;
 
-            var actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
+            PowerPoint.ShapeRange actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
 
             Action<PowerPoint.ShapeRange> positionsAction = (shapes) => PositionsLabMain.DistributeRadial(shapes);
             ExecutePositionsAction(positionsAction, actualShapes, isConvertPPShape: false);
 
             PpOperations.SelectSlide(DistributeAngleAtSecondWithEdgesDynamicShapeOrientationSlide);
-            var expectedShapes = PpOperations.SelectShapes(_shapeNames);
+            PowerPoint.ShapeRange expectedShapes = PpOperations.SelectShapes(_shapeNames);
 
             CheckShapes(expectedShapes, actualShapes);
         }
@@ -103,13 +103,13 @@ namespace Test.UnitTest.PositionsLab
             PositionsLabSettings.DistributeSpaceReference = PositionsLabSettings.DistributeSpaceReferenceObject.ObjectCenter;
             PositionsLabSettings.DistributeShapeOrientation = PositionsLabSettings.RadialShapeOrientationObject.Fixed;
 
-            var actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
+            PowerPoint.ShapeRange actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
 
             Action<PowerPoint.ShapeRange> positionsAction = (shapes) => PositionsLabMain.DistributeRadial(shapes);
             ExecutePositionsAction(positionsAction, actualShapes, isConvertPPShape: false);
 
             PpOperations.SelectSlide(DistributeAngleAtSecondWithCenterFixedShapeOrientationSlide);
-            var expectedShapes = PpOperations.SelectShapes(_shapeNames);
+            PowerPoint.ShapeRange expectedShapes = PpOperations.SelectShapes(_shapeNames);
 
             CheckShapes(expectedShapes, actualShapes);
         }
@@ -122,13 +122,13 @@ namespace Test.UnitTest.PositionsLab
             PositionsLabSettings.DistributeSpaceReference = PositionsLabSettings.DistributeSpaceReferenceObject.ObjectCenter;
             PositionsLabSettings.DistributeShapeOrientation = PositionsLabSettings.RadialShapeOrientationObject.Dynamic;
 
-            var actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
+            PowerPoint.ShapeRange actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
 
             Action<PowerPoint.ShapeRange> positionsAction = (shapes) => PositionsLabMain.DistributeRadial(shapes);
             ExecutePositionsAction(positionsAction, actualShapes, isConvertPPShape: false);
 
             PpOperations.SelectSlide(DistributeAngleAtSecondWithCenterDynamicShapeOrientationSlide);
-            var expectedShapes = PpOperations.SelectShapes(_shapeNames);
+            PowerPoint.ShapeRange expectedShapes = PpOperations.SelectShapes(_shapeNames);
 
             CheckShapes(expectedShapes, actualShapes);
         }
@@ -141,13 +141,13 @@ namespace Test.UnitTest.PositionsLab
             PositionsLabSettings.DistributeSpaceReference = PositionsLabSettings.DistributeSpaceReferenceObject.ObjectBoundary;
             PositionsLabSettings.DistributeShapeOrientation = PositionsLabSettings.RadialShapeOrientationObject.Fixed;
 
-            var actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
+            PowerPoint.ShapeRange actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
 
             Action<PowerPoint.ShapeRange> positionsAction = (shapes) => PositionsLabMain.DistributeRadial(shapes);
             ExecutePositionsAction(positionsAction, actualShapes, isConvertPPShape: false);
 
             PpOperations.SelectSlide(DistributeAngleWithinSecondAndThirdWithEdgesFixedShapeOrientationSlide);
-            var expectedShapes = PpOperations.SelectShapes(_shapeNames);
+            PowerPoint.ShapeRange expectedShapes = PpOperations.SelectShapes(_shapeNames);
 
             CheckShapes(expectedShapes, actualShapes);
         }
@@ -160,13 +160,13 @@ namespace Test.UnitTest.PositionsLab
             PositionsLabSettings.DistributeSpaceReference = PositionsLabSettings.DistributeSpaceReferenceObject.ObjectBoundary;
             PositionsLabSettings.DistributeShapeOrientation = PositionsLabSettings.RadialShapeOrientationObject.Dynamic;
 
-            var actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
+            PowerPoint.ShapeRange actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
 
             Action<PowerPoint.ShapeRange> positionsAction = (shapes) => PositionsLabMain.DistributeRadial(shapes);
             ExecutePositionsAction(positionsAction, actualShapes, isConvertPPShape: false);
 
             PpOperations.SelectSlide(DistributeAngleWithinSecondAndThirdWithEdgesDynamicShapeOrientationSlide);
-            var expectedShapes = PpOperations.SelectShapes(_shapeNames);
+            PowerPoint.ShapeRange expectedShapes = PpOperations.SelectShapes(_shapeNames);
 
             CheckShapes(expectedShapes, actualShapes);
         }
@@ -179,13 +179,13 @@ namespace Test.UnitTest.PositionsLab
             PositionsLabSettings.DistributeSpaceReference = PositionsLabSettings.DistributeSpaceReferenceObject.ObjectCenter;
             PositionsLabSettings.DistributeShapeOrientation = PositionsLabSettings.RadialShapeOrientationObject.Fixed;
 
-            var actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
+            PowerPoint.ShapeRange actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
 
             Action<PowerPoint.ShapeRange> positionsAction = (shapes) => PositionsLabMain.DistributeRadial(shapes);
             ExecutePositionsAction(positionsAction, actualShapes, isConvertPPShape: false);
 
             PpOperations.SelectSlide(DistributeAngleWithinSecondAndThirdWithCenterFixedShapeOrientationSlide);
-            var expectedShapes = PpOperations.SelectShapes(_shapeNames);
+            PowerPoint.ShapeRange expectedShapes = PpOperations.SelectShapes(_shapeNames);
 
             CheckShapes(expectedShapes, actualShapes);
         }
@@ -198,13 +198,13 @@ namespace Test.UnitTest.PositionsLab
             PositionsLabSettings.DistributeSpaceReference = PositionsLabSettings.DistributeSpaceReferenceObject.ObjectCenter;
             PositionsLabSettings.DistributeShapeOrientation = PositionsLabSettings.RadialShapeOrientationObject.Dynamic;
 
-            var actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
+            PowerPoint.ShapeRange actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
 
             Action<PowerPoint.ShapeRange> positionsAction = (shapes) => PositionsLabMain.DistributeRadial(shapes);
             ExecutePositionsAction(positionsAction, actualShapes, isConvertPPShape: false);
 
             PpOperations.SelectSlide(DistributeAngleWithinSecondAndThirdWithCenterDynamicShapeOrientationSlide);
-            var expectedShapes = PpOperations.SelectShapes(_shapeNames);
+            PowerPoint.ShapeRange expectedShapes = PpOperations.SelectShapes(_shapeNames);
 
             CheckShapes(expectedShapes, actualShapes);
         }

--- a/PowerPointLabs/Test/UnitTest/PositionsLab/PositionsLabDistributeTest.cs
+++ b/PowerPointLabs/Test/UnitTest/PositionsLab/PositionsLabDistributeTest.cs
@@ -80,14 +80,14 @@ namespace Test.UnitTest.PositionsLab
             PositionsLabSettings.DistributeSpaceReference = PositionsLabSettings.DistributeSpaceReferenceObject.ObjectBoundary;
 
             _shapeNames = new List<string> { UnrotatedRectangle, Oval, RotatedArrow, RotatedRectangle };
-            var actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
-            var slideWidth = Pres.PageSetup.SlideWidth;
+            PowerPoint.ShapeRange actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
+            float slideWidth = Pres.PageSetup.SlideWidth;
 
             Action<List<PPShape>, float> positionsAction = (shapes, width) => PositionsLabMain.DistributeHorizontal(shapes, width);
             ExecutePositionsAction(positionsAction, actualShapes, slideWidth);
 
             PpOperations.SelectSlide(DistributeHorizontalWithinSlideWithEdgesSlide);
-            var expectedShapes = PpOperations.SelectShapes(_shapeNames);
+            PowerPoint.ShapeRange expectedShapes = PpOperations.SelectShapes(_shapeNames);
 
             CheckShapes(expectedShapes, actualShapes);
         }
@@ -100,14 +100,14 @@ namespace Test.UnitTest.PositionsLab
             PositionsLabSettings.DistributeSpaceReference = PositionsLabSettings.DistributeSpaceReferenceObject.ObjectBoundary;
 
             _shapeNames = new List<string> { UnrotatedRectangle, Oval, RotatedArrow, RotatedRectangle };
-            var actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
-            var slideHeight = Pres.PageSetup.SlideHeight;
+            PowerPoint.ShapeRange actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
+            float slideHeight = Pres.PageSetup.SlideHeight;
 
             Action<List<PPShape>, float> positionsAction = (shapes, height) => PositionsLabMain.DistributeVertical(shapes, height);
             ExecutePositionsAction(positionsAction, actualShapes, slideHeight);
 
             PpOperations.SelectSlide(DistributeVerticalWithinSlideWithEdgesSlide);
-            var expectedShapes = PpOperations.SelectShapes(_shapeNames);
+            PowerPoint.ShapeRange expectedShapes = PpOperations.SelectShapes(_shapeNames);
 
             CheckShapes(expectedShapes, actualShapes);
         }
@@ -120,15 +120,15 @@ namespace Test.UnitTest.PositionsLab
             PositionsLabSettings.DistributeSpaceReference = PositionsLabSettings.DistributeSpaceReferenceObject.ObjectBoundary;
 
             _shapeNames = new List<string> { UnrotatedRectangle, Oval, RotatedArrow, RotatedRectangle };
-            var actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
-            var slideWidth = Pres.PageSetup.SlideWidth;
-            var slideHeight = Pres.PageSetup.SlideHeight;
+            PowerPoint.ShapeRange actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
+            float slideWidth = Pres.PageSetup.SlideWidth;
+            float slideHeight = Pres.PageSetup.SlideHeight;
 
             Action<List<PPShape>, float, float> positionsAction = (shapes, width, height) => PositionsLabMain.DistributeCenter(shapes, width, height);
             ExecutePositionsAction(positionsAction, actualShapes, slideWidth, slideHeight);
 
             PpOperations.SelectSlide(DistributeCenterWithinSlideWithEdgesSlide);
-            var expectedShapes = PpOperations.SelectShapes(_shapeNames);
+            PowerPoint.ShapeRange expectedShapes = PpOperations.SelectShapes(_shapeNames);
 
             CheckShapes(expectedShapes, actualShapes);
         }
@@ -140,14 +140,14 @@ namespace Test.UnitTest.PositionsLab
             PositionsLabSettings.DistributeSpaceReference = PositionsLabSettings.DistributeSpaceReferenceObject.ObjectBoundary;
 
             _shapeNames = new List<string> { BorderRectangle, UnrotatedRectangle, Oval, RotatedArrow, RotatedRectangle };
-            var actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
-            var slideWidth = Pres.PageSetup.SlideWidth;
+            PowerPoint.ShapeRange actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
+            float slideWidth = Pres.PageSetup.SlideWidth;
 
             Action<List<PPShape>, float> positionsAction = (shapes, width) => PositionsLabMain.DistributeHorizontal(shapes, width);
             ExecutePositionsAction(positionsAction, actualShapes, slideWidth);
 
             PpOperations.SelectSlide(DistributeHorizontalWithinFirstWithEdgesSlide);
-            var expectedShapes = PpOperations.SelectShapes(_shapeNames);
+            PowerPoint.ShapeRange expectedShapes = PpOperations.SelectShapes(_shapeNames);
 
             CheckShapes(expectedShapes, actualShapes);
         }
@@ -160,14 +160,14 @@ namespace Test.UnitTest.PositionsLab
             PositionsLabSettings.DistributeSpaceReference = PositionsLabSettings.DistributeSpaceReferenceObject.ObjectBoundary;
 
             _shapeNames = new List<string> { BorderRectangle, UnrotatedRectangle, Oval, RotatedArrow, RotatedRectangle };
-            var actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
-            var slideHeight = Pres.PageSetup.SlideHeight;
+            PowerPoint.ShapeRange actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
+            float slideHeight = Pres.PageSetup.SlideHeight;
 
             Action<List<PPShape>, float> positionsAction = (shapes, height) => PositionsLabMain.DistributeVertical(shapes, height);
             ExecutePositionsAction(positionsAction, actualShapes, slideHeight);
 
             PpOperations.SelectSlide(DistributeVerticalWithinFirstWithEdgesSlide);
-            var expectedShapes = PpOperations.SelectShapes(_shapeNames);
+            PowerPoint.ShapeRange expectedShapes = PpOperations.SelectShapes(_shapeNames);
 
             CheckShapes(expectedShapes, actualShapes);
         }
@@ -180,15 +180,15 @@ namespace Test.UnitTest.PositionsLab
             PositionsLabSettings.DistributeSpaceReference = PositionsLabSettings.DistributeSpaceReferenceObject.ObjectBoundary;
 
             _shapeNames = new List<string> { BorderRectangle, UnrotatedRectangle, Oval, RotatedArrow, RotatedRectangle };
-            var actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
-            var slideWidth = Pres.PageSetup.SlideWidth;
-            var slideHeight = Pres.PageSetup.SlideHeight;
+            PowerPoint.ShapeRange actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
+            float slideWidth = Pres.PageSetup.SlideWidth;
+            float slideHeight = Pres.PageSetup.SlideHeight;
 
             Action<List<PPShape>, float, float> positionsAction = (shapes, width, height) => PositionsLabMain.DistributeCenter(shapes, width, height);
             ExecutePositionsAction(positionsAction, actualShapes, slideWidth, slideHeight);
 
             PpOperations.SelectSlide(DistributeCenterWithinFirstWithEdgesSlide);
-            var expectedShapes = PpOperations.SelectShapes(_shapeNames);
+            PowerPoint.ShapeRange expectedShapes = PpOperations.SelectShapes(_shapeNames);
 
             CheckShapes(expectedShapes, actualShapes);
         }
@@ -201,14 +201,14 @@ namespace Test.UnitTest.PositionsLab
             PositionsLabSettings.DistributeSpaceReference = PositionsLabSettings.DistributeSpaceReferenceObject.ObjectBoundary;
 
             _shapeNames = new List<string> { UnrotatedRectangle, RotatedArrow, Oval, RotatedRectangle };
-            var actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
-            var slideWidth = Pres.PageSetup.SlideWidth;
+            PowerPoint.ShapeRange actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
+            float slideWidth = Pres.PageSetup.SlideWidth;
 
             Action<List<PPShape>, float> positionsAction = (shapes, width) => PositionsLabMain.DistributeHorizontal(shapes, width);
             ExecutePositionsAction(positionsAction, actualShapes, slideWidth);
 
             PpOperations.SelectSlide(DistributeHorizontalWithinFirstAndSecondWithEdgesSlide);
-            var expectedShapes = PpOperations.SelectShapes(_shapeNames);
+            PowerPoint.ShapeRange expectedShapes = PpOperations.SelectShapes(_shapeNames);
 
             CheckShapes(expectedShapes, actualShapes);
         }
@@ -221,14 +221,14 @@ namespace Test.UnitTest.PositionsLab
             PositionsLabSettings.DistributeSpaceReference = PositionsLabSettings.DistributeSpaceReferenceObject.ObjectBoundary;
 
             _shapeNames = new List<string> { UnrotatedRectangle, RotatedArrow, Oval, RotatedRectangle };
-            var actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
-            var slideHeight = Pres.PageSetup.SlideHeight;
+            PowerPoint.ShapeRange actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
+            float slideHeight = Pres.PageSetup.SlideHeight;
 
             Action<List<PPShape>, float> positionsAction = (shapes, height) => PositionsLabMain.DistributeVertical(shapes, height);
             ExecutePositionsAction(positionsAction, actualShapes, slideHeight);
 
             PpOperations.SelectSlide(DistributeVerticalWithinFirstAndSecondWithEdgesSlide);
-            var expectedShapes = PpOperations.SelectShapes(_shapeNames);
+            PowerPoint.ShapeRange expectedShapes = PpOperations.SelectShapes(_shapeNames);
 
             CheckShapes(expectedShapes, actualShapes);
         }
@@ -241,15 +241,15 @@ namespace Test.UnitTest.PositionsLab
             PositionsLabSettings.DistributeSpaceReference = PositionsLabSettings.DistributeSpaceReferenceObject.ObjectBoundary;
 
             _shapeNames = new List<string> { UnrotatedRectangle, RotatedArrow, Oval, RotatedRectangle };
-            var actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
-            var slideWidth = Pres.PageSetup.SlideWidth;
-            var slideHeight = Pres.PageSetup.SlideHeight;
+            PowerPoint.ShapeRange actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
+            float slideWidth = Pres.PageSetup.SlideWidth;
+            float slideHeight = Pres.PageSetup.SlideHeight;
 
             Action<List<PPShape>, float, float> positionsAction = (shapes, width, height) => PositionsLabMain.DistributeCenter(shapes, width, height);
             ExecutePositionsAction(positionsAction, actualShapes, slideWidth, slideHeight);
 
             PpOperations.SelectSlide(DistributeCenterWithinFirstAndSecondWithEdgesSlide);
-            var expectedShapes = PpOperations.SelectShapes(_shapeNames);
+            PowerPoint.ShapeRange expectedShapes = PpOperations.SelectShapes(_shapeNames);
 
             CheckShapes(expectedShapes, actualShapes);
         }
@@ -262,14 +262,14 @@ namespace Test.UnitTest.PositionsLab
             PositionsLabSettings.DistributeSpaceReference = PositionsLabSettings.DistributeSpaceReferenceObject.ObjectBoundary;
 
             _shapeNames = new List<string> { UnrotatedRectangle, Oval, RotatedArrow, RotatedRectangle };
-            var actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
-            var slideWidth = Pres.PageSetup.SlideWidth;
+            PowerPoint.ShapeRange actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
+            float slideWidth = Pres.PageSetup.SlideWidth;
 
             Action<List<PPShape>, float> positionsAction = (shapes, width) => PositionsLabMain.DistributeHorizontal(shapes, width);
             ExecutePositionsAction(positionsAction, actualShapes, slideWidth);
 
             PpOperations.SelectSlide(DistributeHorizontalWithinCornerWithEdgesSlide);
-            var expectedShapes = PpOperations.SelectShapes(_shapeNames);
+            PowerPoint.ShapeRange expectedShapes = PpOperations.SelectShapes(_shapeNames);
 
             CheckShapes(expectedShapes, actualShapes);
         }
@@ -282,14 +282,14 @@ namespace Test.UnitTest.PositionsLab
             PositionsLabSettings.DistributeSpaceReference = PositionsLabSettings.DistributeSpaceReferenceObject.ObjectBoundary;
 
             _shapeNames = new List<string> { UnrotatedRectangle, Oval, RotatedArrow, RotatedRectangle };
-            var actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
-            var slideHeight = Pres.PageSetup.SlideHeight;
+            PowerPoint.ShapeRange actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
+            float slideHeight = Pres.PageSetup.SlideHeight;
 
             Action<List<PPShape>, float> positionsAction = (shapes, height) => PositionsLabMain.DistributeVertical(shapes, height);
             ExecutePositionsAction(positionsAction, actualShapes, slideHeight);
 
             PpOperations.SelectSlide(DistributeVerticalWithinCornerWithEdgesSlide);
-            var expectedShapes = PpOperations.SelectShapes(_shapeNames);
+            PowerPoint.ShapeRange expectedShapes = PpOperations.SelectShapes(_shapeNames);
 
             CheckShapes(expectedShapes, actualShapes);
         }
@@ -302,15 +302,15 @@ namespace Test.UnitTest.PositionsLab
             PositionsLabSettings.DistributeSpaceReference = PositionsLabSettings.DistributeSpaceReferenceObject.ObjectBoundary;
 
             _shapeNames = new List<string> { UnrotatedRectangle, Oval, RotatedArrow, RotatedRectangle };
-            var actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
-            var slideWidth = Pres.PageSetup.SlideWidth;
-            var slideHeight = Pres.PageSetup.SlideHeight;
+            PowerPoint.ShapeRange actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
+            float slideWidth = Pres.PageSetup.SlideWidth;
+            float slideHeight = Pres.PageSetup.SlideHeight;
 
             Action<List<PPShape>, float, float> positionsAction = (shapes, width, height) => PositionsLabMain.DistributeCenter(shapes, width, height);
             ExecutePositionsAction(positionsAction, actualShapes, slideWidth, slideHeight);
 
             PpOperations.SelectSlide(DistributeCenterWithinCornerWithEdgesSlide);
-            var expectedShapes = PpOperations.SelectShapes(_shapeNames);
+            PowerPoint.ShapeRange expectedShapes = PpOperations.SelectShapes(_shapeNames);
 
             CheckShapes(expectedShapes, actualShapes);
         }
@@ -323,14 +323,14 @@ namespace Test.UnitTest.PositionsLab
             PositionsLabSettings.DistributeSpaceReference = PositionsLabSettings.DistributeSpaceReferenceObject.ObjectCenter;
 
             _shapeNames = new List<string> { UnrotatedRectangle, Oval, RotatedArrow, RotatedRectangle };
-            var actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
-            var slideWidth = Pres.PageSetup.SlideWidth;
+            PowerPoint.ShapeRange actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
+            float slideWidth = Pres.PageSetup.SlideWidth;
 
             Action<List<PPShape>, float> positionsAction = (shapes, width) => PositionsLabMain.DistributeHorizontal(shapes, width);
             ExecutePositionsAction(positionsAction, actualShapes, slideWidth);
 
             PpOperations.SelectSlide(DistributeHorizontalWithinSlideWithCenterSlide);
-            var expectedShapes = PpOperations.SelectShapes(_shapeNames);
+            PowerPoint.ShapeRange expectedShapes = PpOperations.SelectShapes(_shapeNames);
 
             CheckShapes(expectedShapes, actualShapes);
         }
@@ -343,14 +343,14 @@ namespace Test.UnitTest.PositionsLab
             PositionsLabSettings.DistributeSpaceReference = PositionsLabSettings.DistributeSpaceReferenceObject.ObjectCenter;
 
             _shapeNames = new List<string> { UnrotatedRectangle, Oval, RotatedArrow, RotatedRectangle };
-            var actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
-            var slideHeight = Pres.PageSetup.SlideHeight;
+            PowerPoint.ShapeRange actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
+            float slideHeight = Pres.PageSetup.SlideHeight;
 
             Action<List<PPShape>, float> positionsAction = (shapes, height) => PositionsLabMain.DistributeVertical(shapes, height);
             ExecutePositionsAction(positionsAction, actualShapes, slideHeight);
 
             PpOperations.SelectSlide(DistributeVerticalWithinSlideWithCenterSlide);
-            var expectedShapes = PpOperations.SelectShapes(_shapeNames);
+            PowerPoint.ShapeRange expectedShapes = PpOperations.SelectShapes(_shapeNames);
 
             CheckShapes(expectedShapes, actualShapes);
         }
@@ -363,15 +363,15 @@ namespace Test.UnitTest.PositionsLab
             PositionsLabSettings.DistributeSpaceReference = PositionsLabSettings.DistributeSpaceReferenceObject.ObjectCenter;
 
             _shapeNames = new List<string> { UnrotatedRectangle, Oval, RotatedArrow, RotatedRectangle };
-            var actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
-            var slideWidth = Pres.PageSetup.SlideWidth;
-            var slideHeight = Pres.PageSetup.SlideHeight;
+            PowerPoint.ShapeRange actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
+            float slideWidth = Pres.PageSetup.SlideWidth;
+            float slideHeight = Pres.PageSetup.SlideHeight;
 
             Action<List<PPShape>, float, float> positionsAction = (shapes, width, height) => PositionsLabMain.DistributeCenter(shapes, width, height);
             ExecutePositionsAction(positionsAction, actualShapes, slideWidth, slideHeight);
 
             PpOperations.SelectSlide(DistributeCenterWithinSlideWithCenterSlide);
-            var expectedShapes = PpOperations.SelectShapes(_shapeNames);
+            PowerPoint.ShapeRange expectedShapes = PpOperations.SelectShapes(_shapeNames);
 
             CheckShapes(expectedShapes, actualShapes);
         }
@@ -383,14 +383,14 @@ namespace Test.UnitTest.PositionsLab
             PositionsLabSettings.DistributeSpaceReference = PositionsLabSettings.DistributeSpaceReferenceObject.ObjectCenter;
 
             _shapeNames = new List<string> { BorderRectangle, UnrotatedRectangle, Oval, RotatedArrow, RotatedRectangle };
-            var actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
-            var slideWidth = Pres.PageSetup.SlideWidth;
+            PowerPoint.ShapeRange actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
+            float slideWidth = Pres.PageSetup.SlideWidth;
 
             Action<List<PPShape>, float> positionsAction = (shapes, width) => PositionsLabMain.DistributeHorizontal(shapes, width);
             ExecutePositionsAction(positionsAction, actualShapes, slideWidth);
 
             PpOperations.SelectSlide(DistributeHorizontalWithinFirstWithCenterSlide);
-            var expectedShapes = PpOperations.SelectShapes(_shapeNames);
+            PowerPoint.ShapeRange expectedShapes = PpOperations.SelectShapes(_shapeNames);
 
             CheckShapes(expectedShapes, actualShapes);
         }
@@ -403,14 +403,14 @@ namespace Test.UnitTest.PositionsLab
             PositionsLabSettings.DistributeSpaceReference = PositionsLabSettings.DistributeSpaceReferenceObject.ObjectCenter;
 
             _shapeNames = new List<string> { BorderRectangle, UnrotatedRectangle, Oval, RotatedArrow, RotatedRectangle };
-            var actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
-            var slideHeight = Pres.PageSetup.SlideHeight;
+            PowerPoint.ShapeRange actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
+            float slideHeight = Pres.PageSetup.SlideHeight;
 
             Action<List<PPShape>, float> positionsAction = (shapes, height) => PositionsLabMain.DistributeVertical(shapes, height);
             ExecutePositionsAction(positionsAction, actualShapes, slideHeight);
 
             PpOperations.SelectSlide(DistributeVerticalWithinFirstWithCenterSlide);
-            var expectedShapes = PpOperations.SelectShapes(_shapeNames);
+            PowerPoint.ShapeRange expectedShapes = PpOperations.SelectShapes(_shapeNames);
 
             CheckShapes(expectedShapes, actualShapes);
         }
@@ -423,15 +423,15 @@ namespace Test.UnitTest.PositionsLab
             PositionsLabSettings.DistributeSpaceReference = PositionsLabSettings.DistributeSpaceReferenceObject.ObjectCenter;
 
             _shapeNames = new List<string> { BorderRectangle, UnrotatedRectangle, Oval, RotatedArrow, RotatedRectangle };
-            var actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
-            var slideWidth = Pres.PageSetup.SlideWidth;
-            var slideHeight = Pres.PageSetup.SlideHeight;
+            PowerPoint.ShapeRange actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
+            float slideWidth = Pres.PageSetup.SlideWidth;
+            float slideHeight = Pres.PageSetup.SlideHeight;
 
             Action<List<PPShape>, float, float> positionsAction = (shapes, width, height) => PositionsLabMain.DistributeCenter(shapes, width, height);
             ExecutePositionsAction(positionsAction, actualShapes, slideWidth, slideHeight);
 
             PpOperations.SelectSlide(DistributeCenterWithinFirstWithCenterSlide);
-            var expectedShapes = PpOperations.SelectShapes(_shapeNames);
+            PowerPoint.ShapeRange expectedShapes = PpOperations.SelectShapes(_shapeNames);
 
             CheckShapes(expectedShapes, actualShapes);
         }
@@ -444,14 +444,14 @@ namespace Test.UnitTest.PositionsLab
             PositionsLabSettings.DistributeSpaceReference = PositionsLabSettings.DistributeSpaceReferenceObject.ObjectCenter;
 
             _shapeNames = new List<string> { UnrotatedRectangle, RotatedArrow, Oval, RotatedRectangle };
-            var actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
-            var slideWidth = Pres.PageSetup.SlideWidth;
+            PowerPoint.ShapeRange actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
+            float slideWidth = Pres.PageSetup.SlideWidth;
 
             Action<List<PPShape>, float> positionsAction = (shapes, width) => PositionsLabMain.DistributeHorizontal(shapes, width);
             ExecutePositionsAction(positionsAction, actualShapes, slideWidth);
 
             PpOperations.SelectSlide(DistributeHorizontalWithinFirstAndSecondWithCenterSlide);
-            var expectedShapes = PpOperations.SelectShapes(_shapeNames);
+            PowerPoint.ShapeRange expectedShapes = PpOperations.SelectShapes(_shapeNames);
 
             CheckShapes(expectedShapes, actualShapes);
         }
@@ -464,14 +464,14 @@ namespace Test.UnitTest.PositionsLab
             PositionsLabSettings.DistributeSpaceReference = PositionsLabSettings.DistributeSpaceReferenceObject.ObjectCenter;
 
             _shapeNames = new List<string> { UnrotatedRectangle, RotatedArrow, Oval, RotatedRectangle };
-            var actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
-            var slideHeight = Pres.PageSetup.SlideHeight;
+            PowerPoint.ShapeRange actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
+            float slideHeight = Pres.PageSetup.SlideHeight;
 
             Action<List<PPShape>, float> positionsAction = (shapes, height) => PositionsLabMain.DistributeVertical(shapes, height);
             ExecutePositionsAction(positionsAction, actualShapes, slideHeight);
 
             PpOperations.SelectSlide(DistributeVerticalWithinFirstAndSecondWithCenterSlide);
-            var expectedShapes = PpOperations.SelectShapes(_shapeNames);
+            PowerPoint.ShapeRange expectedShapes = PpOperations.SelectShapes(_shapeNames);
 
             CheckShapes(expectedShapes, actualShapes);
         }
@@ -484,15 +484,15 @@ namespace Test.UnitTest.PositionsLab
             PositionsLabSettings.DistributeSpaceReference = PositionsLabSettings.DistributeSpaceReferenceObject.ObjectCenter;
 
             _shapeNames = new List<string> { UnrotatedRectangle, RotatedArrow, Oval, RotatedRectangle };
-            var actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
-            var slideWidth = Pres.PageSetup.SlideWidth;
-            var slideHeight = Pres.PageSetup.SlideHeight;
+            PowerPoint.ShapeRange actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
+            float slideWidth = Pres.PageSetup.SlideWidth;
+            float slideHeight = Pres.PageSetup.SlideHeight;
 
             Action<List<PPShape>, float, float> positionsAction = (shapes, width, height) => PositionsLabMain.DistributeCenter(shapes, width, height);
             ExecutePositionsAction(positionsAction, actualShapes, slideWidth, slideHeight);
 
             PpOperations.SelectSlide(DistributeCenterWithinFirstAndSecondWithCenterSlide);
-            var expectedShapes = PpOperations.SelectShapes(_shapeNames);
+            PowerPoint.ShapeRange expectedShapes = PpOperations.SelectShapes(_shapeNames);
 
             CheckShapes(expectedShapes, actualShapes);
         }
@@ -505,14 +505,14 @@ namespace Test.UnitTest.PositionsLab
             PositionsLabSettings.DistributeSpaceReference = PositionsLabSettings.DistributeSpaceReferenceObject.ObjectCenter;
 
             _shapeNames = new List<string> { UnrotatedRectangle, Oval, RotatedArrow, RotatedRectangle };
-            var actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
-            var slideWidth = Pres.PageSetup.SlideWidth;
+            PowerPoint.ShapeRange actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
+            float slideWidth = Pres.PageSetup.SlideWidth;
 
             Action<List<PPShape>, float> positionsAction = (shapes, width) => PositionsLabMain.DistributeHorizontal(shapes, width);
             ExecutePositionsAction(positionsAction, actualShapes, slideWidth);
 
             PpOperations.SelectSlide(DistributeHorizontalWithinCornerWithCenterSlide);
-            var expectedShapes = PpOperations.SelectShapes(_shapeNames);
+            PowerPoint.ShapeRange expectedShapes = PpOperations.SelectShapes(_shapeNames);
 
             CheckShapes(expectedShapes, actualShapes);
         }
@@ -525,14 +525,14 @@ namespace Test.UnitTest.PositionsLab
             PositionsLabSettings.DistributeSpaceReference = PositionsLabSettings.DistributeSpaceReferenceObject.ObjectCenter;
 
             _shapeNames = new List<string> { UnrotatedRectangle, Oval, RotatedArrow, RotatedRectangle };
-            var actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
-            var slideHeight = Pres.PageSetup.SlideHeight;
+            PowerPoint.ShapeRange actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
+            float slideHeight = Pres.PageSetup.SlideHeight;
 
             Action<List<PPShape>, float> positionsAction = (shapes, height) => PositionsLabMain.DistributeVertical(shapes, height);
             ExecutePositionsAction(positionsAction, actualShapes, slideHeight);
 
             PpOperations.SelectSlide(DistributeVerticalWithinCornerWithCenterSlide);
-            var expectedShapes = PpOperations.SelectShapes(_shapeNames);
+            PowerPoint.ShapeRange expectedShapes = PpOperations.SelectShapes(_shapeNames);
 
             CheckShapes(expectedShapes, actualShapes);
         }
@@ -545,15 +545,15 @@ namespace Test.UnitTest.PositionsLab
             PositionsLabSettings.DistributeSpaceReference = PositionsLabSettings.DistributeSpaceReferenceObject.ObjectCenter;
 
             _shapeNames = new List<string> { UnrotatedRectangle, Oval, RotatedArrow, RotatedRectangle };
-            var actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
-            var slideWidth = Pres.PageSetup.SlideWidth;
-            var slideHeight = Pres.PageSetup.SlideHeight;
+            PowerPoint.ShapeRange actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
+            float slideWidth = Pres.PageSetup.SlideWidth;
+            float slideHeight = Pres.PageSetup.SlideHeight;
 
             Action<List<PPShape>, float, float> positionsAction = (shapes, width, height) => PositionsLabMain.DistributeCenter(shapes, width, height);
             ExecutePositionsAction(positionsAction, actualShapes, slideWidth, slideHeight);
 
             PpOperations.SelectSlide(DistributeCenterWithinCornerWithCenterSlide);
-            var expectedShapes = PpOperations.SelectShapes(_shapeNames);
+            PowerPoint.ShapeRange expectedShapes = PpOperations.SelectShapes(_shapeNames);
 
             CheckShapes(expectedShapes, actualShapes);
         }

--- a/PowerPointLabs/Test/UnitTest/PositionsLab/PositionsLabSnapTest.cs
+++ b/PowerPointLabs/Test/UnitTest/PositionsLab/PositionsLabSnapTest.cs
@@ -91,13 +91,13 @@ namespace Test.UnitTest.PositionsLab
                                             Chevron27, RightArrowCallout28, DownArrowCallout29, LeftArrowCallout30, UpArrowCallout31, LeftRightArrowCallout32, UpArrowCallout31,
                                             LeftRightArrowCallout32, QuadArrowCallout33, CircularArrow34, RightArrow1 };
             InitOriginalShapes(OriginalShapes0DegreesSlideNo, _shapeNames);
-            var actualShapes = GetShapes(OriginalShapes0DegreesSlideNo, _shapeNames);
+            PowerPoint.ShapeRange actualShapes = GetShapes(OriginalShapes0DegreesSlideNo, _shapeNames);
 
             Action<IList<Shape>> positionsAction = (shapes) => PositionsLabMain.SnapHorizontal(shapes);
             ExecutePositionsAction(positionsAction, actualShapes);
 
             PpOperations.SelectSlide(SnapHorizontal0DegreesSlideNo);
-            var expectedShapes = PpOperations.SelectShapes(_shapeNames);
+            PowerPoint.ShapeRange expectedShapes = PpOperations.SelectShapes(_shapeNames);
 
             CheckShapes(expectedShapes, actualShapes);
 
@@ -114,13 +114,13 @@ namespace Test.UnitTest.PositionsLab
                                             Chevron27, RightArrowCallout28, DownArrowCallout29, LeftArrowCallout30, UpArrowCallout31, LeftRightArrowCallout32, UpArrowCallout31,
                                             LeftRightArrowCallout32, QuadArrowCallout33, CircularArrow34, RightArrow1 };
             InitOriginalShapes(OriginalShapes315DegreesSlideNo, _shapeNames);
-            var actualShapes = GetShapes(OriginalShapes315DegreesSlideNo, _shapeNames);
+            PowerPoint.ShapeRange actualShapes = GetShapes(OriginalShapes315DegreesSlideNo, _shapeNames);
 
             Action<IList<Shape>> positionsAction = (shapes) => PositionsLabMain.SnapHorizontal(shapes);
             ExecutePositionsAction(positionsAction, actualShapes);
 
             PpOperations.SelectSlide(SnapHorizontal315DegreesSlideNo);
-            var expectedShapes = PpOperations.SelectShapes(_shapeNames);
+            PowerPoint.ShapeRange expectedShapes = PpOperations.SelectShapes(_shapeNames);
 
             CheckShapes(expectedShapes, actualShapes);
 
@@ -137,13 +137,13 @@ namespace Test.UnitTest.PositionsLab
                                             Chevron27, RightArrowCallout28, DownArrowCallout29, LeftArrowCallout30, UpArrowCallout31, LeftRightArrowCallout32, UpArrowCallout31,
                                             LeftRightArrowCallout32, QuadArrowCallout33, CircularArrow34, RightArrow1 };
             InitOriginalShapes(OriginalShapes225DegreesSlideNo, _shapeNames);
-            var actualShapes = GetShapes(OriginalShapes225DegreesSlideNo, _shapeNames);
+            PowerPoint.ShapeRange actualShapes = GetShapes(OriginalShapes225DegreesSlideNo, _shapeNames);
 
             Action<IList<Shape>> positionsAction = (shapes) => PositionsLabMain.SnapHorizontal(shapes);
             ExecutePositionsAction(positionsAction, actualShapes);
 
             PpOperations.SelectSlide(SnapHorizontal225DegreesSlideNo);
-            var expectedShapes = PpOperations.SelectShapes(_shapeNames);
+            PowerPoint.ShapeRange expectedShapes = PpOperations.SelectShapes(_shapeNames);
 
             CheckShapes(expectedShapes, actualShapes);
 
@@ -160,13 +160,13 @@ namespace Test.UnitTest.PositionsLab
                                             Chevron27, RightArrowCallout28, DownArrowCallout29, LeftArrowCallout30, UpArrowCallout31, LeftRightArrowCallout32, UpArrowCallout31,
                                             LeftRightArrowCallout32, QuadArrowCallout33, CircularArrow34, RightArrow1 };
             InitOriginalShapes(OriginalShapes135DegreesSlideNo, _shapeNames);
-            var actualShapes = GetShapes(OriginalShapes135DegreesSlideNo, _shapeNames);
+            PowerPoint.ShapeRange actualShapes = GetShapes(OriginalShapes135DegreesSlideNo, _shapeNames);
 
             Action<IList<Shape>> positionsAction = (shapes) => PositionsLabMain.SnapHorizontal(shapes);
             ExecutePositionsAction(positionsAction, actualShapes);
 
             PpOperations.SelectSlide(SnapHorizontal135DegreesSlideNo);
-            var expectedShapes = PpOperations.SelectShapes(_shapeNames);
+            PowerPoint.ShapeRange expectedShapes = PpOperations.SelectShapes(_shapeNames);
 
             CheckShapes(expectedShapes, actualShapes);
 
@@ -183,13 +183,13 @@ namespace Test.UnitTest.PositionsLab
                                             Chevron27, RightArrowCallout28, DownArrowCallout29, LeftArrowCallout30, UpArrowCallout31, LeftRightArrowCallout32, UpArrowCallout31,
                                             LeftRightArrowCallout32, QuadArrowCallout33, CircularArrow34, RightArrow1 };
             InitOriginalShapes(OriginalShapes45DegreesSlideNo, _shapeNames);
-            var actualShapes = GetShapes(OriginalShapes45DegreesSlideNo, _shapeNames);
+            PowerPoint.ShapeRange actualShapes = GetShapes(OriginalShapes45DegreesSlideNo, _shapeNames);
 
             Action<IList<Shape>> positionsAction = (shapes) => PositionsLabMain.SnapHorizontal(shapes);
             ExecutePositionsAction(positionsAction, actualShapes);
 
             PpOperations.SelectSlide(SnapHorizontal45DegreesSlideNo);
-            var expectedShapes = PpOperations.SelectShapes(_shapeNames);
+            PowerPoint.ShapeRange expectedShapes = PpOperations.SelectShapes(_shapeNames);
 
             CheckShapes(expectedShapes, actualShapes);
 
@@ -206,13 +206,13 @@ namespace Test.UnitTest.PositionsLab
                                             Chevron27, RightArrowCallout28, DownArrowCallout29, LeftArrowCallout30, UpArrowCallout31, LeftRightArrowCallout32, UpArrowCallout31,
                                             LeftRightArrowCallout32, QuadArrowCallout33, CircularArrow34, RightArrow1 };
             InitOriginalShapes(OriginalShapes0DegreesSlideNo, _shapeNames);
-            var actualShapes = GetShapes(OriginalShapes0DegreesSlideNo, _shapeNames);
+            PowerPoint.ShapeRange actualShapes = GetShapes(OriginalShapes0DegreesSlideNo, _shapeNames);
 
             Action<IList<Shape>> positionsAction = (shapes) => PositionsLabMain.SnapVertical(shapes);
             ExecutePositionsAction(positionsAction, actualShapes);
 
             PpOperations.SelectSlide(SnapVertical0DegreesSlideNo);
-            var expectedShapes = PpOperations.SelectShapes(_shapeNames);
+            PowerPoint.ShapeRange expectedShapes = PpOperations.SelectShapes(_shapeNames);
 
             CheckShapes(expectedShapes, actualShapes);
 
@@ -229,13 +229,13 @@ namespace Test.UnitTest.PositionsLab
                                             Chevron27, RightArrowCallout28, DownArrowCallout29, LeftArrowCallout30, UpArrowCallout31, LeftRightArrowCallout32, UpArrowCallout31,
                                             LeftRightArrowCallout32, QuadArrowCallout33, CircularArrow34, RightArrow1 };
             InitOriginalShapes(OriginalShapes315DegreesSlideNo, _shapeNames);
-            var actualShapes = GetShapes(OriginalShapes315DegreesSlideNo, _shapeNames);
+            PowerPoint.ShapeRange actualShapes = GetShapes(OriginalShapes315DegreesSlideNo, _shapeNames);
 
             Action<IList<Shape>> positionsAction = (shapes) => PositionsLabMain.SnapVertical(shapes);
             ExecutePositionsAction(positionsAction, actualShapes);
 
             PpOperations.SelectSlide(SnapVertical315DegreesSlideNo);
-            var expectedShapes = PpOperations.SelectShapes(_shapeNames);
+            PowerPoint.ShapeRange expectedShapes = PpOperations.SelectShapes(_shapeNames);
 
             CheckShapes(expectedShapes, actualShapes);
 
@@ -252,13 +252,13 @@ namespace Test.UnitTest.PositionsLab
                                             Chevron27, RightArrowCallout28, DownArrowCallout29, LeftArrowCallout30, UpArrowCallout31, LeftRightArrowCallout32, UpArrowCallout31,
                                             LeftRightArrowCallout32, QuadArrowCallout33, CircularArrow34, RightArrow1 };
             InitOriginalShapes(OriginalShapes225DegreesSlideNo, _shapeNames);
-            var actualShapes = GetShapes(OriginalShapes225DegreesSlideNo, _shapeNames);
+            PowerPoint.ShapeRange actualShapes = GetShapes(OriginalShapes225DegreesSlideNo, _shapeNames);
 
             Action<IList<Shape>> positionsAction = (shapes) => PositionsLabMain.SnapVertical(shapes);
             ExecutePositionsAction(positionsAction, actualShapes);
 
             PpOperations.SelectSlide(SnapVertical225DegreesSlideNo);
-            var expectedShapes = PpOperations.SelectShapes(_shapeNames);
+            PowerPoint.ShapeRange expectedShapes = PpOperations.SelectShapes(_shapeNames);
 
             CheckShapes(expectedShapes, actualShapes);
 
@@ -275,13 +275,13 @@ namespace Test.UnitTest.PositionsLab
                                             Chevron27, RightArrowCallout28, DownArrowCallout29, LeftArrowCallout30, UpArrowCallout31, LeftRightArrowCallout32, UpArrowCallout31,
                                             LeftRightArrowCallout32, QuadArrowCallout33, CircularArrow34, RightArrow1 };
             InitOriginalShapes(OriginalShapes135DegreesSlideNo, _shapeNames);
-            var actualShapes = GetShapes(OriginalShapes135DegreesSlideNo, _shapeNames);
+            PowerPoint.ShapeRange actualShapes = GetShapes(OriginalShapes135DegreesSlideNo, _shapeNames);
 
             Action<IList<Shape>> positionsAction = (shapes) => PositionsLabMain.SnapVertical(shapes);
             ExecutePositionsAction(positionsAction, actualShapes);
 
             PpOperations.SelectSlide(SnapVertical135DegreesSlideNo);
-            var expectedShapes = PpOperations.SelectShapes(_shapeNames);
+            PowerPoint.ShapeRange expectedShapes = PpOperations.SelectShapes(_shapeNames);
 
             CheckShapes(expectedShapes, actualShapes);
 
@@ -298,13 +298,13 @@ namespace Test.UnitTest.PositionsLab
                                             Chevron27, RightArrowCallout28, DownArrowCallout29, LeftArrowCallout30, UpArrowCallout31, LeftRightArrowCallout32, UpArrowCallout31,
                                             LeftRightArrowCallout32, QuadArrowCallout33, CircularArrow34, RightArrow1 };
             InitOriginalShapes(OriginalShapes45DegreesSlideNo, _shapeNames);
-            var actualShapes = GetShapes(OriginalShapes45DegreesSlideNo, _shapeNames);
+            PowerPoint.ShapeRange actualShapes = GetShapes(OriginalShapes45DegreesSlideNo, _shapeNames);
 
             Action<IList<Shape>> positionsAction = (shapes) => PositionsLabMain.SnapVertical(shapes);
             ExecutePositionsAction(positionsAction, actualShapes);
 
             PpOperations.SelectSlide(SnapVertical45DegreesSlideNo);
-            var expectedShapes = PpOperations.SelectShapes(_shapeNames);
+            PowerPoint.ShapeRange expectedShapes = PpOperations.SelectShapes(_shapeNames);
 
             CheckShapes(expectedShapes, actualShapes);
 
@@ -321,13 +321,13 @@ namespace Test.UnitTest.PositionsLab
                                             Chevron27, RightArrowCallout28, DownArrowCallout29, LeftArrowCallout30, UpArrowCallout31, LeftRightArrowCallout32, UpArrowCallout31,
                                             LeftRightArrowCallout32, QuadArrowCallout33, CircularArrow34, RightArrow1 };
             InitOriginalShapes(OriginalShapes0DegreesSlideNo, _shapeNames);
-            var actualShapes = GetShapes(OriginalShapes0DegreesSlideNo, _shapeNames);
+            PowerPoint.ShapeRange actualShapes = GetShapes(OriginalShapes0DegreesSlideNo, _shapeNames);
 
             Action<IList<Shape>> positionsAction = (shapes) => PositionsLabMain.SnapAway(shapes);
             ExecutePositionsAction(positionsAction, actualShapes);
 
             PpOperations.SelectSlide(SnapAway1SlideNo);
-            var expectedShapes = PpOperations.SelectShapes(_shapeNames);
+            PowerPoint.ShapeRange expectedShapes = PpOperations.SelectShapes(_shapeNames);
 
             CheckShapes(expectedShapes, actualShapes);
 
@@ -344,14 +344,14 @@ namespace Test.UnitTest.PositionsLab
                                             Chevron27, RightArrowCallout28, DownArrowCallout29, LeftArrowCallout30, UpArrowCallout31, LeftRightArrowCallout32, UpArrowCallout31,
                                             LeftRightArrowCallout32, QuadArrowCallout33, CircularArrow34, RightArrow1 };
             InitOriginalShapes(OriginalShapes0DegreesSlideNo, _shapeNames);
-            var actualShapes = GetShapes(OriginalShapes0DegreesSlideNo, _shapeNames);
+            PowerPoint.ShapeRange actualShapes = GetShapes(OriginalShapes0DegreesSlideNo, _shapeNames);
 
             Action<IList<Shape>> positionsAction = (shapes) => PositionsLabMain.SnapAway(shapes);
             ExecutePositionsAction(positionsAction, actualShapes);
             ExecutePositionsAction(positionsAction, actualShapes);
 
             PpOperations.SelectSlide(SnapAway2SlideNo);
-            var expectedShapes = PpOperations.SelectShapes(_shapeNames);
+            PowerPoint.ShapeRange expectedShapes = PpOperations.SelectShapes(_shapeNames);
 
             CheckShapes(expectedShapes, actualShapes);
 
@@ -368,7 +368,7 @@ namespace Test.UnitTest.PositionsLab
                                             Chevron27, RightArrowCallout28, DownArrowCallout29, LeftArrowCallout30, UpArrowCallout31, LeftRightArrowCallout32, UpArrowCallout31,
                                             LeftRightArrowCallout32, QuadArrowCallout33, CircularArrow34, RightArrow1 };
             InitOriginalShapes(OriginalShapes0DegreesSlideNo, _shapeNames);
-            var actualShapes = GetShapes(OriginalShapes0DegreesSlideNo, _shapeNames);
+            PowerPoint.ShapeRange actualShapes = GetShapes(OriginalShapes0DegreesSlideNo, _shapeNames);
 
             Action<IList<Shape>> positionsAction = (shapes) => PositionsLabMain.SnapAway(shapes);
             ExecutePositionsAction(positionsAction, actualShapes);
@@ -376,7 +376,7 @@ namespace Test.UnitTest.PositionsLab
             ExecutePositionsAction(positionsAction, actualShapes);
 
             PpOperations.SelectSlide(SnapAway3SlideNo);
-            var expectedShapes = PpOperations.SelectShapes(_shapeNames);
+            PowerPoint.ShapeRange expectedShapes = PpOperations.SelectShapes(_shapeNames);
 
             CheckShapes(expectedShapes, actualShapes);
 
@@ -393,7 +393,7 @@ namespace Test.UnitTest.PositionsLab
                                             Chevron27, RightArrowCallout28, DownArrowCallout29, LeftArrowCallout30, UpArrowCallout31, LeftRightArrowCallout32, UpArrowCallout31,
                                             LeftRightArrowCallout32, QuadArrowCallout33, CircularArrow34, RightArrow1 };
             InitOriginalShapes(OriginalShapes0DegreesSlideNo, _shapeNames);
-            var actualShapes = GetShapes(OriginalShapes0DegreesSlideNo, _shapeNames);
+            PowerPoint.ShapeRange actualShapes = GetShapes(OriginalShapes0DegreesSlideNo, _shapeNames);
 
             Action<IList<Shape>> positionsAction = (shapes) => PositionsLabMain.SnapAway(shapes);
             ExecutePositionsAction(positionsAction, actualShapes);
@@ -402,7 +402,7 @@ namespace Test.UnitTest.PositionsLab
             ExecutePositionsAction(positionsAction, actualShapes);
 
             PpOperations.SelectSlide(SnapAway4SlideNo);
-            var expectedShapes = PpOperations.SelectShapes(_shapeNames);
+            PowerPoint.ShapeRange expectedShapes = PpOperations.SelectShapes(_shapeNames);
 
             CheckShapes(expectedShapes, actualShapes);
 

--- a/PowerPointLabs/Test/UnitTest/PositionsLab/PositionsLabSwapTest.cs
+++ b/PowerPointLabs/Test/UnitTest/PositionsLab/PositionsLabSwapTest.cs
@@ -55,29 +55,29 @@ namespace Test.UnitTest.PositionsLab
         {
             PositionsLabSettings.IsSwapByClickOrder = false;
             PositionsLabSettings.SwapReferencePoint = PositionsLabSettings.SwapReference.MiddleCenter;
-            
-            var shapesToSwap = GetShapes(OriginalShapesSlideNo, _swapShapes);
+
+            PowerPoint.ShapeRange shapesToSwap = GetShapes(OriginalShapesSlideNo, _swapShapes);
 
             Action<List<PPShape>, bool> positionsAction = (shapes, isPreview) => PositionsLabMain.Swap(shapes, isPreview);
 
             ExecutePositionsAction(positionsAction, shapesToSwap, false);
-            var expectedShapes1Swap = GetShapes(SwapLeftToRight1Slide, _allShapes);
-            var actualShapes1Swap = GetShapes(OriginalShapesSlideNo, _allShapes);
+            PowerPoint.ShapeRange expectedShapes1Swap = GetShapes(SwapLeftToRight1Slide, _allShapes);
+            PowerPoint.ShapeRange actualShapes1Swap = GetShapes(OriginalShapesSlideNo, _allShapes);
             CheckShapes(expectedShapes1Swap, actualShapes1Swap);
 
             ExecutePositionsAction(positionsAction, shapesToSwap, false);
-            var expectedShapes2Swap = GetShapes(SwapLeftToRight2Slide, _allShapes);
-            var actualShapes2Swap = GetShapes(OriginalShapesSlideNo, _allShapes);
+            PowerPoint.ShapeRange expectedShapes2Swap = GetShapes(SwapLeftToRight2Slide, _allShapes);
+            PowerPoint.ShapeRange actualShapes2Swap = GetShapes(OriginalShapesSlideNo, _allShapes);
             CheckShapes(expectedShapes2Swap, actualShapes2Swap);
 
             ExecutePositionsAction(positionsAction, shapesToSwap, false);
-            var expectedShapes3Swap = GetShapes(SwapLeftToRight3Slide, _allShapes);
-            var actualShapes3Swap = GetShapes(OriginalShapesSlideNo, _allShapes);
+            PowerPoint.ShapeRange expectedShapes3Swap = GetShapes(SwapLeftToRight3Slide, _allShapes);
+            PowerPoint.ShapeRange actualShapes3Swap = GetShapes(OriginalShapesSlideNo, _allShapes);
             CheckShapes(expectedShapes3Swap, actualShapes3Swap);
 
             ExecutePositionsAction(positionsAction, shapesToSwap, false);
-            var expectedShapes4Swap = GetShapes(SwapLeftToRight4Slide, _allShapes);
-            var actualShapes4Swap = GetShapes(OriginalShapesSlideNo, _allShapes);
+            PowerPoint.ShapeRange expectedShapes4Swap = GetShapes(SwapLeftToRight4Slide, _allShapes);
+            PowerPoint.ShapeRange actualShapes4Swap = GetShapes(OriginalShapesSlideNo, _allShapes);
             CheckShapes(expectedShapes4Swap, actualShapes4Swap);
         }
 
@@ -88,28 +88,28 @@ namespace Test.UnitTest.PositionsLab
             PositionsLabSettings.IsSwapByClickOrder = true;
             PositionsLabSettings.SwapReferencePoint = PositionsLabSettings.SwapReference.MiddleCenter;
 
-            var shapesToSwap = GetShapes(OriginalShapesSlideNo, _swapShapes);
+            PowerPoint.ShapeRange shapesToSwap = GetShapes(OriginalShapesSlideNo, _swapShapes);
 
             Action<List<PPShape>, bool> positionsAction = (shapes, isPreview) => PositionsLabMain.Swap(shapes, isPreview);
 
             ExecutePositionsAction(positionsAction, shapesToSwap, false);
-            var expectedShapes1Swap = GetShapes(SwapClick1Slide, _allShapes);
-            var actualShapes1Swap = GetShapes(OriginalShapesSlideNo, _allShapes);
+            PowerPoint.ShapeRange expectedShapes1Swap = GetShapes(SwapClick1Slide, _allShapes);
+            PowerPoint.ShapeRange actualShapes1Swap = GetShapes(OriginalShapesSlideNo, _allShapes);
             CheckShapes(expectedShapes1Swap, actualShapes1Swap);
             
             ExecutePositionsAction(positionsAction, shapesToSwap, false);
-            var expectedShapes2Swap = GetShapes(SwapClick2Slide, _allShapes);
-            var actualShapes2Swap = GetShapes(OriginalShapesSlideNo, _allShapes);
+            PowerPoint.ShapeRange expectedShapes2Swap = GetShapes(SwapClick2Slide, _allShapes);
+            PowerPoint.ShapeRange actualShapes2Swap = GetShapes(OriginalShapesSlideNo, _allShapes);
             CheckShapes(expectedShapes2Swap, actualShapes2Swap);
 
             ExecutePositionsAction(positionsAction, shapesToSwap, false);
-            var expectedShapes3Swap = GetShapes(SwapClick3Slide, _allShapes);
-            var actualShapes3Swap = GetShapes(OriginalShapesSlideNo, _allShapes);
+            PowerPoint.ShapeRange expectedShapes3Swap = GetShapes(SwapClick3Slide, _allShapes);
+            PowerPoint.ShapeRange actualShapes3Swap = GetShapes(OriginalShapesSlideNo, _allShapes);
             CheckShapes(expectedShapes3Swap, actualShapes3Swap);
 
             ExecutePositionsAction(positionsAction, shapesToSwap, false);
-            var expectedShapes4Swap = GetShapes(SwapClick4Slide, _allShapes);
-            var actualShapes4Swap = GetShapes(OriginalShapesSlideNo, _allShapes);
+            PowerPoint.ShapeRange expectedShapes4Swap = GetShapes(SwapClick4Slide, _allShapes);
+            PowerPoint.ShapeRange actualShapes4Swap = GetShapes(OriginalShapesSlideNo, _allShapes);
             CheckShapes(expectedShapes4Swap, actualShapes4Swap);
         }
 
@@ -117,7 +117,7 @@ namespace Test.UnitTest.PositionsLab
         {
             foreach (PowerPoint.Shape actualShape in actualShapes)
             {
-                var isFound = false;
+                bool isFound = false;
 
                 foreach (PowerPoint.Shape expectedShape in expectedShapes)
                 {

--- a/PowerPointLabs/Test/UnitTest/ResizeLab/AdjustProportionallyTest.cs
+++ b/PowerPointLabs/Test/UnitTest/ResizeLab/AdjustProportionallyTest.cs
@@ -1,6 +1,8 @@
 ﻿using System.Collections.Generic;
+
 using Microsoft.Office.Core;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+
 using PowerPointLabs.ResizeLab;
 
 namespace Test.UnitTest.ResizeLab
@@ -41,8 +43,8 @@ namespace Test.UnitTest.ResizeLab
         [TestCategory("UT")]
         public void TestAdjustVisualWidthProportionallyWithoutAspectRatio()
         {
-            var actualShapes = GetShapes(SlideNo.AdjustProportionallyOrigin, _shapeNames);
-            var expectedShapes = GetShapes(SlideNo.AdjustVisualWidthProportionally, _shapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange actualShapes = GetShapes(SlideNo.AdjustProportionallyOrigin, _shapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange expectedShapes = GetShapes(SlideNo.AdjustVisualWidthProportionally, _shapeNames);
             actualShapes.LockAspectRatio = MsoTriState.msoFalse;
 
             _resizeLab.ResizeType = ResizeLabMain.ResizeBy.Visual;
@@ -55,8 +57,8 @@ namespace Test.UnitTest.ResizeLab
         [TestCategory("UT")]
         public void TestAdjustActualWidthProportionallyWithoutAspectRatio()
         {
-            var actualShapes = GetShapes(SlideNo.AdjustProportionallyOrigin, _shapeNames);
-            var expectedShapes = GetShapes(SlideNo.AdjustActualWidthProportionally, _shapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange actualShapes = GetShapes(SlideNo.AdjustProportionallyOrigin, _shapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange expectedShapes = GetShapes(SlideNo.AdjustActualWidthProportionally, _shapeNames);
             actualShapes.LockAspectRatio = MsoTriState.msoFalse;
 
             _resizeLab.ResizeType = ResizeLabMain.ResizeBy.Actual;
@@ -69,8 +71,8 @@ namespace Test.UnitTest.ResizeLab
         [TestCategory("UT")]
         public void TestAdjustVisualWidthProportionallyWithAspectRatio()
         {
-            var actualShapes = GetShapes(SlideNo.AdjustProportionallyOrigin, _shapeNames);
-            var expectedShapes = GetShapes(SlideNo.AdjustVisualWidthProportionallyAspectRatio, _shapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange actualShapes = GetShapes(SlideNo.AdjustProportionallyOrigin, _shapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange expectedShapes = GetShapes(SlideNo.AdjustVisualWidthProportionallyAspectRatio, _shapeNames);
             actualShapes.LockAspectRatio = MsoTriState.msoTrue;
 
             _resizeLab.ResizeType = ResizeLabMain.ResizeBy.Visual;
@@ -83,8 +85,8 @@ namespace Test.UnitTest.ResizeLab
         [TestCategory("UT")]
         public void TestAdjustActualWidthProportionallyWithAspectRatio()
         {
-            var actualShapes = GetShapes(SlideNo.AdjustProportionallyOrigin, _shapeNames);
-            var expectedShapes = GetShapes(SlideNo.AdjustActualWidthProportionallyAspectRatio, _shapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange actualShapes = GetShapes(SlideNo.AdjustProportionallyOrigin, _shapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange expectedShapes = GetShapes(SlideNo.AdjustActualWidthProportionallyAspectRatio, _shapeNames);
             actualShapes.LockAspectRatio = MsoTriState.msoTrue;
 
             _resizeLab.ResizeType = ResizeLabMain.ResizeBy.Actual;
@@ -97,8 +99,8 @@ namespace Test.UnitTest.ResizeLab
         [TestCategory("UT")]
         public void TestAdjustVisualHeightProportionallyWithoutAspectRatio()
         {
-            var actualShapes = GetShapes(SlideNo.AdjustProportionallyOrigin, _shapeNames);
-            var expectedShapes = GetShapes(SlideNo.AdjustVisualHeightProportionally, _shapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange actualShapes = GetShapes(SlideNo.AdjustProportionallyOrigin, _shapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange expectedShapes = GetShapes(SlideNo.AdjustVisualHeightProportionally, _shapeNames);
             actualShapes.LockAspectRatio = MsoTriState.msoFalse;
 
             _resizeLab.ResizeType = ResizeLabMain.ResizeBy.Visual;
@@ -111,8 +113,8 @@ namespace Test.UnitTest.ResizeLab
         [TestCategory("UT")]
         public void TestAdjustActualHeightProportionallyWithoutAspectRatio()
         {
-            var actualShapes = GetShapes(SlideNo.AdjustProportionallyOrigin, _shapeNames);
-            var expectedShapes = GetShapes(SlideNo.AdjustActualHeightProportionally, _shapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange actualShapes = GetShapes(SlideNo.AdjustProportionallyOrigin, _shapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange expectedShapes = GetShapes(SlideNo.AdjustActualHeightProportionally, _shapeNames);
             actualShapes.LockAspectRatio = MsoTriState.msoFalse;
 
             _resizeLab.ResizeType = ResizeLabMain.ResizeBy.Actual;
@@ -125,8 +127,8 @@ namespace Test.UnitTest.ResizeLab
         [TestCategory("UT")]
         public void TestAdjustVisualHeightProportionallyWithAspectRatio()
         {
-            var actualShapes = GetShapes(SlideNo.AdjustProportionallyOrigin, _shapeNames);
-            var expectedShapes = GetShapes(SlideNo.AdjustVisualHeightProportionallyAspectRatio, _shapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange actualShapes = GetShapes(SlideNo.AdjustProportionallyOrigin, _shapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange expectedShapes = GetShapes(SlideNo.AdjustVisualHeightProportionallyAspectRatio, _shapeNames);
             actualShapes.LockAspectRatio = MsoTriState.msoTrue;
 
             _resizeLab.ResizeType = ResizeLabMain.ResizeBy.Visual;
@@ -139,8 +141,8 @@ namespace Test.UnitTest.ResizeLab
         [TestCategory("UT")]
         public void TestAdjustActualHeightProportionallyWithAspectRatio()
         {
-            var actualShapes = GetShapes(SlideNo.AdjustProportionallyOrigin, _shapeNames);
-            var expectedShapes = GetShapes(SlideNo.AdjustActualHeightProportionallyAspectRatio, _shapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange actualShapes = GetShapes(SlideNo.AdjustProportionallyOrigin, _shapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange expectedShapes = GetShapes(SlideNo.AdjustActualHeightProportionallyAspectRatio, _shapeNames);
             actualShapes.LockAspectRatio = MsoTriState.msoTrue;
 
             _resizeLab.ResizeType = ResizeLabMain.ResizeBy.Actual;
@@ -156,8 +158,8 @@ namespace Test.UnitTest.ResizeLab
             _shapeNames = new List<string> { RefShapeName, BlackCornerRectangleName, BlueCornerRectangleName };
             InitOriginalShapes(SlideNo.AdjustAreaProportionallyAutoShapeOrigin, _shapeNames);
 
-            var actualShapes = GetShapes(SlideNo.AdjustAreaProportionallyAutoShapeOrigin, _shapeNames);
-            var expectedShapes = GetShapes(SlideNo.AdjustAreaProportionallyAutoShape, _shapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange actualShapes = GetShapes(SlideNo.AdjustAreaProportionallyAutoShapeOrigin, _shapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange expectedShapes = GetShapes(SlideNo.AdjustAreaProportionallyAutoShape, _shapeNames);
             actualShapes.LockAspectRatio = MsoTriState.msoFalse;
 
             _resizeLab.ResizeType = ResizeLabMain.ResizeBy.Actual;
@@ -184,8 +186,8 @@ namespace Test.UnitTest.ResizeLab
             _shapeNames = new List<string> { RefShapeName, BlackCornerRectangleName, BlueCornerRectangleName };
             InitOriginalShapes(SlideNo.AdjustAreaProportionallyAutoShapeOrigin, _shapeNames);
 
-            var actualShapes = GetShapes(SlideNo.AdjustAreaProportionallyAutoShapeOrigin, _shapeNames);
-            var expectedShapes = GetShapes(SlideNo.AdjustAreaProportionallyAutoShapeAspectRatio, _shapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange actualShapes = GetShapes(SlideNo.AdjustAreaProportionallyAutoShapeOrigin, _shapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange expectedShapes = GetShapes(SlideNo.AdjustAreaProportionallyAutoShapeAspectRatio, _shapeNames);
             actualShapes.LockAspectRatio = MsoTriState.msoTrue;
 
             _resizeLab.ResizeType = ResizeLabMain.ResizeBy.Actual;

--- a/PowerPointLabs/Test/UnitTest/ResizeLab/BaseResizeLabTest.cs
+++ b/PowerPointLabs/Test/UnitTest/ResizeLab/BaseResizeLabTest.cs
@@ -18,12 +18,12 @@ namespace Test.UnitTest.ResizeLab
 
         protected void InitOriginalShapes(int slideNumber, List<string> shapeNames)
         {
-            var shapes = GetShapes(slideNumber, shapeNames);
+            PowerPoint.ShapeRange shapes = GetShapes(slideNumber, shapeNames);
 
             _originalShapeName.Clear();
             foreach(PowerPoint.Shape shape in shapes)
             {
-                var duplicateShape = shape.Duplicate()[1];
+                PowerPoint.Shape duplicateShape = shape.Duplicate()[1];
                 duplicateShape.Top = shape.Top;
                 duplicateShape.Left = shape.Left;
                 duplicateShape.Name = Guid.NewGuid().ToString();
@@ -41,9 +41,9 @@ namespace Test.UnitTest.ResizeLab
         {
             try
             {
-                var duplicatedShapeNames = new List<string>(_originalShapeName.Keys);
-                var executedShapes = GetShapes(slideNumber, shapeNames);
-                var shapes = GetShapes(slideNumber, duplicatedShapeNames);
+                List<string> duplicatedShapeNames = new List<string>(_originalShapeName.Keys);
+                PowerPoint.ShapeRange executedShapes = GetShapes(slideNumber, shapeNames);
+                PowerPoint.ShapeRange shapes = GetShapes(slideNumber, duplicatedShapeNames);
                 executedShapes.Delete();
 
                 foreach (PowerPoint.Shape shape in shapes)
@@ -61,7 +61,7 @@ namespace Test.UnitTest.ResizeLab
         {
             foreach (PowerPoint.Shape actualShape in actualShapes)
             {
-                var isFound = false;
+                bool isFound = false;
 
                 foreach (PowerPoint.Shape expectedShape in expectedShapes)
                 {

--- a/PowerPointLabs/Test/UnitTest/ResizeLab/EqualizeTest.cs
+++ b/PowerPointLabs/Test/UnitTest/ResizeLab/EqualizeTest.cs
@@ -32,8 +32,8 @@ namespace Test.UnitTest.ResizeLab
         [TestCategory("UT")]
         public void TestEqualizeVisualWidthWithoutAspectRatio()
         {
-            var actualShapes = GetShapes(SlideNo.EqualizeOrigin, _shapeNames);
-            var expectedShapes = GetShapes(SlideNo.EqualizeVisualWidth, _shapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange actualShapes = GetShapes(SlideNo.EqualizeOrigin, _shapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange expectedShapes = GetShapes(SlideNo.EqualizeVisualWidth, _shapeNames);
             actualShapes.LockAspectRatio = MsoTriState.msoFalse;
 
             _resizeLab.ResizeType = ResizeLabMain.ResizeBy.Visual;
@@ -45,8 +45,8 @@ namespace Test.UnitTest.ResizeLab
         [TestCategory("UT")]
         public void TestEqualizeVisualWidthWithAspectRatio()
         {
-            var actualShapes = GetShapes(SlideNo.EqualizeOrigin, _shapeNames);
-            var expectedShapes = GetShapes(SlideNo.EqualizeVisualWidthAspectRatio, _shapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange actualShapes = GetShapes(SlideNo.EqualizeOrigin, _shapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange expectedShapes = GetShapes(SlideNo.EqualizeVisualWidthAspectRatio, _shapeNames);
             actualShapes.LockAspectRatio = MsoTriState.msoTrue;
 
             _resizeLab.ResizeType = ResizeLabMain.ResizeBy.Visual;
@@ -58,8 +58,8 @@ namespace Test.UnitTest.ResizeLab
         [TestCategory("UT")]
         public void TestEqualizeActualWidthWithoutAspectRatio()
         {
-            var actualShapes = GetShapes(SlideNo.EqualizeOrigin, _shapeNames);
-            var expectedShapes = GetShapes(SlideNo.EqualizeActualWidth, _shapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange actualShapes = GetShapes(SlideNo.EqualizeOrigin, _shapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange expectedShapes = GetShapes(SlideNo.EqualizeActualWidth, _shapeNames);
             actualShapes.LockAspectRatio = MsoTriState.msoFalse;
 
             _resizeLab.ResizeType = ResizeLabMain.ResizeBy.Actual;
@@ -71,8 +71,8 @@ namespace Test.UnitTest.ResizeLab
         [TestCategory("UT")]
         public void TestEqualizeActualWidthWithAspectRatio()
         {
-            var actualShapes = GetShapes(SlideNo.EqualizeOrigin, _shapeNames);
-            var expectedShapes = GetShapes(SlideNo.EqualizeActualWidthAspectRatio, _shapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange actualShapes = GetShapes(SlideNo.EqualizeOrigin, _shapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange expectedShapes = GetShapes(SlideNo.EqualizeActualWidthAspectRatio, _shapeNames);
             actualShapes.LockAspectRatio = MsoTriState.msoTrue;
 
             _resizeLab.ResizeType = ResizeLabMain.ResizeBy.Actual;
@@ -84,8 +84,8 @@ namespace Test.UnitTest.ResizeLab
         [TestCategory("UT")]
         public void TestEqualizeVisualHeightWithoutAspectRatio()
         {
-            var actualShapes = GetShapes(SlideNo.EqualizeOrigin, _shapeNames);
-            var expectedShapes = GetShapes(SlideNo.EqualizeVisualHeight, _shapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange actualShapes = GetShapes(SlideNo.EqualizeOrigin, _shapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange expectedShapes = GetShapes(SlideNo.EqualizeVisualHeight, _shapeNames);
             actualShapes.LockAspectRatio = MsoTriState.msoFalse;
 
             _resizeLab.ResizeType = ResizeLabMain.ResizeBy.Visual;
@@ -97,8 +97,8 @@ namespace Test.UnitTest.ResizeLab
         [TestCategory("UT")]
         public void TestEqualizeVisualHeightWithAspectRatio()
         {
-            var actualShapes = GetShapes(SlideNo.EqualizeOrigin, _shapeNames);
-            var expectedShapes = GetShapes(SlideNo.EqualizeVisualHeightAspectRatio, _shapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange actualShapes = GetShapes(SlideNo.EqualizeOrigin, _shapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange expectedShapes = GetShapes(SlideNo.EqualizeVisualHeightAspectRatio, _shapeNames);
             actualShapes.LockAspectRatio = MsoTriState.msoTrue;
 
             _resizeLab.ResizeType = ResizeLabMain.ResizeBy.Visual;
@@ -110,8 +110,8 @@ namespace Test.UnitTest.ResizeLab
         [TestCategory("UT")]
         public void TestEqualizeActualHeightWithoutAspectRatio()
         {
-            var actualShapes = GetShapes(SlideNo.EqualizeOrigin, _shapeNames);
-            var expectedShapes = GetShapes(SlideNo.EqualizeActualHeight, _shapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange actualShapes = GetShapes(SlideNo.EqualizeOrigin, _shapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange expectedShapes = GetShapes(SlideNo.EqualizeActualHeight, _shapeNames);
             actualShapes.LockAspectRatio = MsoTriState.msoFalse;
 
             _resizeLab.ResizeType = ResizeLabMain.ResizeBy.Actual;
@@ -123,8 +123,8 @@ namespace Test.UnitTest.ResizeLab
         [TestCategory("UT")]
         public void TestEqualizeActualHeightWithAspectRatio()
         {
-            var actualShapes = GetShapes(SlideNo.EqualizeOrigin, _shapeNames);
-            var expectedShapes = GetShapes(SlideNo.EqualizeActualHeightAspectRatio, _shapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange actualShapes = GetShapes(SlideNo.EqualizeOrigin, _shapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange expectedShapes = GetShapes(SlideNo.EqualizeActualHeightAspectRatio, _shapeNames);
             actualShapes.LockAspectRatio = MsoTriState.msoTrue;
 
             _resizeLab.ResizeType = ResizeLabMain.ResizeBy.Actual;
@@ -136,8 +136,8 @@ namespace Test.UnitTest.ResizeLab
         [TestCategory("UT")]
         public void TestEqualizeVisualWidthAndHeight()
         {
-            var actualShapes = GetShapes(SlideNo.EqualizeOrigin, _shapeNames);
-            var expectedShapes = GetShapes(SlideNo.EqualizeVisualBoth, _shapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange actualShapes = GetShapes(SlideNo.EqualizeOrigin, _shapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange expectedShapes = GetShapes(SlideNo.EqualizeVisualBoth, _shapeNames);
             actualShapes.LockAspectRatio = MsoTriState.msoFalse;
 
             _resizeLab.ResizeType = ResizeLabMain.ResizeBy.Visual;
@@ -149,8 +149,8 @@ namespace Test.UnitTest.ResizeLab
         [TestCategory("UT")]
         public void TestEqualizeActualWidthAndHeight()
         {
-            var actualShapes = GetShapes(SlideNo.EqualizeOrigin, _shapeNames);
-            var expectedShapes = GetShapes(SlideNo.EqualizeActualBoth, _shapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange actualShapes = GetShapes(SlideNo.EqualizeOrigin, _shapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange expectedShapes = GetShapes(SlideNo.EqualizeActualBoth, _shapeNames);
             actualShapes.LockAspectRatio = MsoTriState.msoFalse;
 
             _resizeLab.ResizeType = ResizeLabMain.ResizeBy.Actual;

--- a/PowerPointLabs/Test/UnitTest/ResizeLab/FitToSlideTest.cs
+++ b/PowerPointLabs/Test/UnitTest/ResizeLab/FitToSlideTest.cs
@@ -30,10 +30,10 @@ namespace Test.UnitTest.ResizeLab
         [TestCategory("UT")]
         public void TestFitToWidthWithoutAspectRatio()
         {
-            var actualShapes = GetShapes(SlideNo.FitToSlideOrigin, _shapeNames);
-            var expectedShapes = GetShapes(SlideNo.FitToSlideWidth, _shapeNames);
-            var slideWidth = Pres.PageSetup.SlideWidth;
-            var slideHeight = Pres.PageSetup.SlideHeight;
+            Microsoft.Office.Interop.PowerPoint.ShapeRange actualShapes = GetShapes(SlideNo.FitToSlideOrigin, _shapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange expectedShapes = GetShapes(SlideNo.FitToSlideWidth, _shapeNames);
+            float slideWidth = Pres.PageSetup.SlideWidth;
+            float slideHeight = Pres.PageSetup.SlideHeight;
 
             _resizeLab.FitToWidth(actualShapes, slideWidth, slideHeight, false);
             CheckShapes(expectedShapes, actualShapes);
@@ -43,10 +43,10 @@ namespace Test.UnitTest.ResizeLab
         [TestCategory("UT")]
         public void TestFitToWidthWithAspectRatio()
         {
-            var actualShapes = GetShapes(SlideNo.FitToSlideOrigin, _shapeNames);
-            var expectedShapes = GetShapes(SlideNo.FitToSlideWidthAspectRatio, _shapeNames);
-            var slideWidth = Pres.PageSetup.SlideWidth;
-            var slideHeight = Pres.PageSetup.SlideHeight;
+            Microsoft.Office.Interop.PowerPoint.ShapeRange actualShapes = GetShapes(SlideNo.FitToSlideOrigin, _shapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange expectedShapes = GetShapes(SlideNo.FitToSlideWidthAspectRatio, _shapeNames);
+            float slideWidth = Pres.PageSetup.SlideWidth;
+            float slideHeight = Pres.PageSetup.SlideHeight;
 
             _resizeLab.FitToWidth(actualShapes, slideWidth, slideHeight, true);
             CheckShapes(expectedShapes, actualShapes);
@@ -56,10 +56,10 @@ namespace Test.UnitTest.ResizeLab
         [TestCategory("UT")]
         public void TestFitToHeightWithoutAspectRatio()
         {
-            var actualShapes = GetShapes(SlideNo.FitToSlideOrigin, _shapeNames);
-            var expectedShapes = GetShapes(SlideNo.FitToSlideHeight, _shapeNames);
-            var slideWidth = Pres.PageSetup.SlideWidth;
-            var slideHeight = Pres.PageSetup.SlideHeight;
+            Microsoft.Office.Interop.PowerPoint.ShapeRange actualShapes = GetShapes(SlideNo.FitToSlideOrigin, _shapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange expectedShapes = GetShapes(SlideNo.FitToSlideHeight, _shapeNames);
+            float slideWidth = Pres.PageSetup.SlideWidth;
+            float slideHeight = Pres.PageSetup.SlideHeight;
 
             _resizeLab.FitToHeight(actualShapes, slideWidth, slideHeight, false);
             CheckShapes(expectedShapes, actualShapes);
@@ -69,10 +69,10 @@ namespace Test.UnitTest.ResizeLab
         [TestCategory("UT")]
         public void TestFitToHeightWithAspectRatio()
         {
-            var actualShapes = GetShapes(SlideNo.FitToSlideOrigin, _shapeNames);
-            var expectedShapes = GetShapes(SlideNo.FitToSlideHeightAspectRatio, _shapeNames);
-            var slideWidth = Pres.PageSetup.SlideWidth;
-            var slideHeight = Pres.PageSetup.SlideHeight;
+            Microsoft.Office.Interop.PowerPoint.ShapeRange actualShapes = GetShapes(SlideNo.FitToSlideOrigin, _shapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange expectedShapes = GetShapes(SlideNo.FitToSlideHeightAspectRatio, _shapeNames);
+            float slideWidth = Pres.PageSetup.SlideWidth;
+            float slideHeight = Pres.PageSetup.SlideHeight;
 
             _resizeLab.FitToHeight(actualShapes, slideWidth, slideHeight, true);
             CheckShapes(expectedShapes, actualShapes);
@@ -82,10 +82,10 @@ namespace Test.UnitTest.ResizeLab
         [TestCategory("UT")]
         public void TestFitToFillWithoutAspectRatio()
         {
-            var actualShapes = GetShapes(SlideNo.FitToSlideOrigin, _shapeNames);
-            var expectedShapes = GetShapes(SlideNo.FitToSlideFill, _shapeNames);
-            var slideWidth = Pres.PageSetup.SlideWidth;
-            var slideHeight = Pres.PageSetup.SlideHeight;
+            Microsoft.Office.Interop.PowerPoint.ShapeRange actualShapes = GetShapes(SlideNo.FitToSlideOrigin, _shapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange expectedShapes = GetShapes(SlideNo.FitToSlideFill, _shapeNames);
+            float slideWidth = Pres.PageSetup.SlideWidth;
+            float slideHeight = Pres.PageSetup.SlideHeight;
 
             _resizeLab.FitToFill(actualShapes, slideWidth, slideHeight, false);
             CheckShapes(expectedShapes, actualShapes);
@@ -95,10 +95,10 @@ namespace Test.UnitTest.ResizeLab
         [TestCategory("UT")]
         public void TestFitToFillWithAspectRatio()
         {
-            var actualShapes = GetShapes(SlideNo.FitToSlideOrigin, _shapeNames);
-            var expectedShapes = GetShapes(SlideNo.FitToSlideFillAspectRatio, _shapeNames);
-            var slideWidth = Pres.PageSetup.SlideWidth;
-            var slideHeight = Pres.PageSetup.SlideHeight;
+            Microsoft.Office.Interop.PowerPoint.ShapeRange actualShapes = GetShapes(SlideNo.FitToSlideOrigin, _shapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange expectedShapes = GetShapes(SlideNo.FitToSlideFillAspectRatio, _shapeNames);
+            float slideWidth = Pres.PageSetup.SlideWidth;
+            float slideHeight = Pres.PageSetup.SlideHeight;
 
             _resizeLab.FitToFill(actualShapes, slideWidth, slideHeight, true);
             CheckShapes(expectedShapes, actualShapes);

--- a/PowerPointLabs/Test/UnitTest/ResizeLab/MainSettingsTest.cs
+++ b/PowerPointLabs/Test/UnitTest/ResizeLab/MainSettingsTest.cs
@@ -44,7 +44,7 @@ namespace Test.UnitTest.ResizeLab
         [TestCategory("UT")]
         public void TestLockAspectRatio()
         {
-            var shapes = GetShapes(SlideNo.AnchorOrigin, _shapeNames);
+            PowerPoint.ShapeRange shapes = GetShapes(SlideNo.AnchorOrigin, _shapeNames);
 
             _resizeLab.ChangeShapesAspectRatio(shapes, true);
 
@@ -58,7 +58,7 @@ namespace Test.UnitTest.ResizeLab
         [TestCategory("UT")]
         public void TestUnlockAspectRatio()
         {
-            var shapes = GetShapes(SlideNo.AnchorOrigin, _shapeNames);
+            PowerPoint.ShapeRange shapes = GetShapes(SlideNo.AnchorOrigin, _shapeNames);
 
             _resizeLab.ChangeShapesAspectRatio(shapes, false);
 
@@ -72,8 +72,8 @@ namespace Test.UnitTest.ResizeLab
         [TestCategory("UT")]
         public void TestEqualizeVisualAnchorTopLeft()
         {
-            var actualShapes = GetShapes(SlideNo.AnchorOrigin, _shapeNames);
-            var expectedShapes = GetShapes(SlideNo.AnchorVisualTopLeft, _shapeNames);
+            PowerPoint.ShapeRange actualShapes = GetShapes(SlideNo.AnchorOrigin, _shapeNames);
+            PowerPoint.ShapeRange expectedShapes = GetShapes(SlideNo.AnchorVisualTopLeft, _shapeNames);
 
             actualShapes.LockAspectRatio = MsoTriState.msoFalse;
             _resizeLab.AnchorPointType = ResizeLabMain.AnchorPoint.TopLeft;
@@ -86,8 +86,8 @@ namespace Test.UnitTest.ResizeLab
         [TestCategory("UT")]
         public void TestEqualizeActualAnchorTopLeft()
         {
-            var actualShapes = GetShapes(SlideNo.AnchorOrigin, _shapeNames);
-            var expectedShapes = GetShapes(SlideNo.AnchorActualTopLeft, _shapeNames);
+            PowerPoint.ShapeRange actualShapes = GetShapes(SlideNo.AnchorOrigin, _shapeNames);
+            PowerPoint.ShapeRange expectedShapes = GetShapes(SlideNo.AnchorActualTopLeft, _shapeNames);
 
             actualShapes.LockAspectRatio = MsoTriState.msoFalse;
             _resizeLab.AnchorPointType = ResizeLabMain.AnchorPoint.TopLeft;
@@ -100,8 +100,8 @@ namespace Test.UnitTest.ResizeLab
         [TestCategory("UT")]
         public void TestEqualizeVisualAnchorTopCenter()
         {
-            var actualShapes = GetShapes(SlideNo.AnchorOrigin, _shapeNames);
-            var expectedShapes = GetShapes(SlideNo.AnchorVisualTopCenter, _shapeNames);
+            PowerPoint.ShapeRange actualShapes = GetShapes(SlideNo.AnchorOrigin, _shapeNames);
+            PowerPoint.ShapeRange expectedShapes = GetShapes(SlideNo.AnchorVisualTopCenter, _shapeNames);
 
             actualShapes.LockAspectRatio = MsoTriState.msoFalse;
             _resizeLab.AnchorPointType = ResizeLabMain.AnchorPoint.TopCenter;
@@ -114,8 +114,8 @@ namespace Test.UnitTest.ResizeLab
         [TestCategory("UT")]
         public void TestEqualizeActualAnchorTopCenter()
         {
-            var actualShapes = GetShapes(SlideNo.AnchorOrigin, _shapeNames);
-            var expectedShapes = GetShapes(SlideNo.AnchorActualTopCenter, _shapeNames);
+            PowerPoint.ShapeRange actualShapes = GetShapes(SlideNo.AnchorOrigin, _shapeNames);
+            PowerPoint.ShapeRange expectedShapes = GetShapes(SlideNo.AnchorActualTopCenter, _shapeNames);
 
             actualShapes.LockAspectRatio = MsoTriState.msoFalse;
             _resizeLab.AnchorPointType = ResizeLabMain.AnchorPoint.TopCenter;
@@ -128,8 +128,8 @@ namespace Test.UnitTest.ResizeLab
         [TestCategory("UT")]
         public void TestEqualizeVisualAnchorTopRight()
         {
-            var actualShapes = GetShapes(SlideNo.AnchorOrigin, _shapeNames);
-            var expectedShapes = GetShapes(SlideNo.AnchorVisualTopRight, _shapeNames);
+            PowerPoint.ShapeRange actualShapes = GetShapes(SlideNo.AnchorOrigin, _shapeNames);
+            PowerPoint.ShapeRange expectedShapes = GetShapes(SlideNo.AnchorVisualTopRight, _shapeNames);
 
             actualShapes.LockAspectRatio = MsoTriState.msoFalse;
             _resizeLab.AnchorPointType = ResizeLabMain.AnchorPoint.TopRight;
@@ -142,8 +142,8 @@ namespace Test.UnitTest.ResizeLab
         [TestCategory("UT")]
         public void TestEqualizeActualAnchorTopRight()
         {
-            var actualShapes = GetShapes(SlideNo.AnchorOrigin, _shapeNames);
-            var expectedShapes = GetShapes(SlideNo.AnchorActualTopRight, _shapeNames);
+            PowerPoint.ShapeRange actualShapes = GetShapes(SlideNo.AnchorOrigin, _shapeNames);
+            PowerPoint.ShapeRange expectedShapes = GetShapes(SlideNo.AnchorActualTopRight, _shapeNames);
 
             actualShapes.LockAspectRatio = MsoTriState.msoFalse;
             _resizeLab.AnchorPointType = ResizeLabMain.AnchorPoint.TopRight;
@@ -156,8 +156,8 @@ namespace Test.UnitTest.ResizeLab
         [TestCategory("UT")]
         public void TestEqualizeVisualAnchorMiddleLeft()
         {
-            var actualShapes = GetShapes(SlideNo.AnchorOrigin, _shapeNames);
-            var expectedShapes = GetShapes(SlideNo.AnchorVisualMiddleLeft, _shapeNames);
+            PowerPoint.ShapeRange actualShapes = GetShapes(SlideNo.AnchorOrigin, _shapeNames);
+            PowerPoint.ShapeRange expectedShapes = GetShapes(SlideNo.AnchorVisualMiddleLeft, _shapeNames);
 
             actualShapes.LockAspectRatio = MsoTriState.msoFalse;
             _resizeLab.AnchorPointType = ResizeLabMain.AnchorPoint.MiddleLeft;
@@ -170,8 +170,8 @@ namespace Test.UnitTest.ResizeLab
         [TestCategory("UT")]
         public void TestEqualizeActualAnchorMiddleLeft()
         {
-            var actualShapes = GetShapes(SlideNo.AnchorOrigin, _shapeNames);
-            var expectedShapes = GetShapes(SlideNo.AnchorActualMiddleLeft, _shapeNames);
+            PowerPoint.ShapeRange actualShapes = GetShapes(SlideNo.AnchorOrigin, _shapeNames);
+            PowerPoint.ShapeRange expectedShapes = GetShapes(SlideNo.AnchorActualMiddleLeft, _shapeNames);
 
             actualShapes.LockAspectRatio = MsoTriState.msoFalse;
             _resizeLab.AnchorPointType = ResizeLabMain.AnchorPoint.MiddleLeft;
@@ -184,8 +184,8 @@ namespace Test.UnitTest.ResizeLab
         [TestCategory("UT")]
         public void TestEqualizeVisualAnchorCenter()
         {
-            var actualShapes = GetShapes(SlideNo.AnchorOrigin, _shapeNames);
-            var expectedShapes = GetShapes(SlideNo.AnchorVisualCenter, _shapeNames);
+            PowerPoint.ShapeRange actualShapes = GetShapes(SlideNo.AnchorOrigin, _shapeNames);
+            PowerPoint.ShapeRange expectedShapes = GetShapes(SlideNo.AnchorVisualCenter, _shapeNames);
 
             actualShapes.LockAspectRatio = MsoTriState.msoFalse;
             _resizeLab.AnchorPointType = ResizeLabMain.AnchorPoint.Center;
@@ -198,8 +198,8 @@ namespace Test.UnitTest.ResizeLab
         [TestCategory("UT")]
         public void TestEqualizeActualAnchorCenter()
         {
-            var actualShapes = GetShapes(SlideNo.AnchorOrigin, _shapeNames);
-            var expectedShapes = GetShapes(SlideNo.AnchorActualCenter, _shapeNames);
+            PowerPoint.ShapeRange actualShapes = GetShapes(SlideNo.AnchorOrigin, _shapeNames);
+            PowerPoint.ShapeRange expectedShapes = GetShapes(SlideNo.AnchorActualCenter, _shapeNames);
 
             actualShapes.LockAspectRatio = MsoTriState.msoFalse;
             _resizeLab.AnchorPointType = ResizeLabMain.AnchorPoint.Center;
@@ -212,8 +212,8 @@ namespace Test.UnitTest.ResizeLab
         [TestCategory("UT")]
         public void TestEqualizeVisualAnchorMiddleRight()
         {
-            var actualShapes = GetShapes(SlideNo.AnchorOrigin, _shapeNames);
-            var expectedShapes = GetShapes(SlideNo.AnchorVisualMiddleRight, _shapeNames);
+            PowerPoint.ShapeRange actualShapes = GetShapes(SlideNo.AnchorOrigin, _shapeNames);
+            PowerPoint.ShapeRange expectedShapes = GetShapes(SlideNo.AnchorVisualMiddleRight, _shapeNames);
 
             actualShapes.LockAspectRatio = MsoTriState.msoFalse;
             _resizeLab.AnchorPointType = ResizeLabMain.AnchorPoint.MiddleRight;
@@ -226,8 +226,8 @@ namespace Test.UnitTest.ResizeLab
         [TestCategory("UT")]
         public void TestEqualizeActualAnchorMiddleRight()
         {
-            var actualShapes = GetShapes(SlideNo.AnchorOrigin, _shapeNames);
-            var expectedShapes = GetShapes(SlideNo.AnchorActualMiddleRight, _shapeNames);
+            PowerPoint.ShapeRange actualShapes = GetShapes(SlideNo.AnchorOrigin, _shapeNames);
+            PowerPoint.ShapeRange expectedShapes = GetShapes(SlideNo.AnchorActualMiddleRight, _shapeNames);
 
             actualShapes.LockAspectRatio = MsoTriState.msoFalse;
             _resizeLab.AnchorPointType = ResizeLabMain.AnchorPoint.MiddleRight;
@@ -240,8 +240,8 @@ namespace Test.UnitTest.ResizeLab
         [TestCategory("UT")]
         public void TestEqualizeVisualAnchorBottomLeft()
         {
-            var actualShapes = GetShapes(SlideNo.AnchorOrigin, _shapeNames);
-            var expectedShapes = GetShapes(SlideNo.AnchorVisualBottomLeft, _shapeNames);
+            PowerPoint.ShapeRange actualShapes = GetShapes(SlideNo.AnchorOrigin, _shapeNames);
+            PowerPoint.ShapeRange expectedShapes = GetShapes(SlideNo.AnchorVisualBottomLeft, _shapeNames);
 
             actualShapes.LockAspectRatio = MsoTriState.msoFalse;
             _resizeLab.AnchorPointType = ResizeLabMain.AnchorPoint.BottomLeft;
@@ -254,8 +254,8 @@ namespace Test.UnitTest.ResizeLab
         [TestCategory("UT")]
         public void TestEqualizeActualAnchorBottomLeft()
         {
-            var actualShapes = GetShapes(SlideNo.AnchorOrigin, _shapeNames);
-            var expectedShapes = GetShapes(SlideNo.AnchorActualBottomLeft, _shapeNames);
+            PowerPoint.ShapeRange actualShapes = GetShapes(SlideNo.AnchorOrigin, _shapeNames);
+            PowerPoint.ShapeRange expectedShapes = GetShapes(SlideNo.AnchorActualBottomLeft, _shapeNames);
 
             actualShapes.LockAspectRatio = MsoTriState.msoFalse;
             _resizeLab.AnchorPointType = ResizeLabMain.AnchorPoint.BottomLeft;
@@ -268,8 +268,8 @@ namespace Test.UnitTest.ResizeLab
         [TestCategory("UT")]
         public void TestEqualizeVisualAnchorBottomCenter()
         {
-            var actualShapes = GetShapes(SlideNo.AnchorOrigin, _shapeNames);
-            var expectedShapes = GetShapes(SlideNo.AnchorVisualBottomCenter, _shapeNames);
+            PowerPoint.ShapeRange actualShapes = GetShapes(SlideNo.AnchorOrigin, _shapeNames);
+            PowerPoint.ShapeRange expectedShapes = GetShapes(SlideNo.AnchorVisualBottomCenter, _shapeNames);
 
             actualShapes.LockAspectRatio = MsoTriState.msoFalse;
             _resizeLab.AnchorPointType = ResizeLabMain.AnchorPoint.BottomCenter;
@@ -282,8 +282,8 @@ namespace Test.UnitTest.ResizeLab
         [TestCategory("UT")]
         public void TestEqualizeActualAnchorBottomCenter()
         {
-            var actualShapes = GetShapes(SlideNo.AnchorOrigin, _shapeNames);
-            var expectedShapes = GetShapes(SlideNo.AnchorActualBottomCenter, _shapeNames);
+            PowerPoint.ShapeRange actualShapes = GetShapes(SlideNo.AnchorOrigin, _shapeNames);
+            PowerPoint.ShapeRange expectedShapes = GetShapes(SlideNo.AnchorActualBottomCenter, _shapeNames);
 
             actualShapes.LockAspectRatio = MsoTriState.msoFalse;
             _resizeLab.AnchorPointType = ResizeLabMain.AnchorPoint.BottomCenter;
@@ -296,8 +296,8 @@ namespace Test.UnitTest.ResizeLab
         [TestCategory("UT")]
         public void TestEqualizeVisualAnchorBottomRight()
         {
-            var actualShapes = GetShapes(SlideNo.AnchorOrigin, _shapeNames);
-            var expectedShapes = GetShapes(SlideNo.AnchorVisualBottomRight, _shapeNames);
+            PowerPoint.ShapeRange actualShapes = GetShapes(SlideNo.AnchorOrigin, _shapeNames);
+            PowerPoint.ShapeRange expectedShapes = GetShapes(SlideNo.AnchorVisualBottomRight, _shapeNames);
 
             actualShapes.LockAspectRatio = MsoTriState.msoFalse;
             _resizeLab.AnchorPointType = ResizeLabMain.AnchorPoint.BottomRight;
@@ -310,8 +310,8 @@ namespace Test.UnitTest.ResizeLab
         [TestCategory("UT")]
         public void TestEqualizeActualAnchorBottomRight()
         {
-            var actualShapes = GetShapes(SlideNo.AnchorOrigin, _shapeNames);
-            var expectedShapes = GetShapes(SlideNo.AnchorActualBottomRight, _shapeNames);
+            PowerPoint.ShapeRange actualShapes = GetShapes(SlideNo.AnchorOrigin, _shapeNames);
+            PowerPoint.ShapeRange expectedShapes = GetShapes(SlideNo.AnchorActualBottomRight, _shapeNames);
 
             actualShapes.LockAspectRatio = MsoTriState.msoFalse;
             _resizeLab.AnchorPointType = ResizeLabMain.AnchorPoint.BottomRight;

--- a/PowerPointLabs/Test/UnitTest/ResizeLab/MatchTest.cs
+++ b/PowerPointLabs/Test/UnitTest/ResizeLab/MatchTest.cs
@@ -30,8 +30,8 @@ namespace Test.UnitTest.ResizeLab
         [TestCategory("UT")]
         public void TestVisualMatchWidth()
         {
-            var actualShapes = GetShapes(SlideNo.MatchOrigin, _shapeNames);
-            var expectedShapes = GetShapes(SlideNo.MatchVisualWidth, _shapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange actualShapes = GetShapes(SlideNo.MatchOrigin, _shapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange expectedShapes = GetShapes(SlideNo.MatchVisualWidth, _shapeNames);
 
             _resizeLab.ResizeType = ResizeLabMain.ResizeBy.Visual;
             _resizeLab.MatchWidth(actualShapes);
@@ -42,8 +42,8 @@ namespace Test.UnitTest.ResizeLab
         [TestCategory("UT")]
         public void TestActualMatchWidth()
         {
-            var actualShapes = GetShapes(SlideNo.MatchOrigin, _shapeNames);
-            var expectedShapes = GetShapes(SlideNo.MatchActualWidth, _shapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange actualShapes = GetShapes(SlideNo.MatchOrigin, _shapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange expectedShapes = GetShapes(SlideNo.MatchActualWidth, _shapeNames);
 
             _resizeLab.ResizeType = ResizeLabMain.ResizeBy.Actual;
             _resizeLab.MatchWidth(actualShapes);
@@ -54,8 +54,8 @@ namespace Test.UnitTest.ResizeLab
         [TestCategory("UT")]
         public void TestVisualMatchHeight()
         {
-            var actualShapes = GetShapes(SlideNo.MatchOrigin, _shapeNames);
-            var expectedShapes = GetShapes(SlideNo.MatchVisualHeight, _shapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange actualShapes = GetShapes(SlideNo.MatchOrigin, _shapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange expectedShapes = GetShapes(SlideNo.MatchVisualHeight, _shapeNames);
 
             _resizeLab.ResizeType = ResizeLabMain.ResizeBy.Visual;
             _resizeLab.MatchHeight(actualShapes);
@@ -66,8 +66,8 @@ namespace Test.UnitTest.ResizeLab
         [TestCategory("UT")]
         public void TestActualMatchHeight()
         {
-            var actualShapes = GetShapes(SlideNo.MatchOrigin, _shapeNames);
-            var expectedShapes = GetShapes(SlideNo.MatchActualHeight, _shapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange actualShapes = GetShapes(SlideNo.MatchOrigin, _shapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange expectedShapes = GetShapes(SlideNo.MatchActualHeight, _shapeNames);
 
             _resizeLab.ResizeType = ResizeLabMain.ResizeBy.Actual;
             _resizeLab.MatchHeight(actualShapes);

--- a/PowerPointLabs/Test/UnitTest/ResizeLab/SlightAdjustTest.cs
+++ b/PowerPointLabs/Test/UnitTest/ResizeLab/SlightAdjustTest.cs
@@ -31,8 +31,8 @@ namespace Test.UnitTest.ResizeLab
         [TestCategory("UT")]
         public void TestSlightIncreaseVisualWidthWithoutAspectRatio()
         {
-            var actualShapes = GetShapes(SlideNo.SlightAdjustOrigin, _shapeNames);
-            var expectedShapes = GetShapes(SlideNo.SlightVisualIncreaseWidth, _shapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange actualShapes = GetShapes(SlideNo.SlightAdjustOrigin, _shapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange expectedShapes = GetShapes(SlideNo.SlightVisualIncreaseWidth, _shapeNames);
             actualShapes.LockAspectRatio = MsoTriState.msoFalse;
 
             _resizeLab.ResizeType = ResizeLabMain.ResizeBy.Visual;
@@ -44,8 +44,8 @@ namespace Test.UnitTest.ResizeLab
         [TestCategory("UT")]
         public void TestSlightIncreaseActualWidthWithoutAspectRatio()
         {
-            var actualShapes = GetShapes(SlideNo.SlightAdjustOrigin, _shapeNames);
-            var expectedShapes = GetShapes(SlideNo.SlightActualIncreaseWidth, _shapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange actualShapes = GetShapes(SlideNo.SlightAdjustOrigin, _shapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange expectedShapes = GetShapes(SlideNo.SlightActualIncreaseWidth, _shapeNames);
             actualShapes.LockAspectRatio = MsoTriState.msoFalse;
 
             _resizeLab.ResizeType = ResizeLabMain.ResizeBy.Actual;
@@ -57,8 +57,8 @@ namespace Test.UnitTest.ResizeLab
         [TestCategory("UT")]
         public void TestSlightIncreaseVisualWidthWithAspectRatio()
         {
-            var actualShapes = GetShapes(SlideNo.SlightAdjustOrigin, _shapeNames);
-            var expectedShapes = GetShapes(SlideNo.SlightVisualIncreaseWidthAspectRatio, _shapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange actualShapes = GetShapes(SlideNo.SlightAdjustOrigin, _shapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange expectedShapes = GetShapes(SlideNo.SlightVisualIncreaseWidthAspectRatio, _shapeNames);
             actualShapes.LockAspectRatio = MsoTriState.msoTrue;
 
             _resizeLab.ResizeType = ResizeLabMain.ResizeBy.Visual;
@@ -70,8 +70,8 @@ namespace Test.UnitTest.ResizeLab
         [TestCategory("UT")]
         public void TestSlightIncreaseActualWidthWithAspectRatio()
         {
-            var actualShapes = GetShapes(SlideNo.SlightAdjustOrigin, _shapeNames);
-            var expectedShapes = GetShapes(SlideNo.SlightActualIncreaseWidthAspectRatio, _shapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange actualShapes = GetShapes(SlideNo.SlightAdjustOrigin, _shapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange expectedShapes = GetShapes(SlideNo.SlightActualIncreaseWidthAspectRatio, _shapeNames);
             actualShapes.LockAspectRatio = MsoTriState.msoTrue;
 
             _resizeLab.ResizeType = ResizeLabMain.ResizeBy.Actual;
@@ -83,8 +83,8 @@ namespace Test.UnitTest.ResizeLab
         [TestCategory("UT")]
         public void TestSlightDecreaseVisualWidthWithoutAspectRatio()
         {
-            var actualShapes = GetShapes(SlideNo.SlightAdjustOrigin, _shapeNames);
-            var expectedShapes = GetShapes(SlideNo.SlightVisualDecreaseWidth, _shapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange actualShapes = GetShapes(SlideNo.SlightAdjustOrigin, _shapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange expectedShapes = GetShapes(SlideNo.SlightVisualDecreaseWidth, _shapeNames);
             actualShapes.LockAspectRatio = MsoTriState.msoFalse;
 
             _resizeLab.ResizeType = ResizeLabMain.ResizeBy.Visual;
@@ -96,8 +96,8 @@ namespace Test.UnitTest.ResizeLab
         [TestCategory("UT")]
         public void TestSlightDecreaseActualWidthWithoutAspectRatio()
         {
-            var actualShapes = GetShapes(SlideNo.SlightAdjustOrigin, _shapeNames);
-            var expectedShapes = GetShapes(SlideNo.SlightActualDecreaseWidth, _shapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange actualShapes = GetShapes(SlideNo.SlightAdjustOrigin, _shapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange expectedShapes = GetShapes(SlideNo.SlightActualDecreaseWidth, _shapeNames);
             actualShapes.LockAspectRatio = MsoTriState.msoFalse;
 
             _resizeLab.ResizeType = ResizeLabMain.ResizeBy.Actual;
@@ -109,8 +109,8 @@ namespace Test.UnitTest.ResizeLab
         [TestCategory("UT")]
         public void TestSlightDecreaseVisualWidthWithAspectRatio()
         {
-            var actualShapes = GetShapes(SlideNo.SlightAdjustOrigin, _shapeNames);
-            var expectedShapes = GetShapes(SlideNo.SlightVisualDecreaseWidthAspectRatio, _shapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange actualShapes = GetShapes(SlideNo.SlightAdjustOrigin, _shapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange expectedShapes = GetShapes(SlideNo.SlightVisualDecreaseWidthAspectRatio, _shapeNames);
             actualShapes.LockAspectRatio = MsoTriState.msoTrue;
 
             _resizeLab.ResizeType = ResizeLabMain.ResizeBy.Visual;
@@ -122,8 +122,8 @@ namespace Test.UnitTest.ResizeLab
         [TestCategory("UT")]
         public void TestSlightDecreaseActualWidthWithAspectRatio()
         {
-            var actualShapes = GetShapes(SlideNo.SlightAdjustOrigin, _shapeNames);
-            var expectedShapes = GetShapes(SlideNo.SlightActualDecreaseWidthAspectRatio, _shapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange actualShapes = GetShapes(SlideNo.SlightAdjustOrigin, _shapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange expectedShapes = GetShapes(SlideNo.SlightActualDecreaseWidthAspectRatio, _shapeNames);
             actualShapes.LockAspectRatio = MsoTriState.msoTrue;
 
             _resizeLab.ResizeType = ResizeLabMain.ResizeBy.Actual;
@@ -135,8 +135,8 @@ namespace Test.UnitTest.ResizeLab
         [TestCategory("UT")]
         public void TestSlightIncreaseVisualHeightWithoutAspectRatio()
         {
-            var actualShapes = GetShapes(SlideNo.SlightAdjustOrigin, _shapeNames);
-            var expectedShapes = GetShapes(SlideNo.SlightVisualIncreaseHeight, _shapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange actualShapes = GetShapes(SlideNo.SlightAdjustOrigin, _shapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange expectedShapes = GetShapes(SlideNo.SlightVisualIncreaseHeight, _shapeNames);
             actualShapes.LockAspectRatio = MsoTriState.msoFalse;
 
             _resizeLab.ResizeType = ResizeLabMain.ResizeBy.Visual;
@@ -148,8 +148,8 @@ namespace Test.UnitTest.ResizeLab
         [TestCategory("UT")]
         public void TestSlightIncreaseActualHeightWithoutAspectRatio()
         {
-            var actualShapes = GetShapes(SlideNo.SlightAdjustOrigin, _shapeNames);
-            var expectedShapes = GetShapes(SlideNo.SlightActualIncreaseHeight, _shapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange actualShapes = GetShapes(SlideNo.SlightAdjustOrigin, _shapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange expectedShapes = GetShapes(SlideNo.SlightActualIncreaseHeight, _shapeNames);
             actualShapes.LockAspectRatio = MsoTriState.msoFalse;
 
             _resizeLab.ResizeType = ResizeLabMain.ResizeBy.Actual;
@@ -161,8 +161,8 @@ namespace Test.UnitTest.ResizeLab
         [TestCategory("UT")]
         public void TestSlightIncreaseVisualHeightWithAspectRatio()
         {
-            var actualShapes = GetShapes(SlideNo.SlightAdjustOrigin, _shapeNames);
-            var expectedShapes = GetShapes(SlideNo.SlightVisualIncreaseHeightAspectRatio, _shapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange actualShapes = GetShapes(SlideNo.SlightAdjustOrigin, _shapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange expectedShapes = GetShapes(SlideNo.SlightVisualIncreaseHeightAspectRatio, _shapeNames);
             actualShapes.LockAspectRatio = MsoTriState.msoTrue;
 
             _resizeLab.ResizeType = ResizeLabMain.ResizeBy.Visual;
@@ -174,8 +174,8 @@ namespace Test.UnitTest.ResizeLab
         [TestCategory("UT")]
         public void TestSlightIncreaseActualHeightWithAspectRatio()
         {
-            var actualShapes = GetShapes(SlideNo.SlightAdjustOrigin, _shapeNames);
-            var expectedShapes = GetShapes(SlideNo.SlightActualIncreaseHeightAspectRatio, _shapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange actualShapes = GetShapes(SlideNo.SlightAdjustOrigin, _shapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange expectedShapes = GetShapes(SlideNo.SlightActualIncreaseHeightAspectRatio, _shapeNames);
             actualShapes.LockAspectRatio = MsoTriState.msoTrue;
 
             _resizeLab.ResizeType = ResizeLabMain.ResizeBy.Actual;
@@ -187,8 +187,8 @@ namespace Test.UnitTest.ResizeLab
         [TestCategory("UT")]
         public void TestSlightDecreaseVisualHeightWithoutAspectRatio()
         {
-            var actualShapes = GetShapes(SlideNo.SlightAdjustOrigin, _shapeNames);
-            var expectedShapes = GetShapes(SlideNo.SlightVisualDecreaseHeight, _shapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange actualShapes = GetShapes(SlideNo.SlightAdjustOrigin, _shapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange expectedShapes = GetShapes(SlideNo.SlightVisualDecreaseHeight, _shapeNames);
             actualShapes.LockAspectRatio = MsoTriState.msoFalse;
 
             _resizeLab.ResizeType = ResizeLabMain.ResizeBy.Visual;
@@ -200,8 +200,8 @@ namespace Test.UnitTest.ResizeLab
         [TestCategory("UT")]
         public void TestSlightDecreaseActualHeightWithoutAspectRatio()
         {
-            var actualShapes = GetShapes(SlideNo.SlightAdjustOrigin, _shapeNames);
-            var expectedShapes = GetShapes(SlideNo.SlightActualDecreaseHeight, _shapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange actualShapes = GetShapes(SlideNo.SlightAdjustOrigin, _shapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange expectedShapes = GetShapes(SlideNo.SlightActualDecreaseHeight, _shapeNames);
             actualShapes.LockAspectRatio = MsoTriState.msoFalse;
 
             _resizeLab.ResizeType = ResizeLabMain.ResizeBy.Actual;
@@ -213,8 +213,8 @@ namespace Test.UnitTest.ResizeLab
         [TestCategory("UT")]
         public void TestSlightDecreaseVisualHeightWithAspectRatio()
         {
-            var actualShapes = GetShapes(SlideNo.SlightAdjustOrigin, _shapeNames);
-            var expectedShapes = GetShapes(SlideNo.SlightVisualDecreaseHeightAspectRatio, _shapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange actualShapes = GetShapes(SlideNo.SlightAdjustOrigin, _shapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange expectedShapes = GetShapes(SlideNo.SlightVisualDecreaseHeightAspectRatio, _shapeNames);
             actualShapes.LockAspectRatio = MsoTriState.msoTrue;
 
             _resizeLab.ResizeType = ResizeLabMain.ResizeBy.Visual;
@@ -226,8 +226,8 @@ namespace Test.UnitTest.ResizeLab
         [TestCategory("UT")]
         public void TestSlightDecreaseActualHeightWithAspectRatio()
         {
-            var actualShapes = GetShapes(SlideNo.SlightAdjustOrigin, _shapeNames);
-            var expectedShapes = GetShapes(SlideNo.SlightActualDecreaseHeightAspectRatio, _shapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange actualShapes = GetShapes(SlideNo.SlightAdjustOrigin, _shapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange expectedShapes = GetShapes(SlideNo.SlightActualDecreaseHeightAspectRatio, _shapeNames);
             actualShapes.LockAspectRatio = MsoTriState.msoTrue;
 
             _resizeLab.ResizeType = ResizeLabMain.ResizeBy.Actual;

--- a/PowerPointLabs/Test/UnitTest/ResizeLab/StretchShrinkTest.cs
+++ b/PowerPointLabs/Test/UnitTest/ResizeLab/StretchShrinkTest.cs
@@ -33,8 +33,8 @@ namespace Test.UnitTest.ResizeLab
         [TestCategory("UT")]
         public void TestStretchLeftWithoutAspectRatio()
         {
-            var actualShapes = GetShapes(SlideNo.StretchOrigin, _shapeNames);
-            var expectedShapes = GetShapes(SlideNo.StretchLeft, _shapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange actualShapes = GetShapes(SlideNo.StretchOrigin, _shapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange expectedShapes = GetShapes(SlideNo.StretchLeft, _shapeNames);
 
             _resizeLab.StretchLeft(actualShapes);
             CheckShapes(expectedShapes, actualShapes);
@@ -44,8 +44,8 @@ namespace Test.UnitTest.ResizeLab
         [TestCategory("UT")]
         public void TestStretchLeftWithAspectRatio()
         {
-            var actualShapes = GetShapes(SlideNo.StretchOrigin, _shapeNames);
-            var expectedShapes = GetShapes(SlideNo.StretchLeftAspectRatio, _shapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange actualShapes = GetShapes(SlideNo.StretchOrigin, _shapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange expectedShapes = GetShapes(SlideNo.StretchLeftAspectRatio, _shapeNames);
 
             actualShapes.LockAspectRatio = MsoTriState.msoTrue;
             _resizeLab.StretchLeft(actualShapes);
@@ -56,8 +56,8 @@ namespace Test.UnitTest.ResizeLab
         [TestCategory("UT")]
         public void TestStretchLeftOuterMost()
         {
-            var actualShapes = GetShapes(SlideNo.StretchOrigin, _shapeNames);
-            var expectedShapes = GetShapes(SlideNo.StretchLeftOuterMost, _shapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange actualShapes = GetShapes(SlideNo.StretchOrigin, _shapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange expectedShapes = GetShapes(SlideNo.StretchLeftOuterMost, _shapeNames);
 
             _resizeLab.ReferenceType = ResizeLabMain.StretchRefType.Outermost;
             _resizeLab.StretchLeft(actualShapes);
@@ -68,8 +68,8 @@ namespace Test.UnitTest.ResizeLab
         [TestCategory("UT")]
         public void TestStretchRightWithoutAspectRatio()
         {
-            var actualShapes = GetShapes(SlideNo.StretchOrigin, _shapeNames);
-            var expectedShapes = GetShapes(SlideNo.StretchRight, _shapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange actualShapes = GetShapes(SlideNo.StretchOrigin, _shapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange expectedShapes = GetShapes(SlideNo.StretchRight, _shapeNames);
 
             _resizeLab.StretchRight(actualShapes);
             CheckShapes(expectedShapes, actualShapes);
@@ -79,8 +79,8 @@ namespace Test.UnitTest.ResizeLab
         [TestCategory("UT")]
         public void TestStretchRightWithAspectRatio()
         {
-            var actualShapes = GetShapes(SlideNo.StretchOrigin, _shapeNames);
-            var expectedShapes = GetShapes(SlideNo.StretchRightAspectRatio, _shapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange actualShapes = GetShapes(SlideNo.StretchOrigin, _shapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange expectedShapes = GetShapes(SlideNo.StretchRightAspectRatio, _shapeNames);
 
             actualShapes.LockAspectRatio = MsoTriState.msoTrue;
             _resizeLab.StretchRight(actualShapes);
@@ -91,8 +91,8 @@ namespace Test.UnitTest.ResizeLab
         [TestCategory("UT")]
         public void TestStretchRightOuterMost()
         {
-            var actualShapes = GetShapes(SlideNo.StretchOrigin, _shapeNames);
-            var expectedShapes = GetShapes(SlideNo.StretchRightOuterMost, _shapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange actualShapes = GetShapes(SlideNo.StretchOrigin, _shapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange expectedShapes = GetShapes(SlideNo.StretchRightOuterMost, _shapeNames);
 
             _resizeLab.ReferenceType = ResizeLabMain.StretchRefType.Outermost;
             _resizeLab.StretchRight(actualShapes);
@@ -103,8 +103,8 @@ namespace Test.UnitTest.ResizeLab
         [TestCategory("UT")]
         public void TestStretchTopWithoutAspectRatio()
         {
-            var actualShapes = GetShapes(SlideNo.StretchOrigin, _shapeNames);
-            var expectedShapes = GetShapes(SlideNo.StretchTop, _shapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange actualShapes = GetShapes(SlideNo.StretchOrigin, _shapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange expectedShapes = GetShapes(SlideNo.StretchTop, _shapeNames);
 
             _resizeLab.StretchTop(actualShapes);
             CheckShapes(expectedShapes, actualShapes);
@@ -114,8 +114,8 @@ namespace Test.UnitTest.ResizeLab
         [TestCategory("UT")]
         public void TestStretchTopWithAspectRatio()
         {
-            var actualShapes = GetShapes(SlideNo.StretchOrigin, _shapeNames);
-            var expectedShapes = GetShapes(SlideNo.StretchTopAspectRatio, _shapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange actualShapes = GetShapes(SlideNo.StretchOrigin, _shapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange expectedShapes = GetShapes(SlideNo.StretchTopAspectRatio, _shapeNames);
 
             actualShapes.LockAspectRatio = MsoTriState.msoTrue;
             _resizeLab.StretchTop(actualShapes);
@@ -126,8 +126,8 @@ namespace Test.UnitTest.ResizeLab
         [TestCategory("UT")]
         public void TestStretchTopOuterMost()
         {
-            var actualShapes = GetShapes(SlideNo.StretchOrigin, _shapeNames);
-            var expectedShapes = GetShapes(SlideNo.StretchTopOuterMost, _shapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange actualShapes = GetShapes(SlideNo.StretchOrigin, _shapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange expectedShapes = GetShapes(SlideNo.StretchTopOuterMost, _shapeNames);
 
             _resizeLab.ReferenceType = ResizeLabMain.StretchRefType.Outermost;
             _resizeLab.StretchTop(actualShapes);
@@ -138,8 +138,8 @@ namespace Test.UnitTest.ResizeLab
         [TestCategory("UT")]
         public void TestStretchBottomWithoutAspectRatio()
         {
-            var actualShapes = GetShapes(SlideNo.StretchOrigin, _shapeNames);
-            var expectedShapes = GetShapes(SlideNo.StretchBottom, _shapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange actualShapes = GetShapes(SlideNo.StretchOrigin, _shapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange expectedShapes = GetShapes(SlideNo.StretchBottom, _shapeNames);
 
             _resizeLab.StretchBottom(actualShapes);
             CheckShapes(expectedShapes, actualShapes);
@@ -149,8 +149,8 @@ namespace Test.UnitTest.ResizeLab
         [TestCategory("UT")]
         public void TestStretchBottomWithAspectRatio()
         {
-            var actualShapes = GetShapes(SlideNo.StretchOrigin, _shapeNames);
-            var expectedShapes = GetShapes(SlideNo.StretchBottomAspectRatio, _shapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange actualShapes = GetShapes(SlideNo.StretchOrigin, _shapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange expectedShapes = GetShapes(SlideNo.StretchBottomAspectRatio, _shapeNames);
 
             actualShapes.LockAspectRatio = MsoTriState.msoTrue;
             _resizeLab.StretchBottom(actualShapes);
@@ -161,8 +161,8 @@ namespace Test.UnitTest.ResizeLab
         [TestCategory("UT")]
         public void TestStretchBottomOuterMost()
         {
-            var actualShapes = GetShapes(SlideNo.StretchOrigin, _shapeNames);
-            var expectedShapes = GetShapes(SlideNo.StretchBottomOuterMost, _shapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange actualShapes = GetShapes(SlideNo.StretchOrigin, _shapeNames);
+            Microsoft.Office.Interop.PowerPoint.ShapeRange expectedShapes = GetShapes(SlideNo.StretchBottomOuterMost, _shapeNames);
 
             _resizeLab.ReferenceType = ResizeLabMain.StretchRefType.Outermost;
             _resizeLab.StretchBottom(actualShapes);

--- a/PowerPointLabs/Test/UnitTest/SyncLab/BaseSyncLabTest.cs
+++ b/PowerPointLabs/Test/UnitTest/SyncLab/BaseSyncLabTest.cs
@@ -30,9 +30,9 @@ namespace Test.UnitTest.SyncLab
 
         protected void CompareSlides(int actualShapesSlideNo, int expectedShapesSlideNo)
         {
-          
-            var actualSlide = PpOperations.SelectSlide(actualShapesSlideNo);
-            var expectedSlide = PpOperations.SelectSlide(expectedShapesSlideNo);
+
+            PowerPoint.Slide actualSlide = PpOperations.SelectSlide(actualShapesSlideNo);
+            PowerPoint.Slide expectedSlide = PpOperations.SelectSlide(expectedShapesSlideNo);
 
             SlideUtil.IsSameLooking(actualSlide, expectedSlide);
         }

--- a/PowerPointLabs/Test/UnitTest/SyncLab/SyncLabFillTest.cs
+++ b/PowerPointLabs/Test/UnitTest/SyncLab/SyncLabFillTest.cs
@@ -54,9 +54,9 @@ namespace Test.UnitTest.SyncLab
         [TestCategory("UT")]
         public void TestSyncTransparency()
         {
-            var formatShape = GetShape(OriginalShapesSlideNo, SolidFill);
+            Microsoft.Office.Interop.PowerPoint.Shape formatShape = GetShape(OriginalShapesSlideNo, SolidFill);
 
-            var newShape = GetShape(OriginalShapesSlideNo, CopyToShape);
+            Microsoft.Office.Interop.PowerPoint.Shape newShape = GetShape(OriginalShapesSlideNo, CopyToShape);
             FillTransparencyFormat.SyncFormat(formatShape, newShape);
 
             CompareSlides(OriginalShapesSlideNo, SyncTransparencySlideNo);
@@ -65,9 +65,9 @@ namespace Test.UnitTest.SyncLab
 
         protected void syncFill(string shapeToCopy, int expectedSlideNo)
         {
-            var formatShape = GetShape(OriginalShapesSlideNo, shapeToCopy);
+            Microsoft.Office.Interop.PowerPoint.Shape formatShape = GetShape(OriginalShapesSlideNo, shapeToCopy);
 
-            var newShape = GetShape(OriginalShapesSlideNo, CopyToShape);
+            Microsoft.Office.Interop.PowerPoint.Shape newShape = GetShape(OriginalShapesSlideNo, CopyToShape);
             FillFormat.SyncFormat(formatShape, newShape);
 
             CompareSlides(OriginalShapesSlideNo, expectedSlideNo);
@@ -77,8 +77,8 @@ namespace Test.UnitTest.SyncLab
         //Changes in transparency are too minute for CompareSlide to detect so we need to check them manually
         protected void CheckTransparency(string shape, int actualShapesSlideNo, int expectedShapesSlideNo)
         {
-            var actualShape = GetShape(actualShapesSlideNo, shape);
-            var expectedShape = GetShape(expectedShapesSlideNo, shape);
+            Microsoft.Office.Interop.PowerPoint.Shape actualShape = GetShape(actualShapesSlideNo, shape);
+            Microsoft.Office.Interop.PowerPoint.Shape expectedShape = GetShape(expectedShapesSlideNo, shape);
 
             Assert.IsTrue(actualShape.Fill.Transparency == expectedShape.Fill.Transparency,
                 "different transparency. exp:{0}, actual:{1}",

--- a/PowerPointLabs/Test/UnitTest/SyncLab/SyncLabFontTest.cs
+++ b/PowerPointLabs/Test/UnitTest/SyncLab/SyncLabFontTest.cs
@@ -23,9 +23,9 @@ namespace Test.UnitTest.SyncLab
         [TestCategory("UT")]
         public void TestSyncFontFamily()
         {
-            var formatShape = GetShape(OriginalShapesSlideNo, CopyFromLargeShape);
+            Microsoft.Office.Interop.PowerPoint.Shape formatShape = GetShape(OriginalShapesSlideNo, CopyFromLargeShape);
 
-            var newShape = GetShape(OriginalShapesSlideNo, CopyToShape);
+            Microsoft.Office.Interop.PowerPoint.Shape newShape = GetShape(OriginalShapesSlideNo, CopyToShape);
             FontFormat.SyncFormat(formatShape, newShape);
 
             CompareSlides(OriginalShapesSlideNo, SyncFontFamilySlideNo);
@@ -36,9 +36,9 @@ namespace Test.UnitTest.SyncLab
         [TestCategory("UT")]
         public void TestSyncFontSize()
         {
-            var formatShape = GetShape(OriginalShapesSlideNo, CopyFromLargeShape);
+            Microsoft.Office.Interop.PowerPoint.Shape formatShape = GetShape(OriginalShapesSlideNo, CopyFromLargeShape);
 
-            var newShape = GetShape(OriginalShapesSlideNo, CopyToShape);
+            Microsoft.Office.Interop.PowerPoint.Shape newShape = GetShape(OriginalShapesSlideNo, CopyToShape);
             FontSizeFormat.SyncFormat(formatShape, newShape);
 
             CompareSlides(OriginalShapesSlideNo, SyncFontSizeSlideNo);
@@ -49,9 +49,9 @@ namespace Test.UnitTest.SyncLab
         [TestCategory("UT")]
         public void TestSyncFontFill()
         {
-            var formatShape = GetShape(OriginalShapesSlideNo, CopyFromLargeShape);
+            Microsoft.Office.Interop.PowerPoint.Shape formatShape = GetShape(OriginalShapesSlideNo, CopyFromLargeShape);
 
-            var newShape = GetShape(OriginalShapesSlideNo, CopyToShape);
+            Microsoft.Office.Interop.PowerPoint.Shape newShape = GetShape(OriginalShapesSlideNo, CopyToShape);
             FontColorFormat.SyncFormat(formatShape, newShape);
 
             CompareSlides(OriginalShapesSlideNo, SyncFontFillSlideNo);
@@ -62,9 +62,9 @@ namespace Test.UnitTest.SyncLab
         [TestCategory("UT")]
         public void TestSyncOneFontStyle()
         {
-            var formatShape = GetShape(OriginalShapesSlideNo, CopyFromLargeShape);
+            Microsoft.Office.Interop.PowerPoint.Shape formatShape = GetShape(OriginalShapesSlideNo, CopyFromLargeShape);
 
-            var newShape = GetShape(OriginalShapesSlideNo, CopyToShape);
+            Microsoft.Office.Interop.PowerPoint.Shape newShape = GetShape(OriginalShapesSlideNo, CopyToShape);
             FontStyleFormat.SyncFormat(formatShape, newShape);
 
             CheckFontStyle(OriginalShapesSlideNo, SyncOneFontStyleSlideNo);
@@ -74,9 +74,9 @@ namespace Test.UnitTest.SyncLab
         [TestCategory("UT")]
         public void TestSyncAllFontStyle()
         {
-            var formatShape = GetShape(OriginalShapesSlideNo, CopyFromSmallShape);
+            Microsoft.Office.Interop.PowerPoint.Shape formatShape = GetShape(OriginalShapesSlideNo, CopyFromSmallShape);
 
-            var newShape = GetShape(OriginalShapesSlideNo, CopyToShape);
+            Microsoft.Office.Interop.PowerPoint.Shape newShape = GetShape(OriginalShapesSlideNo, CopyToShape);
             FontStyleFormat.SyncFormat(formatShape, newShape);
 
             CheckFontStyle(OriginalShapesSlideNo, SyncAllFontStyleSlideNo);
@@ -85,11 +85,11 @@ namespace Test.UnitTest.SyncLab
         //Changes in font style are too minute for CompareSlide to detect so we need to check them manually
         protected void CheckFontStyle(int actualShapesSlideNo, int expectedShapesSlideNo)
         {
-            var actualShape = GetShape(actualShapesSlideNo, CopyToShape);
-            var expectedShape = GetShape(expectedShapesSlideNo, CopyToShape);
+            Microsoft.Office.Interop.PowerPoint.Shape actualShape = GetShape(actualShapesSlideNo, CopyToShape);
+            Microsoft.Office.Interop.PowerPoint.Shape expectedShape = GetShape(expectedShapesSlideNo, CopyToShape);
 
-            var actualFont = actualShape.TextFrame.TextRange.Font;
-            var expectedFont = expectedShape.TextFrame.TextRange.Font;
+            Microsoft.Office.Interop.PowerPoint.Font actualFont = actualShape.TextFrame.TextRange.Font;
+            Microsoft.Office.Interop.PowerPoint.Font expectedFont = expectedShape.TextFrame.TextRange.Font;
 
             Assert.IsTrue(actualFont.Bold == expectedFont.Bold
                 && actualFont.Italic == expectedFont.Italic

--- a/PowerPointLabs/Test/UnitTest/SyncLab/SyncLabLineTest.cs
+++ b/PowerPointLabs/Test/UnitTest/SyncLab/SyncLabLineTest.cs
@@ -24,9 +24,9 @@ namespace Test.UnitTest.SyncLab
         [TestCategory("UT")]
         public void TestSyncLineFill()
         {
-            var formatShape = GetShape(OriginalShapesSlideNo, CopyFromShape);
+            Microsoft.Office.Interop.PowerPoint.Shape formatShape = GetShape(OriginalShapesSlideNo, CopyFromShape);
 
-            var newShape = GetShape(OriginalShapesSlideNo, StraightLine);
+            Microsoft.Office.Interop.PowerPoint.Shape newShape = GetShape(OriginalShapesSlideNo, StraightLine);
             LineFillFormat.SyncFormat(formatShape, newShape);
 
             CompareSlides(OriginalShapesSlideNo, SyncLineFillSlideNo);
@@ -37,9 +37,9 @@ namespace Test.UnitTest.SyncLab
         [TestCategory("UT")]
         public void TestSyncLineWidth()
         {
-            var formatShape = GetShape(OriginalShapesSlideNo, CopyFromShape);
+            Microsoft.Office.Interop.PowerPoint.Shape formatShape = GetShape(OriginalShapesSlideNo, CopyFromShape);
 
-            var newShape = GetShape(OriginalShapesSlideNo, Arrow);
+            Microsoft.Office.Interop.PowerPoint.Shape newShape = GetShape(OriginalShapesSlideNo, Arrow);
             LineWeightFormat.SyncFormat(formatShape, newShape);
 
             CompareSlides(OriginalShapesSlideNo, SyncLineWidthSlideNo);
@@ -50,9 +50,9 @@ namespace Test.UnitTest.SyncLab
         [TestCategory("UT")]
         public void TestSyncLineCompoundType()
         {
-            var formatShape = GetShape(OriginalShapesSlideNo, CopyFromShape);
+            Microsoft.Office.Interop.PowerPoint.Shape formatShape = GetShape(OriginalShapesSlideNo, CopyFromShape);
 
-            var newShape = GetShape(OriginalShapesSlideNo, StraightLine);
+            Microsoft.Office.Interop.PowerPoint.Shape newShape = GetShape(OriginalShapesSlideNo, StraightLine);
             LineCompoundTypeFormat.SyncFormat(formatShape, newShape);
 
             CompareSlides(OriginalShapesSlideNo, SyncLineCompoundTypeSlideNo);
@@ -63,9 +63,9 @@ namespace Test.UnitTest.SyncLab
         [TestCategory("UT")]
         public void TestSyncLineDashType()
         {
-            var formatShape = GetShape(OriginalShapesSlideNo, CopyFromShape);
+            Microsoft.Office.Interop.PowerPoint.Shape formatShape = GetShape(OriginalShapesSlideNo, CopyFromShape);
 
-            var newShape = GetShape(OriginalShapesSlideNo, StraightLine);
+            Microsoft.Office.Interop.PowerPoint.Shape newShape = GetShape(OriginalShapesSlideNo, StraightLine);
             LineDashTypeFormat.SyncFormat(formatShape, newShape);
 
             CompareSlides(OriginalShapesSlideNo, SyncLineDashTypeSlideNo);
@@ -76,9 +76,9 @@ namespace Test.UnitTest.SyncLab
         [TestCategory("UT")]
         public void TestSyncLineArrow()
         {
-            var formatShape = GetShape(OriginalShapesSlideNo, CopyFromShape);
+            Microsoft.Office.Interop.PowerPoint.Shape formatShape = GetShape(OriginalShapesSlideNo, CopyFromShape);
 
-            var newShape = GetShape(OriginalShapesSlideNo, StraightLine);
+            Microsoft.Office.Interop.PowerPoint.Shape newShape = GetShape(OriginalShapesSlideNo, StraightLine);
             LineArrowFormat.SyncFormat(formatShape, newShape);
 
             CompareSlides(OriginalShapesSlideNo, SyncLineArrowSlideNo);
@@ -89,9 +89,9 @@ namespace Test.UnitTest.SyncLab
         [TestCategory("UT")]
         public void TestSyncLineTransparency()
         {
-            var formatShape = GetShape(OriginalShapesSlideNo, CopyFromShape);
+            Microsoft.Office.Interop.PowerPoint.Shape formatShape = GetShape(OriginalShapesSlideNo, CopyFromShape);
 
-            var newShape = GetShape(OriginalShapesSlideNo, Arrow);
+            Microsoft.Office.Interop.PowerPoint.Shape newShape = GetShape(OriginalShapesSlideNo, Arrow);
             LineTransparencyFormat.SyncFormat(formatShape, newShape);
 
             CompareSlides(OriginalShapesSlideNo, SyncLineTransparencySlideNo);
@@ -101,8 +101,8 @@ namespace Test.UnitTest.SyncLab
         //Changes in line style are too minute for CompareSlide to detect so we need to check them manually
         protected void CheckLineStyle(string shape, int actualShapesSlideNo, int expectedShapesSlideNo)
         {
-            var actualShape = GetShape(actualShapesSlideNo, shape);
-            var expectedShape = GetShape(expectedShapesSlideNo, shape);
+            Microsoft.Office.Interop.PowerPoint.Shape actualShape = GetShape(actualShapesSlideNo, shape);
+            Microsoft.Office.Interop.PowerPoint.Shape expectedShape = GetShape(expectedShapesSlideNo, shape);
 
             //Check transparency style
             Assert.IsTrue(actualShape.Line.Transparency == expectedShape.Line.Transparency,

--- a/PowerPointLabs/Test/UnitTest/SyncLab/SyncLabPositionTest.cs
+++ b/PowerPointLabs/Test/UnitTest/SyncLab/SyncLabPositionTest.cs
@@ -32,7 +32,7 @@ namespace Test.UnitTest.SyncLab
         [TestCategory("UT")]
         public void TestSyncXPosition()
         {
-            var newShape = GetShape(OriginalShapesSlideNo, UnrotatedRectangle);
+            Shape newShape = GetShape(OriginalShapesSlideNo, UnrotatedRectangle);
             PositionXFormat.SyncFormat(_formatShape, newShape);
 
             CompareSlides(OriginalShapesSlideNo, SyncXPositionSlideNo);
@@ -42,7 +42,7 @@ namespace Test.UnitTest.SyncLab
         [TestCategory("UT")]
         public void TestSyncYPosition()
         {
-            var newShape = GetShape(OriginalShapesSlideNo, UnrotatedRectangle);
+            Shape newShape = GetShape(OriginalShapesSlideNo, UnrotatedRectangle);
             PositionYFormat.SyncFormat(_formatShape, newShape);
 
             CompareSlides(OriginalShapesSlideNo, SyncYPositionSlideNo);
@@ -52,7 +52,7 @@ namespace Test.UnitTest.SyncLab
         [TestCategory("UT")]
         public void TestSyncHeight()
         {
-            var newShape = GetShape(OriginalShapesSlideNo, Oval);
+            Shape newShape = GetShape(OriginalShapesSlideNo, Oval);
             PositionHeightFormat.SyncFormat(_formatShape, newShape);
 
             CompareSlides(OriginalShapesSlideNo, SyncHeightSlideNo);
@@ -62,7 +62,7 @@ namespace Test.UnitTest.SyncLab
         [TestCategory("UT")]
         public void TestSyncWidth()
         {
-            var newShape = GetShape(OriginalShapesSlideNo, RotatedArrow);
+            Shape newShape = GetShape(OriginalShapesSlideNo, RotatedArrow);
             PositionWidthFormat.SyncFormat(_formatShape, newShape);
 
             CompareSlides(OriginalShapesSlideNo, SyncWidthSlideNo);

--- a/PowerPointLabs/Test/UnitTest/TagMatchers/EndSpeedTests.cs
+++ b/PowerPointLabs/Test/UnitTest/TagMatchers/EndSpeedTests.cs
@@ -21,7 +21,7 @@ namespace Test.UnitTest.TagMatchers
         [TestCategory("UT")]
         public void MatchEndSpeed()
         {
-            var testTag = "[EndSpeed]";
+            string testTag = "[EndSpeed]";
             TagUtil.MatchAndAssert(testTag, tagRegex);
         }
 
@@ -29,7 +29,7 @@ namespace Test.UnitTest.TagMatchers
         [TestCategory("UT")]
         public void MatchEndSpeedLowercase()
         {
-            var testTag = "[endspeed]";
+            string testTag = "[endspeed]";
             TagUtil.MatchAndAssert(testTag, tagRegex);
         }
 
@@ -37,7 +37,7 @@ namespace Test.UnitTest.TagMatchers
         [TestCategory("UT")]
         public void MatchEndSpeedMixedCase()
         {
-            var testTag = "[endSpeed]";
+            string testTag = "[endSpeed]";
             TagUtil.MatchAndAssert(testTag, tagRegex);
         }
 
@@ -45,13 +45,13 @@ namespace Test.UnitTest.TagMatchers
         [TestCategory("UT")]
         public void MatchListSingleInSentence()
         {
-            var sentence = "This is [speed: fast]a test[endspeed].";
-            var matches = new EndSpeedTagMatcher().Matches(sentence);
+            string sentence = "This is [speed: fast]a test[endspeed].";
+            System.Collections.Generic.List<PowerPointLabs.Tags.ITag> matches = new EndSpeedTagMatcher().Matches(sentence);
 
             Assert.IsTrue(matches.Any(), "No matches found.");
             Assert.IsTrue(matches.Count == 1, "More than one match.");
 
-            var match = matches[0];
+            PowerPointLabs.Tags.ITag match = matches[0];
             Assert.IsTrue(match.Start == 27, "Match start was incorrect.");
             Assert.IsTrue(match.End == 36, "Match end was incorrect.");
         }
@@ -60,8 +60,8 @@ namespace Test.UnitTest.TagMatchers
         [TestCategory("UT")]
         public void MatchListMultipleInSentence()
         {
-            var sentence = "This [speed: slow]has multiple[endspeed][speed: fast] matches.[endspeed]";
-            var matches = new EndSpeedTagMatcher().Matches(sentence);
+            string sentence = "This [speed: slow]has multiple[endspeed][speed: fast] matches.[endspeed]";
+            System.Collections.Generic.List<PowerPointLabs.Tags.ITag> matches = new EndSpeedTagMatcher().Matches(sentence);
 
             Assert.IsTrue(matches.Any(), "No matches found.");
             Assert.IsTrue(matches.Count == 2, "Didn't match all.");

--- a/PowerPointLabs/Test/UnitTest/TagMatchers/EndVoiceTests.cs
+++ b/PowerPointLabs/Test/UnitTest/TagMatchers/EndVoiceTests.cs
@@ -21,7 +21,7 @@ namespace Test.UnitTest.TagMatchers
         [TestCategory("UT")]
         public void MatchEnd()
         {
-            var testTag = "[EndVoice]";
+            string testTag = "[EndVoice]";
             TagUtil.MatchAndAssert(testTag, tagRegex);
         }
 
@@ -29,7 +29,7 @@ namespace Test.UnitTest.TagMatchers
         [TestCategory("UT")]
         public void MatchEndLowercase()
         {
-            var testTag = "[endvoice]";
+            string testTag = "[endvoice]";
             TagUtil.MatchAndAssert(testTag, tagRegex);
         }
 
@@ -37,13 +37,13 @@ namespace Test.UnitTest.TagMatchers
         [TestCategory("UT")]
         public void MatchListSingleInSentence()
         {
-            var sentence = "This is [voice: female]a test[endvoice].";
-            var matches = new EndVoiceTagMatcher().Matches(sentence);
+            string sentence = "This is [voice: female]a test[endvoice].";
+            System.Collections.Generic.List<PowerPointLabs.Tags.ITag> matches = new EndVoiceTagMatcher().Matches(sentence);
 
             Assert.IsTrue(matches.Any(), "No matches found.");
             Assert.IsTrue(matches.Count == 1, "More than one match.");
 
-            var match = matches[0];
+            PowerPointLabs.Tags.ITag match = matches[0];
             Assert.IsTrue(match.Start == 29, "Match start was incorrect.");
             Assert.IsTrue(match.End == 38, "Match end was incorrect.");
         }
@@ -52,8 +52,8 @@ namespace Test.UnitTest.TagMatchers
         [TestCategory("UT")]
         public void MatchListMultipleInSentence()
         {
-            var sentence = "This [voice: male]has multiple[endvoice][voice: female] matches.[endvoice]";
-            var matches = new EndVoiceTagMatcher().Matches(sentence);
+            string sentence = "This [voice: male]has multiple[endvoice][voice: female] matches.[endvoice]";
+            System.Collections.Generic.List<PowerPointLabs.Tags.ITag> matches = new EndVoiceTagMatcher().Matches(sentence);
 
             Assert.IsTrue(matches.Any(), "No matches found.");
             Assert.IsTrue(matches.Count == 2, "Didn't match all.");

--- a/PowerPointLabs/Test/UnitTest/TagMatchers/PauseTest.cs
+++ b/PowerPointLabs/Test/UnitTest/TagMatchers/PauseTest.cs
@@ -21,7 +21,7 @@ namespace Test.UnitTest.TagMatchers
         [TestCategory("UT")]
         public void MatchIntegerInterval()
         {
-            var testTag = "[Pause: 2]";
+            string testTag = "[Pause: 2]";
             TagUtil.MatchAndAssert(testTag, tagRegex);
         }
 
@@ -29,7 +29,7 @@ namespace Test.UnitTest.TagMatchers
         [TestCategory("UT")]
         public void MatchMultipleDigitIntegerInterval()
         {
-            var testTag = "[Pause: 23]";
+            string testTag = "[Pause: 23]";
             TagUtil.MatchAndAssert(testTag, tagRegex);
         }
 
@@ -37,7 +37,7 @@ namespace Test.UnitTest.TagMatchers
         [TestCategory("UT")]
         public void MatchIntegerIntervalLowercase()
         {
-            var testTag = "[pause: 2]";
+            string testTag = "[pause: 2]";
             TagUtil.MatchAndAssert(testTag, tagRegex);
         }
 
@@ -45,7 +45,7 @@ namespace Test.UnitTest.TagMatchers
         [TestCategory("UT")]
         public void MatchMultipleDigitIntegerIntervalLowercase()
         {
-            var testTag = "[pause: 23]";
+            string testTag = "[pause: 23]";
             TagUtil.MatchAndAssert(testTag, tagRegex);
         }
 
@@ -53,7 +53,7 @@ namespace Test.UnitTest.TagMatchers
         [TestCategory("UT")]
         public void MatchDecimalInterval()
         {
-            var testTag = "[Pause: 2.5]";
+            string testTag = "[Pause: 2.5]";
             TagUtil.MatchAndAssert(testTag, tagRegex);
         }
 
@@ -61,7 +61,7 @@ namespace Test.UnitTest.TagMatchers
         [TestCategory("UT")]
         public void DontMatchMultipleDecimals()
         {
-            var testTag = "[Pause: 2.5.1]";
+            string testTag = "[Pause: 2.5.1]";
             Assert.IsFalse(tagRegex.IsMatch(testTag), "Matched multiple decimals.");
         }
 
@@ -69,13 +69,13 @@ namespace Test.UnitTest.TagMatchers
         [TestCategory("UT")]
         public void MatchSingleInSentence()
         {
-            var sentence = "This has a pause [pause: 2] right here.";
-            var matches = new PauseTagMatcher().Matches(sentence);
+            string sentence = "This has a pause [pause: 2] right here.";
+            System.Collections.Generic.List<PowerPointLabs.Tags.ITag> matches = new PauseTagMatcher().Matches(sentence);
 
             Assert.IsTrue(matches.Any(), "No matches found.");
             Assert.IsTrue(matches.Count == 1, "More than one match.");
 
-            var match = matches[0];
+            PowerPointLabs.Tags.ITag match = matches[0];
             Assert.IsTrue(match.Start == 17, "Match start was incorrect.");
             Assert.IsTrue(match.End == 26, "Match end was incorrect.");
         }
@@ -84,8 +84,8 @@ namespace Test.UnitTest.TagMatchers
         [TestCategory("UT")]
         public void MatchMultipleInSentence()
         {
-            var sentence = "This has [pause: 2] many [pause: 2.4] pauses.";
-            var matches = new PauseTagMatcher().Matches(sentence);
+            string sentence = "This has [pause: 2] many [pause: 2.4] pauses.";
+            System.Collections.Generic.List<PowerPointLabs.Tags.ITag> matches = new PauseTagMatcher().Matches(sentence);
 
             Assert.IsTrue(matches.Any(), "No matches found.");
             Assert.IsTrue(matches.Count == 2, "Didn't match all.");

--- a/PowerPointLabs/Test/UnitTest/TagMatchers/PronounceTests.cs
+++ b/PowerPointLabs/Test/UnitTest/TagMatchers/PronounceTests.cs
@@ -21,7 +21,7 @@ namespace Test.UnitTest.TagMatchers
         [TestCategory("UT")]
         public void MatchPronounceBlock()
         {
-            var testTag = "[Pronounce: <IPA>]<Word Here>[EndPronounce]";
+            string testTag = "[Pronounce: <IPA>]<Word Here>[EndPronounce]";
             TagUtil.MatchAndAssert(testTag, tagRegex);
         }
 
@@ -29,7 +29,7 @@ namespace Test.UnitTest.TagMatchers
         [TestCategory("UT")]
         public void MatchPronounceBlockCaseInsensitive()
         {
-            var testTag = "[pronounce: <IPA>]<word here>[endpronounce]";
+            string testTag = "[pronounce: <IPA>]<word here>[endpronounce]";
             TagUtil.MatchAndAssert(testTag, tagRegex);
         }
 
@@ -37,13 +37,13 @@ namespace Test.UnitTest.TagMatchers
         [TestCategory("UT")]
         public void MatchListSingleInSentence()
         {
-            var sentence = "This is a [pronounce: <IPA>]test[endpronounce].";
-            var matches = new PronounceTagMatcher().Matches(sentence);
+            string sentence = "This is a [pronounce: <IPA>]test[endpronounce].";
+            System.Collections.Generic.List<PowerPointLabs.Tags.ITag> matches = new PronounceTagMatcher().Matches(sentence);
 
             Assert.IsTrue(matches.Any(), "No matches found.");
             Assert.IsTrue(matches.Count == 1, "More than one match.");
 
-            var match = matches[0];
+            PowerPointLabs.Tags.ITag match = matches[0];
             Assert.IsTrue(match.Start == 10, "Match start was incorrect.");
             Assert.IsTrue(match.End == 45, "Match end was incorrect.");
         }
@@ -52,8 +52,8 @@ namespace Test.UnitTest.TagMatchers
         [TestCategory("UT")]
         public void MatchListMultipleInSentence()
         {
-            var sentence = "This [pronounce: <IPA>]has[endpronounce] multiple[pause: 2][pronounce: <IPA>]matches.[endpronounce]";
-            var matches = new PronounceTagMatcher().Matches(sentence);
+            string sentence = "This [pronounce: <IPA>]has[endpronounce] multiple[pause: 2][pronounce: <IPA>]matches.[endpronounce]";
+            System.Collections.Generic.List<PowerPointLabs.Tags.ITag> matches = new PronounceTagMatcher().Matches(sentence);
 
             Assert.IsTrue(matches.Any(), "No matches found.");
             Assert.IsTrue(matches.Count == 2, "Didn't match all.");

--- a/PowerPointLabs/Test/UnitTest/TagMatchers/StartSpeedTests.cs
+++ b/PowerPointLabs/Test/UnitTest/TagMatchers/StartSpeedTests.cs
@@ -21,7 +21,7 @@ namespace Test.UnitTest.TagMatchers
         [TestCategory("UT")]
         public void MatchExtraSlowLowerCase()
         {
-            var testTag = "[speed: extra slow]";
+            string testTag = "[speed: extra slow]";
             TagUtil.MatchAndAssert(testTag, tagRegex);
         }
 
@@ -29,7 +29,7 @@ namespace Test.UnitTest.TagMatchers
         [TestCategory("UT")]
         public void MatchExtraSlowUpperCase()
         {
-            var testTag = "[Speed: Extra Slow]";
+            string testTag = "[Speed: Extra Slow]";
             TagUtil.MatchAndAssert(testTag, tagRegex);
         }
 
@@ -37,7 +37,7 @@ namespace Test.UnitTest.TagMatchers
         [TestCategory("UT")]
         public void MatchExtraSlowMixedCase()
         {
-            var testTag = "[Speed: extra Slow]";
+            string testTag = "[Speed: extra Slow]";
             TagUtil.MatchAndAssert(testTag, tagRegex);
         }
 
@@ -45,7 +45,7 @@ namespace Test.UnitTest.TagMatchers
         [TestCategory("UT")]
         public void MatchSlowLowerCase()
         {
-            var testTag = "[speed: slow]";
+            string testTag = "[speed: slow]";
             TagUtil.MatchAndAssert(testTag, tagRegex);
         }
 
@@ -53,7 +53,7 @@ namespace Test.UnitTest.TagMatchers
         [TestCategory("UT")]
         public void MatchSlowUpperCase()
         {
-            var testTag = "[Speed: Slow]";
+            string testTag = "[Speed: Slow]";
             TagUtil.MatchAndAssert(testTag, tagRegex);
         }
 
@@ -61,7 +61,7 @@ namespace Test.UnitTest.TagMatchers
         [TestCategory("UT")]
         public void MatchSlowMixedCase()
         {
-            var testTag = "[Speed: slow]";
+            string testTag = "[Speed: slow]";
             TagUtil.MatchAndAssert(testTag, tagRegex);
         }
 
@@ -69,7 +69,7 @@ namespace Test.UnitTest.TagMatchers
         [TestCategory("UT")]
         public void MatchMediumLowerCase()
         {
-            var testTag = "[speed: medium]";
+            string testTag = "[speed: medium]";
             TagUtil.MatchAndAssert(testTag, tagRegex);
         }
 
@@ -77,7 +77,7 @@ namespace Test.UnitTest.TagMatchers
         [TestCategory("UT")]
         public void MatchMediumUpperCase()
         {
-            var testTag = "[Speed: Medium]";
+            string testTag = "[Speed: Medium]";
             TagUtil.MatchAndAssert(testTag, tagRegex);
         }
 
@@ -85,7 +85,7 @@ namespace Test.UnitTest.TagMatchers
         [TestCategory("UT")]
         public void MatchMediumMixedCase()
         {
-            var testTag = "[Speed: medium]";
+            string testTag = "[Speed: medium]";
             TagUtil.MatchAndAssert(testTag, tagRegex);
         }
 
@@ -93,7 +93,7 @@ namespace Test.UnitTest.TagMatchers
         [TestCategory("UT")]
         public void MatchFastLowerCase()
         {
-            var testTag = "[speed: fast]";
+            string testTag = "[speed: fast]";
             TagUtil.MatchAndAssert(testTag, tagRegex);
         }
 
@@ -101,7 +101,7 @@ namespace Test.UnitTest.TagMatchers
         [TestCategory("UT")]
         public void MatchFastUpperCase()
         {
-            var testTag = "[Speed: Fast]";
+            string testTag = "[Speed: Fast]";
             TagUtil.MatchAndAssert(testTag, tagRegex);
         }
 
@@ -109,7 +109,7 @@ namespace Test.UnitTest.TagMatchers
         [TestCategory("UT")]
         public void MatchFastMixedCase()
         {
-            var testTag = "[Speed: fast]";
+            string testTag = "[Speed: fast]";
             TagUtil.MatchAndAssert(testTag, tagRegex);
         }
 
@@ -117,7 +117,7 @@ namespace Test.UnitTest.TagMatchers
         [TestCategory("UT")]
         public void MatchExtraFastLowerCase()
         {
-            var testTag = "[speed: extra fast]";
+            string testTag = "[speed: extra fast]";
             TagUtil.MatchAndAssert(testTag, tagRegex);
         }
 
@@ -125,7 +125,7 @@ namespace Test.UnitTest.TagMatchers
         [TestCategory("UT")]
         public void MatchExtraFastUpperCase()
         {
-            var testTag = "[Speed: Extra Fast]";
+            string testTag = "[Speed: Extra Fast]";
             TagUtil.MatchAndAssert(testTag, tagRegex);
         }
 
@@ -133,7 +133,7 @@ namespace Test.UnitTest.TagMatchers
         [TestCategory("UT")]
         public void MatchExtraFastMixedCase()
         {
-            var testTag = "[Speed: extra fast]";
+            string testTag = "[Speed: extra fast]";
             TagUtil.MatchAndAssert(testTag, tagRegex);
         }
 
@@ -141,8 +141,8 @@ namespace Test.UnitTest.TagMatchers
         [TestCategory("UT")]
         public void DoesntMatchWithNoParameters()
         {
-            var testTag = "[Speed]";
-            var match = tagRegex.Match(testTag);
+            string testTag = "[Speed]";
+            Match match = tagRegex.Match(testTag);
 
             Assert.IsFalse(match.Success);
 
@@ -161,13 +161,13 @@ namespace Test.UnitTest.TagMatchers
         [TestCategory("UT")]
         public void MatchListSingleInSentence()
         {
-            var sentence = "This is [speed: fast]a test[endspeed].";
-            var matches = new StartSpeedTagMatcher().Matches(sentence);
+            string sentence = "This is [speed: fast]a test[endspeed].";
+            System.Collections.Generic.List<PowerPointLabs.Tags.ITag> matches = new StartSpeedTagMatcher().Matches(sentence);
 
             Assert.IsTrue(matches.Any(), "No matches found.");
             Assert.IsTrue(matches.Count == 1, "More than one match.");
 
-            var match = matches[0];
+            PowerPointLabs.Tags.ITag match = matches[0];
             Assert.IsTrue(match.Start == 8, "Match start was incorrect.");
             Assert.IsTrue(match.End == 20, "Match end was incorrect.");
         }
@@ -176,8 +176,8 @@ namespace Test.UnitTest.TagMatchers
         [TestCategory("UT")]
         public void MatchListMultipleInSentence()
         {
-            var sentence = "This [speed: slow]has multiple[endspeed][speed: fast] matches.[endspeed]";
-            var matches = new StartSpeedTagMatcher().Matches(sentence);
+            string sentence = "This [speed: slow]has multiple[endspeed][speed: fast] matches.[endspeed]";
+            System.Collections.Generic.List<PowerPointLabs.Tags.ITag> matches = new StartSpeedTagMatcher().Matches(sentence);
 
             Assert.IsTrue(matches.Any(), "No matches found.");
             Assert.IsTrue(matches.Count == 2, "Didn't match all.");

--- a/PowerPointLabs/Test/UnitTest/TagMatchers/StartVoiceTests.cs
+++ b/PowerPointLabs/Test/UnitTest/TagMatchers/StartVoiceTests.cs
@@ -21,7 +21,7 @@ namespace Test.UnitTest.TagMatchers
         [TestCategory("UT")]
         public void MatchMale()
         {
-            var testTag = "[Voice: Male]";
+            string testTag = "[Voice: Male]";
             TagUtil.MatchAndAssert(testTag, tagRegex);
         }
 
@@ -29,7 +29,7 @@ namespace Test.UnitTest.TagMatchers
         [TestCategory("UT")]
         public void MatchMaleLowercase()
         {
-            var testTag = "[voice: male]";
+            string testTag = "[voice: male]";
             TagUtil.MatchAndAssert(testTag, tagRegex);
         }
 
@@ -37,13 +37,13 @@ namespace Test.UnitTest.TagMatchers
         [TestCategory("UT")]
         public void MatchListSingleInSentence()
         {
-            var sentence = "This is [voice: female]a test[endvoice].";
-            var matches = new StartVoiceTagMatcher().Matches(sentence);
+            string sentence = "This is [voice: female]a test[endvoice].";
+            System.Collections.Generic.List<PowerPointLabs.Tags.ITag> matches = new StartVoiceTagMatcher().Matches(sentence);
 
             Assert.IsTrue(matches.Any(), "No matches found.");
             Assert.IsTrue(matches.Count == 1, "More than one match.");
 
-            var match = matches[0];
+            PowerPointLabs.Tags.ITag match = matches[0];
             Assert.IsTrue(match.Start == 8, "Match start was incorrect.");
             Assert.IsTrue(match.End == 22, "Match end was incorrect.");
         }
@@ -52,8 +52,8 @@ namespace Test.UnitTest.TagMatchers
         [TestCategory("UT")]
         public void MatchListMultipleInSentence()
         {
-            var sentence = "This [voice: male]has multiple[endvoice][voice: female] matches.[endvoice]";
-            var matches = new StartVoiceTagMatcher().Matches(sentence);
+            string sentence = "This [voice: male]has multiple[endvoice][voice: female] matches.[endvoice]";
+            System.Collections.Generic.List<PowerPointLabs.Tags.ITag> matches = new StartVoiceTagMatcher().Matches(sentence);
 
             Assert.IsTrue(matches.Any(), "No matches found.");
             Assert.IsTrue(matches.Count == 2, "Didn't match all.");

--- a/PowerPointLabs/Test/UnitTest/TagMatchers/TaggedTextTest.cs
+++ b/PowerPointLabs/Test/UnitTest/TagMatchers/TaggedTextTest.cs
@@ -15,9 +15,9 @@ namespace Test.UnitTest.TagMatchers
         {
             const string sentence = "This is separated by a click.[afterclick]This is the next part.";
 
-            var t = new TaggedText(sentence);
+            TaggedText t = new TaggedText(sentence);
 
-            var split = t.SplitByClicks();
+            System.Collections.Generic.List<string> split = t.SplitByClicks();
             Assert.IsTrue(split.Count == 2, "Split into incorrect amount of strings.");
             Assert.IsTrue(split[0].Equals("This is separated by a click."), "First split incorrect.");
             Assert.IsTrue(split[1].Equals("This is the next part."), "Second split incorrect.");
@@ -29,8 +29,8 @@ namespace Test.UnitTest.TagMatchers
         {
             const string sentence = "This has no clicks to split by.";
 
-            var t = new TaggedText(sentence);
-            var split = t.SplitByClicks();
+            TaggedText t = new TaggedText(sentence);
+            System.Collections.Generic.List<string> split = t.SplitByClicks();
 
             Assert.IsTrue(split.Count == 1, "Split when there wasn't a click.");
             Assert.IsTrue(split[0].Equals("This has no clicks to split by."), "Didn't leave original string intact.");
@@ -42,8 +42,8 @@ namespace Test.UnitTest.TagMatchers
         {
             const string expected = "This has some tags in it.";
 
-            var t = new TaggedText(SentenceWithTags);
-            var actual = t.ToPrettyString();
+            TaggedText t = new TaggedText(SentenceWithTags);
+            string actual = t.ToPrettyString();
 
             Assert.AreEqual(expected, actual, "Didn't remove tags properly.");
         }
@@ -52,10 +52,10 @@ namespace Test.UnitTest.TagMatchers
         [TestCategory("UT")]
         public void TestToString()
         {
-            var expected = SentenceWithTags;
+            string expected = SentenceWithTags;
             
-            var t = new TaggedText(SentenceWithTags);
-            var actual = t.ToString();
+            TaggedText t = new TaggedText(SentenceWithTags);
+            string actual = t.ToString();
 
             Assert.AreEqual(expected, actual, "Didn't produce the original sentence.");
         }
@@ -64,8 +64,8 @@ namespace Test.UnitTest.TagMatchers
         [TestCategory("UT")]
         public void SplitEmptyString()
         {
-            var t = new TaggedText("");
-            var result = t.SplitByClicks();
+            TaggedText t = new TaggedText("");
+            System.Collections.Generic.List<string> result = t.SplitByClicks();
 
             Assert.IsNotNull(result, "Returned a null list.");
             Assert.IsFalse(result.Any(), "List contained results.");

--- a/PowerPointLabs/Test/UnitTest/Utils/TempPathTest.cs
+++ b/PowerPointLabs/Test/UnitTest/Utils/TempPathTest.cs
@@ -11,8 +11,8 @@ namespace Test.UnitTest.Utils
         [TestCategory("UT")]
         public void TestTempTestFolderName()
         {
-            var tempFolder = TempPath.GetTempTestFolder();
-            var folderName = Path.GetFileName(Path.GetDirectoryName(tempFolder));
+            string tempFolder = TempPath.GetTempTestFolder();
+            string folderName = Path.GetFileName(Path.GetDirectoryName(tempFolder));
             Assert.AreEqual("PowerPointLabsTest", folderName);
         }
 
@@ -37,7 +37,7 @@ namespace Test.UnitTest.Utils
         [TestCategory("UT")]
         public void TestDeleteTempTestFolderWithReadOnlyFile()
         {
-            var readOnlyFile = Path.Combine(TempPath.GetTempTestFolder(), "ReadOnlyFile.txt");
+            string readOnlyFile = Path.Combine(TempPath.GetTempTestFolder(), "ReadOnlyFile.txt");
 
             TempPath.CreateTempTestFolder();
 
@@ -54,7 +54,7 @@ namespace Test.UnitTest.Utils
         [TestCategory("UT")]
         public void TestDeleteTempTestFolderWithNestedFolder()
         {
-            var subFolder = Path.Combine(TempPath.GetTempTestFolder(), "SubPowerPointLabsTest\\");
+            string subFolder = Path.Combine(TempPath.GetTempTestFolder(), "SubPowerPointLabsTest\\");
 
             TempPath.CreateTempTestFolder();
 

--- a/PowerPointLabs/Test/Util/DialogUtil.cs
+++ b/PowerPointLabs/Test/Util/DialogUtil.cs
@@ -11,14 +11,14 @@ namespace Test.Util
     {
         public static void WaitForDialogBox(Action openDialogAction, string lpClassName, string lpWindowName, int timeLimit = 5000)
         {
-            var task = new Task(() => openDialogAction());
+            Task task = new Task(() => openDialogAction());
             task.Start();
 
             int pollCount = 10;
             int retryInterval = timeLimit/pollCount;
             for (int i = 0; i <= pollCount; ++i)
             {
-                var spotlightDialog = NativeUtil.FindWindow(null, lpWindowName);
+                IntPtr spotlightDialog = NativeUtil.FindWindow(null, lpWindowName);
                 if (spotlightDialog != IntPtr.Zero) return;
                 ThreadUtil.WaitFor(retryInterval);
             }
@@ -27,7 +27,7 @@ namespace Test.Util
 
         public static void CloseDialogBox(IntPtr dialogBoxHandle, string buttonName)
         {
-            var btnHandle = NativeUtil.FindWindowEx(dialogBoxHandle, IntPtr.Zero, null, buttonName);
+            IntPtr btnHandle = NativeUtil.FindWindowEx(dialogBoxHandle, IntPtr.Zero, null, buttonName);
             Assert.AreNotEqual(IntPtr.Zero, btnHandle, "Failed to find button in the dialog box.");
             NativeUtil.SetForegroundWindow(dialogBoxHandle);
             NativeUtil.SendMessage(btnHandle, 0x0201 /*left button down*/, IntPtr.Zero, IntPtr.Zero);

--- a/PowerPointLabs/Test/Util/MessageBoxUtil.cs
+++ b/PowerPointLabs/Test/Util/MessageBoxUtil.cs
@@ -22,10 +22,10 @@ namespace Test.Util
         {
             // MessageBox in pptlabs will block the whole thread,
             // so multi-thread is needed here.
-            var taskToVerify = new Task(() =>
+            Task taskToVerify = new Task(() =>
             {
                 // try to find messagebox window
-                var msgBoxHandle = IntPtr.Zero;
+                IntPtr msgBoxHandle = IntPtr.Zero;
                 while (msgBoxHandle == IntPtr.Zero && retryCount > 0)
                 {
                     msgBoxHandle = NativeUtil.FindWindow("#32770", title);
@@ -45,12 +45,12 @@ namespace Test.Util
                 }
 
                 // try to find text label in the message box
-                var dlgHandle = NativeUtil.GetDlgItem(msgBoxHandle, 0xFFFF);
+                IntPtr dlgHandle = NativeUtil.GetDlgItem(msgBoxHandle, 0xFFFF);
                 Assert.AreNotEqual(IntPtr.Zero, dlgHandle, "Failed to find label in the messagebox.");
 
                 const int nchars = 1024;
-                var actualContentBuilder = new StringBuilder(nchars);
-                var isGetTextSuccessful = NativeUtil.GetWindowText(dlgHandle, actualContentBuilder, nchars);
+                StringBuilder actualContentBuilder = new StringBuilder(nchars);
+                int isGetTextSuccessful = NativeUtil.GetWindowText(dlgHandle, actualContentBuilder, nchars);
 
                 // close the message box, otherwise it will block the test
                 CloseMessageBox(msgBoxHandle, buttonNameToClick);
@@ -95,7 +95,7 @@ namespace Test.Util
             {
                 // This may be flaky.. if there're more than one windows pop up at the same time..
                 // it will affect clicking the button
-                var btnHandle = NativeUtil.FindWindowEx(msgBoxHandle, IntPtr.Zero, "Button", buttonName);
+                IntPtr btnHandle = NativeUtil.FindWindowEx(msgBoxHandle, IntPtr.Zero, "Button", buttonName);
                 Assert.AreNotEqual(IntPtr.Zero, btnHandle, "Failed to find button in the messagebox.");
                 NativeUtil.SetForegroundWindow(msgBoxHandle);
                 NativeUtil.SendMessage(btnHandle, 0x0201 /*left button down*/, IntPtr.Zero, IntPtr.Zero);

--- a/PowerPointLabs/Test/Util/MouseUtil.cs
+++ b/PowerPointLabs/Test/Util/MouseUtil.cs
@@ -64,7 +64,7 @@ namespace Test.Util
 
         private static Point GetDpiSafeLocation(int x, int y)
         {
-            var dpi = GetScalingFactor();
+            float dpi = GetScalingFactor();
             return new Point
             {
                 X = (int) (x / dpi),
@@ -74,12 +74,12 @@ namespace Test.Util
 
         private static float GetScalingFactor()
         {
-            var g = Graphics.FromHwnd(IntPtr.Zero);
-            var desktop = g.GetHdc();
-            var LogicalScreenHeight = NativeUtil.GetDeviceCaps(desktop, (int)NativeUtil.DeviceCap.VERTRES);
-            var PhysicalScreenHeight = NativeUtil.GetDeviceCaps(desktop, (int)NativeUtil.DeviceCap.DESKTOPVERTRES);
+            Graphics g = Graphics.FromHwnd(IntPtr.Zero);
+            IntPtr desktop = g.GetHdc();
+            int LogicalScreenHeight = NativeUtil.GetDeviceCaps(desktop, (int)NativeUtil.DeviceCap.VERTRES);
+            int PhysicalScreenHeight = NativeUtil.GetDeviceCaps(desktop, (int)NativeUtil.DeviceCap.DESKTOPVERTRES);
 
-            var ScreenScalingFactor = (float)PhysicalScreenHeight / (float)LogicalScreenHeight;
+            float ScreenScalingFactor = (float)PhysicalScreenHeight / (float)LogicalScreenHeight;
 
             return ScreenScalingFactor; // 1.25 = 125%
         }

--- a/PowerPointLabs/Test/Util/NativeUtil.cs
+++ b/PowerPointLabs/Test/Util/NativeUtil.cs
@@ -149,11 +149,11 @@ namespace Test.Util
 
         internal static Point GetPoint(IntPtr lParam)
         {
-            var uLParam = GetUncheckedInt(lParam);
+            uint uLParam = GetUncheckedInt(lParam);
             
             // cast to long first so that it's 64-bit compatible
-            var x = unchecked((short)(long)uLParam);
-            var y = unchecked((short)((long)uLParam >> 16));
+            short x = unchecked((short)(long)uLParam);
+            short y = unchecked((short)((long)uLParam >> 16));
 
             return new Point(x, y);
         }

--- a/PowerPointLabs/Test/Util/PathUtil.cs
+++ b/PowerPointLabs/Test/Util/PathUtil.cs
@@ -28,10 +28,10 @@ namespace Test.Util
         public static string GetDocTestPath()
         {
             //To get the location the assembly normally resides on disk or the install directory
-            var path = new Uri(
+            string path = new Uri(
                 Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().CodeBase))
                 .LocalPath;
-            var parPath = PathUtil.GetParentFolder(path, 4);
+            string parPath = PathUtil.GetParentFolder(path, 4);
             return Path.Combine(parPath, "doc\\test\\");
         }
 

--- a/PowerPointLabs/Test/Util/PresentationUtil.cs
+++ b/PowerPointLabs/Test/Util/PresentationUtil.cs
@@ -12,7 +12,7 @@ namespace Test.Util
         public static void AssertEqual(List<ISlideData> expectedSlides, List<ISlideData> actualSlides)
         {
             Assert.AreEqual(expectedSlides.Count, actualSlides.Count);
-            for (var i = 0; i < expectedSlides.Count; ++i)
+            for (int i = 0; i < expectedSlides.Count; ++i)
             {
                 SlideDataUtil.AssertEqual(expectedSlides[i], actualSlides[i]);
             }

--- a/PowerPointLabs/Test/Util/SlideUtil.cs
+++ b/PowerPointLabs/Test/Util/SlideUtil.cs
@@ -42,8 +42,8 @@ namespace Test.Util
 
             if (expShape.HasTextFrame == Microsoft.Office.Core.MsoTriState.msoTrue)
             {
-                var expText = expShape.TextFrame.TextRange;
-                var actualText = actualShape.TextFrame.TextRange;
+                TextRange expText = expShape.TextFrame.TextRange;
+                TextRange actualText = actualShape.TextFrame.TextRange;
 
                 Assert.AreEqual(expText.Text, actualText.Text,
                     "different text for {0}. exp:{1}, actual:{2}", expShape.Name, expText.Text, actualText.Text);
@@ -68,18 +68,18 @@ namespace Test.Util
 
         public static void IsSameShapes(Slide expSlide, Slide actualSlide)
         {
-            var expShapes = expSlide.Shapes;
-            var actualShapes = actualSlide.Shapes;
+            Shapes expShapes = expSlide.Shapes;
+            Shapes actualShapes = actualSlide.Shapes;
             Assert.AreEqual(expShapes.Count, actualShapes.Count,
                 "different number of shapes on slide. exp:{0}, actual:{1}", expShapes.Count, actualShapes.Count);
 
             for (int i = 1; i <= expShapes.Count; i++)
             {
-                var expShape = expShapes[i];
+                Shape expShape = expShapes[i];
                 bool isMatchingShapeFound = false;
                 for (int j = 1; j <= actualShapes.Count; j++)
                 {
-                    var actualShape = actualShapes[j];
+                    Shape actualShape = actualShapes[j];
                     if (expShape.Name == actualShape.Name)
                     {
                         isMatchingShapeFound = true;
@@ -121,16 +121,16 @@ namespace Test.Util
         {
             IsSameShape(expShape, actualShape);
 
-            var actualShapeInPic = new ComparableImage(actualFileInfo);
-            var expShapeInPic = new ComparableImage(expFileInfo);
+            ComparableImage actualShapeInPic = new ComparableImage(actualFileInfo);
+            ComparableImage expShapeInPic = new ComparableImage(expFileInfo);
 
-            var similarity = actualShapeInPic.CalculateSimilarity(expShapeInPic);
+            double similarity = actualShapeInPic.CalculateSimilarity(expShapeInPic);
             Assert.IsTrue(similarity > similarityTolerance, "The shapes look different. Similarity = " + similarity);
         }
 
         public static void IsSameLooking(Slide expSlide, Slide actualSlide, double similarityTolerance = 0.95)
         {
-            var hashCode = DateTime.Now.GetHashCode();
+            int hashCode = DateTime.Now.GetHashCode();
             actualSlide.Export(PathUtil.GetTempPath("actualSlide" + hashCode + ".png"), "PNG");
             expSlide.Export(PathUtil.GetTempPath("expSlide" + hashCode + ".png"), "PNG");
 
@@ -146,22 +146,22 @@ namespace Test.Util
 
         public static void IsSameLooking(FileInfo expSlideImage, FileInfo actualSlideImage, double similarityTolerance = 0.95)
         {
-            var actualSlideInPic = new ComparableImage(actualSlideImage);
-            var expSlideInPic = new ComparableImage(expSlideImage);
+            ComparableImage actualSlideInPic = new ComparableImage(actualSlideImage);
+            ComparableImage expSlideInPic = new ComparableImage(expSlideImage);
 
-            var similarity = actualSlideInPic.CalculateSimilarity(expSlideInPic);
+            double similarity = actualSlideInPic.CalculateSimilarity(expSlideInPic);
             Assert.IsTrue(similarity > similarityTolerance, "The slides look different. Similarity = " + similarity);
         }
 
         public static void IsSameAnimations(Slide expSlide, Slide actualSlide)
         {
-            var actualSeq = actualSlide.TimeLine.MainSequence;
-            var expSeq = expSlide.TimeLine.MainSequence;
+            Sequence actualSeq = actualSlide.TimeLine.MainSequence;
+            Sequence expSeq = expSlide.TimeLine.MainSequence;
             Assert.AreEqual(expSeq.Count, actualSeq.Count, "Different animation sequence count.");
             for (int i = 1; i <= actualSeq.Count; i++)
             {
-                var actualEffect = actualSeq[i];
-                var expEffect = expSeq[i];
+                Effect actualEffect = actualSeq[i];
+                Effect expEffect = expSeq[i];
                 Assert.AreEqual(expEffect.EffectType, actualEffect.EffectType, 
                     "Different effect type.");
                 IsSameShape(expEffect.Shape, actualEffect.Shape);

--- a/PowerPointLabs/Test/Util/TagUtil.cs
+++ b/PowerPointLabs/Test/Util/TagUtil.cs
@@ -7,7 +7,7 @@ namespace Test.Util
     {
         public static void MatchAndAssert(string testTag, Regex tagRegex)
         {
-            var match = tagRegex.Match(testTag);
+            Match match = tagRegex.Match(testTag);
 
             Assert.IsTrue(match.Success, "Tag isn't matched.");
             Assert.IsTrue(match.Index == 0, "Match doesn't start at 0.");

--- a/PowerPointLabs/Test/Util/ThreadUtil.cs
+++ b/PowerPointLabs/Test/Util/ThreadUtil.cs
@@ -6,7 +6,7 @@ namespace Test.Util
     {
         public static void WaitFor(int time)
         {
-            var waitedFor = 0;
+            int waitedFor = 0;
             while (waitedFor < time)
             {
                 Thread.Sleep(time);

--- a/PowerPointLabs/Test/Util/UnitTestPpOperations.cs
+++ b/PowerPointLabs/Test/Util/UnitTestPpOperations.cs
@@ -56,15 +56,15 @@ namespace Test.Util
 
         public List<ISlideData> FetchPresentationData(string pathToPresentation)
         {
-            var presentation = App.Presentations.Open(pathToPresentation, WithWindow: MsoTriState.msoFalse);
-            var slideData = presentation.Slides.Cast<Slide>().Select(SlideData.FromSlide).ToList();
+            Presentation presentation = App.Presentations.Open(pathToPresentation, WithWindow: MsoTriState.msoFalse);
+            List<ISlideData> slideData = presentation.Slides.Cast<Slide>().Select(SlideData.FromSlide).ToList();
             presentation.Close();
             return slideData;
         }
 
         public List<ISlideData> FetchCurrentPresentationData()
         {
-            var slideData = Pres.Slides.Cast<Slide>().Select(SlideData.FromSlide).ToList();
+            List<ISlideData> slideData = Pres.Slides.Cast<Slide>().Select(SlideData.FromSlide).ToList();
             return slideData;
         }
 
@@ -110,7 +110,7 @@ namespace Test.Util
 
         public Slide SelectSlide(int index)
         {
-            var slide = Pres.Slides[index];
+            Slide slide = Pres.Slides[index];
             CurrentSlide = slide;
             return slide;
         }
@@ -140,8 +140,8 @@ namespace Test.Util
                 return string.Empty;
             }
 
-            var notesPagePlaceholders = slide.NotesPage.Shapes.Placeholders.Cast<Shape>();
-            var notesPageBody = notesPagePlaceholders
+            IEnumerable<Shape> notesPagePlaceholders = slide.NotesPage.Shapes.Placeholders.Cast<Shape>();
+            Shape notesPageBody = notesPagePlaceholders
                 .FirstOrDefault(shape => shape.PlaceholderFormat.Type == PpPlaceholderType.ppPlaceholderBody);
 
             string notesText = notesPageBody != null ? notesPageBody.TextFrame.TextRange.Text : string.Empty;
@@ -155,8 +155,8 @@ namespace Test.Util
                 return;
             }
 
-            var notesPagePlaceholders = slide.NotesPage.Shapes.Placeholders.Cast<Shape>();
-            var notesPageBody = notesPagePlaceholders
+            IEnumerable<Shape> notesPagePlaceholders = slide.NotesPage.Shapes.Placeholders.Cast<Shape>();
+            Shape notesPageBody = notesPagePlaceholders
                 .FirstOrDefault(shape => shape.PlaceholderFormat.Type == PpPlaceholderType.ppPlaceholderBody);
 
             if (notesPageBody != null)
@@ -174,7 +174,7 @@ namespace Test.Util
         {
             if (CurrentSlide == null) return null;
 
-            var nameList = new List<string>();
+            List<string> nameList = new List<string>();
             nameList.Add(shapeName);
             _currentShape = CurrentSlide.Shapes.Range(nameList.ToArray());
             return _currentShape;
@@ -191,7 +191,7 @@ namespace Test.Util
         {
             if (CurrentSlide == null) return null;
 
-            var nameList = new List<string>();
+            List<string> nameList = new List<string>();
             foreach (Shape shape in CurrentSlide.Shapes)
             {
                 if (shape.Name.StartsWith(prefix))
@@ -205,7 +205,7 @@ namespace Test.Util
 
         public Shape RecursiveGetShapeWithPrefix(params string[] prefixes)
         {
-            var parentShape = SelectShapesByPrefix(prefixes[0])[1];
+            Shape parentShape = SelectShapesByPrefix(prefixes[0])[1];
             for (int i = 1; i < prefixes.Length; ++i)
             {
                 parentShape = parentShape.GroupItems.Cast<Shape>().FirstOrDefault(shape => shape.Name.StartsWith(prefixes[i]));
@@ -215,25 +215,25 @@ namespace Test.Util
 
         public FileInfo ExportSelectedShapes()
         {
-            var shapes = _currentShape;
-            var hashCode = DateTime.Now.GetHashCode();
-            var pathName = TempPath.GetTempTestFolder() + "shapeName" + hashCode;
+            ShapeRange shapes = _currentShape;
+            int hashCode = DateTime.Now.GetHashCode();
+            string pathName = TempPath.GetTempTestFolder() + "shapeName" + hashCode;
             shapes.Export(pathName, PpShapeFormat.ppShapeFormatPNG);
             return new FileInfo(pathName);
         }
 
         public string SelectAllTextInShape(string shapeName)
         {
-            var shape = CurrentSlide.Shapes.Cast<Shape>().FirstOrDefault(sh => sh.Name == shapeName);
-            var textRange = shape.TextFrame2.TextRange;
+            Shape shape = CurrentSlide.Shapes.Cast<Shape>().FirstOrDefault(sh => sh.Name == shapeName);
+            TextRange2 textRange = shape.TextFrame2.TextRange;
             textRange.Select();
             return textRange.Text;
         }
 
         public string SelectTextInShape(string shapeName, int startIndex, int endIndex)
         {
-            var shape = CurrentSlide.Shapes.Cast<Shape>().FirstOrDefault(sh => sh.Name == shapeName);
-            var textRange = shape.TextFrame2.TextRange.Characters[startIndex, endIndex - startIndex];
+            Shape shape = CurrentSlide.Shapes.Cast<Shape>().FirstOrDefault(sh => sh.Name == shapeName);
+            TextRange2 textRange = shape.TextFrame2.TextRange.Characters[startIndex, endIndex - startIndex];
             textRange.Select();
             return textRange.Text;
         }


### PR DESCRIPTION
#1470 

I have change non-dynamic variable types from "var" to static-typed for the entire solutions and also rectified any errors as a result of the changes.

Notes:
1. I am unsure of the data type of the variable "data" and "entry". The editor said that they are anonymous data types 'a but I cannot determine the exact wording of the data type. This case is isolated in PowerPointLabs\XMLMisc\XMLParser.cs lines 62 & 71. I have uploaded 2 photos for reference

2. I have not changed the data types of any variable which are part of commented code as they may or may not be included in the future or may be still subjected to further changes. Would be good to highlight the relevant people doing those parts to update the data type of their variables to static typed

![photo6253434553360295920](https://user-images.githubusercontent.com/16800272/34869584-55138f64-f7c2-11e7-9a8a-a1b5abebf3e7.jpg)
![photo6253434553360295919](https://user-images.githubusercontent.com/16800272/34869585-554d79b8-f7c2-11e7-878f-00cd2f98942b.jpg)

