### PR TITLE
#1585 Update Contributions.md to branch out from dev release instead of master for PRs

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -109,8 +109,8 @@ project:
 2. If you cloned a while ago, get the latest changes from upstream:
 
    ```bash
-   git checkout master
-   git pull upstream master
+   git checkout dev-release
+   git pull upstream dev-release
    ```
 
 3. Create a new topic branch (off the main project development branch) to
@@ -129,7 +129,7 @@ project:
 5. Locally merge (or rebase) the upstream development branch into your topic branch:
 
    ```bash
-   git pull [--rebase] upstream master
+   git pull [--rebase] upstream dev-release
    ```
 
 6. Push your topic branch up to your fork:


### PR DESCRIPTION
#1585 

As discussed with @initialshl, the instructions have been updated to set dev-release as the main project development branch to minimize merge conflicts in future PRs
