### PR TITLE
#1346 Code Quality: Resolve SonarQube issues

### DIFF
--- a/PowerPointLabs/PowerPointLabs/AutoUpdate/Downloader.cs
+++ b/PowerPointLabs/PowerPointLabs/AutoUpdate/Downloader.cs
@@ -44,6 +44,12 @@ namespace PowerPointLabs.AutoUpdate
             return this;
         }
 
+        public void Dispose()
+        {
+            // Dispose web client after downloading or when error occurs
+            this._client.Dispose();
+        }
+
         public void Start()
         {
             try
@@ -91,6 +97,10 @@ namespace PowerPointLabs.AutoUpdate
             {
                 CallWhenErrorDelegate(e);
                 Logger.LogException(e, "Failed to execute Downloader.StartDownload");
+            }
+            finally
+            {
+                Dispose();
             }
         }
     }

--- a/PowerPointLabs/PowerPointLabs/AutoUpdate/Downloader.cs
+++ b/PowerPointLabs/PowerPointLabs/AutoUpdate/Downloader.cs
@@ -6,7 +6,7 @@ using PowerPointLabs.AutoUpdate.Interface;
 
 namespace PowerPointLabs.AutoUpdate
 {
-    public class Downloader : IDownloader
+    public class Downloader : IDownloader, IDisposable
     {
         private readonly WebClient _client = new WebClient();
 

--- a/PowerPointLabs/PowerPointLabs/AutoUpdate/Downloader.cs
+++ b/PowerPointLabs/PowerPointLabs/AutoUpdate/Downloader.cs
@@ -6,7 +6,7 @@ using PowerPointLabs.AutoUpdate.Interface;
 
 namespace PowerPointLabs.AutoUpdate
 {
-    public class Downloader : IDownloader, IDisposable
+    public sealed class Downloader : IDownloader, IDisposable
     {
         private readonly WebClient _client = new WebClient();
 

--- a/PowerPointLabs/PowerPointLabs/PositionsLab/PositionsLabMain.cs
+++ b/PowerPointLabs/PowerPointLabs/PositionsLab/PositionsLabMain.cs
@@ -502,6 +502,16 @@ namespace PowerPointLabs.PositionsLab
 
         #region Distribute
 
+        public class GridSpace
+        {
+            public float RowDifference { get; }
+            public float ColDifference { get; }
+            public GridSpace(float rowDifference, float colDifference)
+            {
+                RowDifference = rowDifference;
+                ColDifference = colDifference;
+            }
+        }
         public static void DistributeHorizontal(List<PPShape> selectedShapes, float slideWidth)
         {
             bool isSlide = PositionsLabSettings.DistributeReference == PositionsLabSettings.DistributeReferenceObject.Slide;
@@ -1499,18 +1509,17 @@ namespace PowerPointLabs.PositionsLab
             float rowDifference = rowWidth / (rowLength - 1);
             float colDifference = colHeight / (colLength - 1);
 
-            float[,] gridSpaces = new float[selectedShapes.Count, 2];
+            GridSpace[] gridSpaces = new GridSpace[selectedShapes.Count];
 
             for (int i = 0; i < selectedShapes.Count; i++)
             {
-                gridSpaces[i, 0] = rowDifference;
-                gridSpaces[i, 1] = colDifference;
+                gridSpaces[i] = new GridSpace(rowDifference, colDifference);
             }
 
             DistributeGridByRow(selectedShapes, rowLength, colLength, gridSpaces, 0, selectedShapes.Count - 1);
         }
 
-        public static void DistributeGridByRow(List<PPShape> selectedShapes, int rowLength, int colLength, float[,] gridSpaces, int start, int end)
+        public static void DistributeGridByRow(List<PPShape> selectedShapes, int rowLength, int colLength, GridSpace[] gridSpaces, int start, int end)
         {
             int numShapes = selectedShapes.Count;
             int numIndicesToSkip = IndicesToSkip(numShapes, rowLength, PositionsLabSettings.DistributeGridAlignment);
@@ -1530,20 +1539,20 @@ namespace PowerPointLabs.PositionsLab
                 if (i % rowLength == 0 && i != 0)
                 {
                     posX = startingAnchor.X;
-                    posY += gridSpaces[i, 1];
+                    posY += gridSpaces[i].ColDifference;
                 }
 
                 //If last row, offset by num of indices to skip
                 if (numShapes - i == remainder)
                 {
-                    posX += numIndicesToSkip * gridSpaces[i, 0];
+                    posX += numIndicesToSkip * gridSpaces[i].RowDifference;
                 }
 
                 PPShape currentShape = selectedShapes[i];
                 currentShape.IncrementLeft(posX - currentShape.VisualCenter.X);
                 currentShape.IncrementTop(posY - currentShape.VisualCenter.Y);
 
-                posX += gridSpaces[i, 0];
+                posX += gridSpaces[i].RowDifference;
             }
         }
 

--- a/PowerPointLabs/PowerPointLabs/PositionsLab/PositionsLabMain.cs
+++ b/PowerPointLabs/PowerPointLabs/PositionsLab/PositionsLabMain.cs
@@ -30,7 +30,18 @@ namespace PowerPointLabs.PositionsLab
         private const int Up = 3;
         private const int Leftorright = 4;
         private const int Upordown = 5;
-        
+
+        public class GridSpace
+        {
+            public float RowDifference { get; }
+            public float ColDifference { get; }
+            public GridSpace(float rowDifference, float colDifference)
+            {
+                RowDifference = rowDifference;
+                ColDifference = colDifference;
+            }
+        }
+
         private class ShapeAngleInfo
         {
             public Shape Shape { get; private set; }
@@ -502,16 +513,6 @@ namespace PowerPointLabs.PositionsLab
 
         #region Distribute
 
-        public class GridSpace
-        {
-            public float RowDifference { get; }
-            public float ColDifference { get; }
-            public GridSpace(float rowDifference, float colDifference)
-            {
-                RowDifference = rowDifference;
-                ColDifference = colDifference;
-            }
-        }
         public static void DistributeHorizontal(List<PPShape> selectedShapes, float slideWidth)
         {
             bool isSlide = PositionsLabSettings.DistributeReference == PositionsLabSettings.DistributeReferenceObject.Slide;
@@ -1703,18 +1704,17 @@ namespace PowerPointLabs.PositionsLab
             selectedShapes.RemoveAt(1);
             selectedShapes.Add(endAnchor);
 
-            float[,] gridSpaces = new float[selectedShapes.Count, 2];
+            GridSpace[] gridSpaces = new GridSpace[selectedShapes.Count];
 
             for (int i = 0; i < selectedShapes.Count; i++)
             {
-                gridSpaces[i, 0] = rowDifference;
-                gridSpaces[i, 1] = colDifference;
+                gridSpaces[i] = new GridSpace(rowDifference, colDifference);
             }
 
             DistributeGridByCol(selectedShapes, rowLength, colLength, gridSpaces, 0, selectedShapes.Count - 1);
         }
 
-        public static void DistributeGridByCol(List<PPShape> selectedShapes, int rowLength, int colLength, float[,] gridSpaces, int start, int end)
+        public static void DistributeGridByCol(List<PPShape> selectedShapes, int rowLength, int colLength, GridSpace[] gridSpaces, int start, int end)
         {
             int numShapes = selectedShapes.Count;
 
@@ -1752,7 +1752,7 @@ namespace PowerPointLabs.PositionsLab
                 if (IsFirstIndexOfRow(augmentedShapeIndex, rowLength) && augmentedShapeIndex != 0)
                 {
                     posX = startingAnchor.X;
-                    posY += gridSpaces[i, 1];
+                    posY += gridSpaces[i].ColDifference;
                 }
 
                 PPShape currentShape = selectedShapes[i];
@@ -1760,7 +1760,7 @@ namespace PowerPointLabs.PositionsLab
                 currentShape.IncrementLeft(posX - center.X);
                 currentShape.IncrementTop(posY - center.Y);
 
-                posX += gridSpaces[i, 0];
+                posX += gridSpaces[i].RowDifference;
                 augmentedShapeIndex++;
             }
         }

--- a/PowerPointLabs/PowerPointLabs/PositionsLab/PositionsPaneWPF.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/PositionsLab/PositionsPaneWPF.xaml.cs
@@ -132,7 +132,7 @@ namespace PowerPointLabs.PositionsLab
         private void AlignLeftButton_Click(object sender, RoutedEventArgs e)
         {
             Action<ShapeRange> positionsAction = shapes => PositionsLabMain.AlignLeft(shapes);
-            ExecutePositionsAction(positionsAction, false);
+            ExecutePositionsAction(positionsAction, false, true);
         }
 
         private void AlignRightButton_Click(object sender, RoutedEventArgs e)
@@ -145,7 +145,7 @@ namespace PowerPointLabs.PositionsLab
         private void AlignTopButton_Click(object sender, RoutedEventArgs e)
         {
             Action<ShapeRange> positionsAction = shapes => PositionsLabMain.AlignTop(shapes);
-            ExecutePositionsAction(positionsAction, false);
+            ExecutePositionsAction(positionsAction, false, true);
         }
 
         private void AlignBottomButton_Click(object sender, RoutedEventArgs e)
@@ -563,7 +563,7 @@ namespace PowerPointLabs.PositionsLab
             Action<ShapeRange> positionsAction = shapes => PositionsLabMain.AlignLeft(shapes);
             _previewCallBack = delegate
             {
-                ExecutePositionsAction(positionsAction, true);
+                ExecutePositionsAction(positionsAction, true, true);
             };
             PreviewHandler();
         }
@@ -584,7 +584,7 @@ namespace PowerPointLabs.PositionsLab
             Action<ShapeRange> positionsAction = shapes => PositionsLabMain.AlignTop(shapes);
             _previewCallBack = delegate
             {
-                ExecutePositionsAction(positionsAction, true);
+                ExecutePositionsAction(positionsAction, true, true);
             };
             PreviewHandler();
         }
@@ -1021,15 +1021,27 @@ namespace PowerPointLabs.PositionsLab
         #endregion
 
         #region Helper
-        // align left and top
-        public void ExecutePositionsAction(Action<ShapeRange> positionsAction, bool isPreview, bool isConvertPPShape = true)
+
+        // returns true if selection is valid
+        public bool HandleInvalidSelection(bool isPreview, Selection selection)
         {
-            if (this.GetCurrentSelection().Type != PpSelectionType.ppSelectionShapes)
+            if (!ShapeUtil.IsSelectionShape(selection))
             {
                 if (!isPreview)
                 {
                     ShowErrorMessageBox(PositionsLabText.ErrorNoSelection);
                 }
+                return false;
+            }
+            return true;
+        }
+        // align left and top
+        public void ExecutePositionsAction(Action<ShapeRange> positionsAction, bool isPreview, bool isConvertPPShape)
+        {
+            Selection selection = this.GetCurrentSelection();
+            if (!HandleInvalidSelection(isPreview, selection))
+            {
+                // invalid selection!
                 return;
             }
 
@@ -1037,7 +1049,7 @@ namespace PowerPointLabs.PositionsLab
 
             try
             {
-                ShapeRange selectedShapes = this.GetCurrentSelection().ShapeRange;
+                ShapeRange selectedShapes = selection.ShapeRange;
 
                 if (isPreview)
                 {
@@ -1096,12 +1108,10 @@ namespace PowerPointLabs.PositionsLab
         // Align right, bottom, vertical center, horizontal center
         public void ExecutePositionsAction(Action<ShapeRange, float> positionsAction, float dimension, bool isPreview)
         {
-            if (this.GetCurrentSelection().Type != PpSelectionType.ppSelectionShapes)
+            Selection selection = this.GetCurrentSelection();
+            if (!HandleInvalidSelection(isPreview, selection))
             {
-                if (!isPreview)
-                {
-                    ShowErrorMessageBox(PositionsLabText.ErrorNoSelection);
-                }
+                // invalid selection!
                 return;
             }
 
@@ -1109,7 +1119,7 @@ namespace PowerPointLabs.PositionsLab
 
             try
             {
-                ShapeRange selectedShapes = this.GetCurrentSelection().ShapeRange;
+                ShapeRange selectedShapes = selection.ShapeRange;
 
                 if (isPreview)
                 {
@@ -1161,12 +1171,10 @@ namespace PowerPointLabs.PositionsLab
         // Align center
         public void ExecutePositionsAction(Action<ShapeRange, float, float> positionsAction, float dimension1, float dimension2, bool isPreview)
         {
-            if (this.GetCurrentSelection().Type != PpSelectionType.ppSelectionShapes)
+            Selection selection = this.GetCurrentSelection();
+            if (!HandleInvalidSelection(isPreview, selection))
             {
-                if (!isPreview)
-                {
-                    ShowErrorMessageBox(PositionsLabText.ErrorNoSelection);
-                }
+                // invalid selection!
                 return;
             }
 
@@ -1174,7 +1182,7 @@ namespace PowerPointLabs.PositionsLab
 
             try
             {
-                ShapeRange selectedShapes = this.GetCurrentSelection().ShapeRange;
+                ShapeRange selectedShapes = selection.ShapeRange;
 
                 if (isPreview)
                 {
@@ -1226,12 +1234,10 @@ namespace PowerPointLabs.PositionsLab
 
         public void ExecutePositionsAction(Action<List<PPShape>> positionsAction, bool isPreview)
         {
-            if (this.GetCurrentSelection().Type != PpSelectionType.ppSelectionShapes)
+            Selection selection = this.GetCurrentSelection();
+            if (!HandleInvalidSelection(isPreview, selection))
             {
-                if (!isPreview)
-                {
-                    ShowErrorMessageBox(PositionsLabText.ErrorNoSelection);
-                }
+                // invalid selection!
                 return;
             }
 
@@ -1239,7 +1245,7 @@ namespace PowerPointLabs.PositionsLab
 
             try
             {
-                ShapeRange selectedShapes = this.GetCurrentSelection().ShapeRange;
+                ShapeRange selectedShapes = selection.ShapeRange;
 
                 if (isPreview)
                 {
@@ -1284,20 +1290,17 @@ namespace PowerPointLabs.PositionsLab
 
         public void ExecutePositionsAction(Action<List<PPShape>, bool> positionsAction, bool booleanVal, bool isPreview)
         {
-            if (this.GetCurrentSelection().Type != PpSelectionType.ppSelectionShapes)
+            Selection selection = this.GetCurrentSelection();
+            if (!HandleInvalidSelection(isPreview, selection))
             {
-                if (!isPreview)
-                {
-                    ShowErrorMessageBox(PositionsLabText.ErrorNoSelection);
-                }
+                // invalid selection!
                 return;
             }
 
             ShapeRange simulatedShapes = null;
-
             try
             {
-                ShapeRange selectedShapes = this.GetCurrentSelection().ShapeRange;
+                ShapeRange selectedShapes = selection.ShapeRange;
 
                 if (isPreview)
                 {
@@ -1350,12 +1353,10 @@ namespace PowerPointLabs.PositionsLab
 
         public void ExecutePositionsAction(Action<List<PPShape>, float> positionsAction, float dimension, bool isPreview)
         {
-            if (this.GetCurrentSelection().Type != PpSelectionType.ppSelectionShapes)
+            Selection selection = this.GetCurrentSelection();
+            if (!HandleInvalidSelection(isPreview, selection))
             {
-                if (!isPreview)
-                {
-                    ShowErrorMessageBox(PositionsLabText.ErrorNoSelection);
-                }
+                // invalid selection!
                 return;
             }
 
@@ -1363,7 +1364,7 @@ namespace PowerPointLabs.PositionsLab
 
             try
             {
-                ShapeRange selectedShapes = this.GetCurrentSelection().ShapeRange;
+                ShapeRange selectedShapes = selection.ShapeRange;
 
                 if (isPreview)
                 {


### PR DESCRIPTION
Fixes #1346

1. Fixes bug at Downloader.cs, Line 11 (ensures disposal of web client after downloading)
2. Simplify parameters to not use multidimensional arrays, fixes code smells at PositionsLab/PositionsLabMain.cs, Line 1708 and Line 1708.

3. PowerPointLabsPositionsLab/PositionsPaneWPF.xaml.cs - Line 1025
It is `public void ExecutePositionsAction(Action<ShapeRange> positionsAction, bool isPreview, bool isConvertPPShape = true)` whereas Line 1227 is `public void ExecutePositionsAction(Action<List<PPShape>> positionsAction, bool isPreview)` thus the code signature is actually different but SonarQube thinks that they are the same.

Edit: Tries to solve Line 1025 problem by removing the default bool value and then adding a 'true' parameter call for certain function calls that relied on the default value.

@initialshl  What features will AutoUpdate affect?