### PR TITLE
#1576 Positions Lab: Should not require at least 2-3 shapes to be selected

### DIFF
--- a/PowerPointLabs/PowerPointLabs/PositionsLab/PositionsLabMain.cs
+++ b/PowerPointLabs/PowerPointLabs/PositionsLab/PositionsLabMain.cs
@@ -142,7 +142,8 @@ namespace PowerPointLabs.PositionsLab
                 case PositionsLabSettings.AlignReferenceObject.SelectedShape:
                     if (toAlign.Count < 2)
                     {
-                        throw new Exception(PositionsLabText.ErrorFewerThanTwoSelection);
+                        // Insert default align right behaviour here
+                        toAlign.Align(MsoAlignCmd.msoAlignRights, MsoTriState.msoTrue);
                     }
 
                     selectedShapes = ConvertShapeRangeToPPShapeList(toAlign);

--- a/PowerPointLabs/PowerPointLabs/PositionsLab/PositionsLabMain.cs
+++ b/PowerPointLabs/PowerPointLabs/PositionsLab/PositionsLabMain.cs
@@ -232,7 +232,8 @@ namespace PowerPointLabs.PositionsLab
                 case PositionsLabSettings.AlignReferenceObject.SelectedShape:
                     if (toAlign.Count < 2)
                     {
-                        throw new Exception(PositionsLabText.ErrorFewerThanTwoSelection);
+                        // Insert default align bottom behaviour here
+                        toAlign.Align(MsoAlignCmd.msoAlignBottoms, MsoTriState.msoTrue);
                     }
 
                     selectedShapes = ConvertShapeRangeToPPShapeList(toAlign);
@@ -277,7 +278,8 @@ namespace PowerPointLabs.PositionsLab
                 case PositionsLabSettings.AlignReferenceObject.SelectedShape:
                     if (toAlign.Count < 2)
                     {
-                        throw new Exception(PositionsLabText.ErrorFewerThanTwoSelection);
+                        // Insert default align horizontal center behaviour here
+                        toAlign.Align(MsoAlignCmd.msoAlignMiddles, MsoTriState.msoTrue);
                     }
 
                     selectedShapes = ConvertShapeRangeToPPShapeList(toAlign);
@@ -320,7 +322,8 @@ namespace PowerPointLabs.PositionsLab
                 case PositionsLabSettings.AlignReferenceObject.SelectedShape:
                     if (toAlign.Count < 2)
                     {
-                        throw new Exception(PositionsLabText.ErrorFewerThanTwoSelection);
+                        // Insert default align vertical center behaviour here
+                        toAlign.Align(MsoAlignCmd.msoAlignCenters, MsoTriState.msoTrue);
                     }
 
                     selectedShapes = ConvertShapeRangeToPPShapeList(toAlign);
@@ -364,7 +367,9 @@ namespace PowerPointLabs.PositionsLab
                 case PositionsLabSettings.AlignReferenceObject.SelectedShape:
                     if (toAlign.Count < 2)
                     {
-                        throw new Exception(PositionsLabText.ErrorFewerThanTwoSelection);
+                        // Insert default align center behaviour here
+                        toAlign.Align(MsoAlignCmd.msoAlignMiddles, MsoTriState.msoTrue);
+                        toAlign.Align(MsoAlignCmd.msoAlignCenters, MsoTriState.msoTrue);
                     }
 
                     selectedShapes = ConvertShapeRangeToPPShapeList(toAlign);

--- a/PowerPointLabs/PowerPointLabs/PositionsLab/PositionsLabMain.cs
+++ b/PowerPointLabs/PowerPointLabs/PositionsLab/PositionsLabMain.cs
@@ -98,6 +98,7 @@ namespace PowerPointLabs.PositionsLab
                     {
                         // Insert default align left behaviour here
                         toAlign.Align(MsoAlignCmd.msoAlignLefts, MsoTriState.msoTrue);
+                        break;
                     }
 
                     selectedShapes = ConvertShapeRangeToPPShapeList(toAlign);
@@ -144,6 +145,7 @@ namespace PowerPointLabs.PositionsLab
                     {
                         // Insert default align right behaviour here
                         toAlign.Align(MsoAlignCmd.msoAlignRights, MsoTriState.msoTrue);
+                        break;
                     }
 
                     selectedShapes = ConvertShapeRangeToPPShapeList(toAlign);
