### PR TITLE
#1532 Convert to picture should preserve z-order

### DIFF
--- a/PowerPointLabs/PowerPointLabs/ShortcutsLab/ConvertToPicture.cs
+++ b/PowerPointLabs/PowerPointLabs/ShortcutsLab/ConvertToPicture.cs
@@ -14,11 +14,14 @@ namespace PowerPointLabs.ShortcutsLab
     internal static class ConvertToPicture
     {
 #pragma warning disable 0618
+        public static int zOrder;
+
         public static void Convert(PowerPoint.Selection selection)
         {
             if (ShapeUtil.IsSelectionShapeOrText(selection))
             {
-                var shape = GetShapeFromSelection(selection);
+                PowerPoint.Shape shape = GetShapeFromSelection(selection);
+                zOrder = shape.ZOrderPosition;
                 shape = CutPasteShape(shape);
                 ConvertToPictureForShape(shape);
             }
@@ -65,10 +68,19 @@ namespace PowerPointLabs.ShortcutsLab
             float width = shape.Width;
             float height = shape.Height;
             shape.Delete();
-            var pic = PowerPointCurrentPresentationInfo.CurrentSlide.Shapes.PasteSpecial(PowerPoint.PpPasteDataType.ppPastePNG)[1];
+            PowerPoint.Shape pic = PowerPointCurrentPresentationInfo.CurrentSlide.Shapes.PasteSpecial(PowerPoint.PpPasteDataType.ppPastePNG)[1];
             pic.Left = x + (width - pic.Width) / 2;
             pic.Top = y + (height - pic.Height) / 2;
             pic.Rotation = rotation;
+            // move picture to original z-order
+            while (pic.ZOrderPosition > zOrder)
+            {
+                pic.ZOrder(Office.MsoZOrderCmd.msoSendBackward);
+            }
+            while (pic.ZOrderPosition < zOrder)
+            {
+                pic.ZOrder(Office.MsoZOrderCmd.msoBringForward);
+            }
             pic.Select();
         }
 

--- a/PowerPointLabs/PowerPointLabs/ShortcutsLab/ConvertToPicture.cs
+++ b/PowerPointLabs/PowerPointLabs/ShortcutsLab/ConvertToPicture.cs
@@ -14,7 +14,7 @@ namespace PowerPointLabs.ShortcutsLab
     internal static class ConvertToPicture
     {
 #pragma warning disable 0618
-        public static int zOrder;
+        private static int zOrder;
 
         public static void Convert(PowerPoint.Selection selection)
         {

--- a/PowerPointLabs/PowerPointLabs/ShortcutsLab/ConvertToPicture.cs
+++ b/PowerPointLabs/PowerPointLabs/ShortcutsLab/ConvertToPicture.cs
@@ -20,7 +20,7 @@ namespace PowerPointLabs.ShortcutsLab
         {
             if (ShapeUtil.IsSelectionShapeOrText(selection))
             {
-                PowerPoint.Shape shape = GetShapeFromSelection(selection);
+                var shape = GetShapeFromSelection(selection);
                 zOrder = shape.ZOrderPosition;
                 shape = CutPasteShape(shape);
                 ConvertToPictureForShape(shape);
@@ -68,7 +68,7 @@ namespace PowerPointLabs.ShortcutsLab
             float width = shape.Width;
             float height = shape.Height;
             shape.Delete();
-            PowerPoint.Shape pic = PowerPointCurrentPresentationInfo.CurrentSlide.Shapes.PasteSpecial(PowerPoint.PpPasteDataType.ppPastePNG)[1];
+            var pic = PowerPointCurrentPresentationInfo.CurrentSlide.Shapes.PasteSpecial(PowerPoint.PpPasteDataType.ppPastePNG)[1];
             pic.Left = x + (width - pic.Width) / 2;
             pic.Top = y + (height - pic.Height) / 2;
             pic.Rotation = rotation;

--- a/PowerPointLabs/PowerPointLabs/ShortcutsLab/ConvertToPicture.cs
+++ b/PowerPointLabs/PowerPointLabs/ShortcutsLab/ConvertToPicture.cs
@@ -20,9 +20,9 @@ namespace PowerPointLabs.ShortcutsLab
             if (ShapeUtil.IsSelectionShapeOrText(selection))
             {
                 PowerPoint.Shape shape = GetShapeFromSelection(selection);
-                int zOrder = shape.ZOrderPosition;
+                int originalZOrder = shape.ZOrderPosition;
                 shape = CutPasteShape(shape);
-                ConvertToPictureForShape(shape, zOrder);
+                ConvertToPictureForShape(shape, originalZOrder);
             }
             else
             {
@@ -49,7 +49,7 @@ namespace PowerPointLabs.ShortcutsLab
             }
         }
 
-        private static void ConvertToPictureForShape(PowerPoint.Shape shape, int zOrder)
+        private static void ConvertToPictureForShape(PowerPoint.Shape shape, int originalZOrder)
         {
             float rotation = 0;
             try
@@ -72,11 +72,11 @@ namespace PowerPointLabs.ShortcutsLab
             pic.Top = y + (height - pic.Height) / 2;
             pic.Rotation = rotation;
             // move picture to original z-order
-            while (pic.ZOrderPosition > zOrder)
+            while (pic.ZOrderPosition > originalZOrder)
             {
                 pic.ZOrder(Office.MsoZOrderCmd.msoSendBackward);
             }
-            while (pic.ZOrderPosition < zOrder)
+            while (pic.ZOrderPosition < originalZOrder)
             {
                 pic.ZOrder(Office.MsoZOrderCmd.msoBringForward);
             }

--- a/PowerPointLabs/PowerPointLabs/ShortcutsLab/ConvertToPicture.cs
+++ b/PowerPointLabs/PowerPointLabs/ShortcutsLab/ConvertToPicture.cs
@@ -20,7 +20,7 @@ namespace PowerPointLabs.ShortcutsLab
         {
             if (ShapeUtil.IsSelectionShapeOrText(selection))
             {
-                var shape = GetShapeFromSelection(selection);
+                PowerPoint.Shape shape = GetShapeFromSelection(selection);
                 zOrder = shape.ZOrderPosition;
                 shape = CutPasteShape(shape);
                 ConvertToPictureForShape(shape);

--- a/PowerPointLabs/PowerPointLabs/ShortcutsLab/ConvertToPicture.cs
+++ b/PowerPointLabs/PowerPointLabs/ShortcutsLab/ConvertToPicture.cs
@@ -14,16 +14,15 @@ namespace PowerPointLabs.ShortcutsLab
     internal static class ConvertToPicture
     {
 #pragma warning disable 0618
-        private static int zOrder;
 
         public static void Convert(PowerPoint.Selection selection)
         {
             if (ShapeUtil.IsSelectionShapeOrText(selection))
             {
                 PowerPoint.Shape shape = GetShapeFromSelection(selection);
-                zOrder = shape.ZOrderPosition;
+                int zOrder = shape.ZOrderPosition;
                 shape = CutPasteShape(shape);
-                ConvertToPictureForShape(shape);
+                ConvertToPictureForShape(shape, zOrder);
             }
             else
             {
@@ -50,7 +49,7 @@ namespace PowerPointLabs.ShortcutsLab
             }
         }
 
-        private static void ConvertToPictureForShape(PowerPoint.Shape shape)
+        private static void ConvertToPictureForShape(PowerPoint.Shape shape, int zOrder)
         {
             float rotation = 0;
             try


### PR DESCRIPTION
#1532 

changes
1. preserved z order for shapes
2. ran functional and unit tests to ensure no related errors
