### PR TITLE
#1564 SyncLab Design Decisions and Documentation

### DIFF
--- a/PowerPointLabs/PowerPointLabs/SyncLab/SyncFormatUtil.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/SyncFormatUtil.cs
@@ -13,6 +13,12 @@ namespace PowerPointLabs.SyncLab
     {
         #region Display Image Utils
 
+        /// <summary>
+        /// User takes ownership of managing shapes created with this Shapes object.
+        /// i.e. Created shapes must be deleted if no longer required
+        /// The shapes already present in this Shapes object MUST NOT be edited
+        /// </summary>
+        /// <returns></returns>
         public static Shapes GetTemplateShapes()
         {
             SyncLabShapeStorage shapeStorage = SyncLabShapeStorage.Instance;


### PR DESCRIPTION
#1564 WIP
PR for documentation only, to document design decisions for SyncLab and to improve comments in code. The documentation to be added here is tightly linked to the code, so it should reside in the repo rather than google docs.

I'm going with a 'edit when I see it' approach here, so I'm not quite sure of the eventual size of this PR. Will update when ready for merging.

- [ ] document strange fill type for lines, textboxes and images (msoFillMixed)
- [ ] document flaky failing test TestSyncGradientFill
- [ ] Picture's transparency color does not set the color of the background.
It sets the color PPT shows as transparent. 
- [ ] Always use ShapeUtil to get color of text from shapes. API provided by MS gives bad output at times