@@ -190,6 +192,7 @@ namespace PowerPointLabs.PositionsLab
                     {
                         // Insert default align top behaviour here
                         toAlign.Align(MsoAlignCmd.msoAlignTops, MsoTriState.msoTrue);
+                        break;
                     }
 
                     selectedShapes = ConvertShapeRangeToPPShapeList(toAlign);
@@ -234,6 +237,7 @@ namespace PowerPointLabs.PositionsLab
                     {
                         // Insert default align bottom behaviour here
                         toAlign.Align(MsoAlignCmd.msoAlignBottoms, MsoTriState.msoTrue);
+                        break;
                     }
 
                     selectedShapes = ConvertShapeRangeToPPShapeList(toAlign);
@@ -280,6 +284,7 @@ namespace PowerPointLabs.PositionsLab
                     {
                         // Insert default align horizontal center behaviour here
                         toAlign.Align(MsoAlignCmd.msoAlignMiddles, MsoTriState.msoTrue);
+                        break;
                     }
 
                     selectedShapes = ConvertShapeRangeToPPShapeList(toAlign);
@@ -324,6 +329,7 @@ namespace PowerPointLabs.PositionsLab
                     {
                         // Insert default align vertical center behaviour here
                         toAlign.Align(MsoAlignCmd.msoAlignCenters, MsoTriState.msoTrue);
+                        break;
                     }
 
                     selectedShapes = ConvertShapeRangeToPPShapeList(toAlign);
@@ -370,8 +376,9 @@ namespace PowerPointLabs.PositionsLab
                         // Insert default align center behaviour here
                         toAlign.Align(MsoAlignCmd.msoAlignMiddles, MsoTriState.msoTrue);
                         toAlign.Align(MsoAlignCmd.msoAlignCenters, MsoTriState.msoTrue);
+                        break;
                     }
-
+                    System.Diagnostics.Debug.WriteLine("Not suppose to see this string");
                     selectedShapes = ConvertShapeRangeToPPShapeList(toAlign);
                     var refShape = selectedShapes[0];
 

--- a/PowerPointLabs/PowerPointLabs/PositionsLab/PositionsLabMain.cs
+++ b/PowerPointLabs/PowerPointLabs/PositionsLab/PositionsLabMain.cs
@@ -96,7 +96,6 @@ namespace PowerPointLabs.PositionsLab
                 case PositionsLabSettings.AlignReferenceObject.SelectedShape:
                     if (toAlign.Count < 2)
                     {
-                        // Insert default align left behaviour here
                         toAlign.Align(MsoAlignCmd.msoAlignLefts, MsoTriState.msoTrue);
                         break;
                     }
@@ -143,7 +142,6 @@ namespace PowerPointLabs.PositionsLab
                 case PositionsLabSettings.AlignReferenceObject.SelectedShape:
                     if (toAlign.Count < 2)
                     {
-                        // Insert default align right behaviour here
                         toAlign.Align(MsoAlignCmd.msoAlignRights, MsoTriState.msoTrue);
                         break;
                     }
@@ -190,7 +188,6 @@ namespace PowerPointLabs.PositionsLab
                 case PositionsLabSettings.AlignReferenceObject.SelectedShape:
                     if (toAlign.Count < 2)
                     {
-                        // Insert default align top behaviour here
                         toAlign.Align(MsoAlignCmd.msoAlignTops, MsoTriState.msoTrue);
                         break;
                     }
@@ -235,7 +232,6 @@ namespace PowerPointLabs.PositionsLab
                 case PositionsLabSettings.AlignReferenceObject.SelectedShape:
                     if (toAlign.Count < 2)
                     {
-                        // Insert default align bottom behaviour here
                         toAlign.Align(MsoAlignCmd.msoAlignBottoms, MsoTriState.msoTrue);
                         break;
                     }
@@ -282,7 +278,6 @@ namespace PowerPointLabs.PositionsLab
                 case PositionsLabSettings.AlignReferenceObject.SelectedShape:
                     if (toAlign.Count < 2)
                     {
-                        // Insert default align horizontal center behaviour here
                         toAlign.Align(MsoAlignCmd.msoAlignMiddles, MsoTriState.msoTrue);
                         break;
                     }
@@ -327,7 +322,6 @@ namespace PowerPointLabs.PositionsLab
                 case PositionsLabSettings.AlignReferenceObject.SelectedShape:
                     if (toAlign.Count < 2)
                     {
-                        // Insert default align vertical center behaviour here
                         toAlign.Align(MsoAlignCmd.msoAlignCenters, MsoTriState.msoTrue);
                         break;
                     }
@@ -373,12 +367,10 @@ namespace PowerPointLabs.PositionsLab
                 case PositionsLabSettings.AlignReferenceObject.SelectedShape:
                     if (toAlign.Count < 2)
                     {
-                        // Insert default align center behaviour here
                         toAlign.Align(MsoAlignCmd.msoAlignMiddles, MsoTriState.msoTrue);
                         toAlign.Align(MsoAlignCmd.msoAlignCenters, MsoTriState.msoTrue);
                         break;
                     }
-                    System.Diagnostics.Debug.WriteLine("Not suppose to see this string");
                     selectedShapes = ConvertShapeRangeToPPShapeList(toAlign);
                     var refShape = selectedShapes[0];
 

--- a/PowerPointLabs/PowerPointLabs/PositionsLab/PositionsLabMain.cs
+++ b/PowerPointLabs/PowerPointLabs/PositionsLab/PositionsLabMain.cs
@@ -188,7 +188,8 @@ namespace PowerPointLabs.PositionsLab
                 case PositionsLabSettings.AlignReferenceObject.SelectedShape:
                     if (toAlign.Count < 2)
                     {
-                        throw new Exception(PositionsLabText.ErrorFewerThanTwoSelection);
+                        // Insert default align top behaviour here
+                        toAlign.Align(MsoAlignCmd.msoAlignTops, MsoTriState.msoTrue);
                     }
 
                     selectedShapes = ConvertShapeRangeToPPShapeList(toAlign);

--- a/PowerPointLabs/PowerPointLabs/PositionsLab/PositionsLabMain.cs
+++ b/PowerPointLabs/PowerPointLabs/PositionsLab/PositionsLabMain.cs
@@ -96,7 +96,8 @@ namespace PowerPointLabs.PositionsLab
                 case PositionsLabSettings.AlignReferenceObject.SelectedShape:
                     if (toAlign.Count < 2)
                     {
-                        throw new Exception(PositionsLabText.ErrorFewerThanTwoSelection);
+                        // Insert default align left behaviour here
+                        toAlign.Align(MsoAlignCmd.msoAlignLefts, MsoTriState.msoTrue);
                     }
 
                     selectedShapes = ConvertShapeRangeToPPShapeList(toAlign);

--- a/PowerPointLabs/Test/UnitTest/PositionsLab/PositionsLabAlignTest.cs
+++ b/PowerPointLabs/Test/UnitTest/PositionsLab/PositionsLabAlignTest.cs
@@ -435,6 +435,117 @@ namespace Test.UnitTest.PositionsLab
 
         [TestMethod]
         [TestCategory("UT")]
+        public void TestAlignOneLeftSingleShape()
+        {
+            PositionsLabSettings.AlignReference = PositionsLabSettings.AlignReferenceObject.SelectedShape;
+            _shapeNames = new List<string> { RotatedRectangle };
+            var actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
+            PositionsLabMain.AlignLeft(actualShapes);
+
+            PpOperations.SelectSlide(AlignOneShapeLeftDefaultNo);
+            var expectedShapes = PpOperations.SelectShapes(_shapeNames);
+
+            CheckShapes(expectedShapes, actualShapes);
+        }
+
+        [TestMethod]
+        [TestCategory("UT")]
+        public void TestAlignOneRightSingleShape()
+        {
+            PositionsLabSettings.AlignReference = PositionsLabSettings.AlignReferenceObject.SelectedShape;
+            _shapeNames = new List<string> { RotatedRectangle };
+            var actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
+            var slideWidth = Pres.PageSetup.SlideWidth;
+            PositionsLabMain.AlignRight(actualShapes, slideWidth);
+
+            PpOperations.SelectSlide(AlignOneShapeRightDefaultNo);
+            var expectedShapes = PpOperations.SelectShapes(_shapeNames);
+
+            CheckShapes(expectedShapes, actualShapes);
+        }
+
+        [TestMethod]
+        [TestCategory("UT")]
+        public void TestAlignOneTopSingleShape()
+        {
+            PositionsLabSettings.AlignReference = PositionsLabSettings.AlignReferenceObject.SelectedShape;
+            _shapeNames = new List<string> { RotatedRectangle };
+            var actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
+            PositionsLabMain.AlignTop(actualShapes);
+
+            PpOperations.SelectSlide(AlignOneShapeTopDefaultNo);
+            var expectedShapes = PpOperations.SelectShapes(_shapeNames);
+
+            CheckShapes(expectedShapes, actualShapes);
+        }
+
+        [TestMethod]
+        [TestCategory("UT")]
+        public void TestAlignOneBottomSingleShape()
+        {
+            PositionsLabSettings.AlignReference = PositionsLabSettings.AlignReferenceObject.SelectedShape;
+            _shapeNames = new List<string> { RotatedRectangle };
+            var actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
+            var slideHeight = Pres.PageSetup.SlideHeight;
+            PositionsLabMain.AlignBottom(actualShapes, slideHeight);
+
+            PpOperations.SelectSlide(AlignOneShapeBottomDefaultNo);
+            var expectedShapes = PpOperations.SelectShapes(_shapeNames);
+
+            CheckShapes(expectedShapes, actualShapes);
+        }
+
+        [TestMethod]
+        [TestCategory("UT")]
+        public void TestAlignOneHorizontalSingleShape()
+        {
+            PositionsLabSettings.AlignReference = PositionsLabSettings.AlignReferenceObject.SelectedShape;
+            _shapeNames = new List<string> { RotatedRectangle };
+            var actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
+            var slideHeight = Pres.PageSetup.SlideHeight;
+            PositionsLabMain.AlignHorizontalCenter(actualShapes, slideHeight);
+
+            PpOperations.SelectSlide(AlignOneShapeHorizontalDefaultNo);
+            var expectedShapes = PpOperations.SelectShapes(_shapeNames);
+
+            CheckShapes(expectedShapes, actualShapes);
+        }
+
+        [TestMethod]
+        [TestCategory("UT")]
+        public void TestAlignOneVerticalSingleShape()
+        {
+            PositionsLabSettings.AlignReference = PositionsLabSettings.AlignReferenceObject.SelectedShape;
+            _shapeNames = new List<string> { RotatedRectangle };
+            var actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
+            var slideWidth = Pres.PageSetup.SlideWidth;
+            PositionsLabMain.AlignVerticalCenter(actualShapes, slideWidth);
+
+            PpOperations.SelectSlide(AlignOneShapeVerticalDefaultNo);
+            var expectedShapes = PpOperations.SelectShapes(_shapeNames);
+
+            CheckShapes(expectedShapes, actualShapes);
+        }
+
+        [TestMethod]
+        [TestCategory("UT")]
+        public void TestAlignOneCenterSingleShape()
+        {
+            PositionsLabSettings.AlignReference = PositionsLabSettings.AlignReferenceObject.SelectedShape;
+            _shapeNames = new List<string> { RotatedRectangle };
+            var actualShapes = GetShapes(OriginalShapesSlideNo, _shapeNames);
+            var slideHeight = Pres.PageSetup.SlideHeight;
+            var slideWidth = Pres.PageSetup.SlideWidth;
+            PositionsLabMain.AlignCenter(actualShapes, slideHeight, slideWidth);
+
+            PpOperations.SelectSlide(AlignOneShapeCenterDefaultNo);
+            var expectedShapes = PpOperations.SelectShapes(_shapeNames);
+
+            CheckShapes(expectedShapes, actualShapes);
+        }
+
+        [TestMethod]
+        [TestCategory("UT")]
         public void TestAlignLeftDefault()
         {
             PositionsLabSettings.AlignReference = PositionsLabSettings.AlignReferenceObject.PowerpointDefaults;


### PR DESCRIPTION
#1576 

I have included default align functionality for when one shape is selected for the following

1. Align-Left
2. Align-Right
3. Align-Top
4. Align-Bottom
5. Align-Center
6. Align-Center (Horizontal)
7. Align-Center (Vertical)

FTs and UTs returned no error
