### PR TITLE
1595-SyncLab-The-Fill-Color-of-textboxes-are-inconsistent-when-using-SyncLab

### DIFF
--- a/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/FillFormat.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/FillFormat.cs
@@ -44,10 +44,14 @@ namespace PowerPointLabs.SyncLab.ObjectFormats
             try
             {
                 // force msoFillMixed to msoFillSolid
-                // freshly created textboxes have the msoFillMixed type for unknown reasons
+                // freshly created textboxes have the msoFillMixed type 
                 // otherwise, msoFillMixed only appears when multiple shapes are selected
                 // manual conversion is needed as msoFillMixed textboxes risk system forced conversions to msoFillSolid
                 // system forced conversions will set fill color to black
+                //
+                // lines also have the msoFillMixed type
+                // they have no fill, throwing an exception in the following if block
+                // this is desired behavior, disabling FillFormat for lines
                 if (formatShape.Fill.Type == Microsoft.Office.Core.MsoFillType.msoFillMixed)
                 {
                     int oldColor = formatShape.Fill.ForeColor.RGB;

--- a/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/FillFormat.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/FillFormat.cs
@@ -43,6 +43,20 @@ namespace PowerPointLabs.SyncLab.ObjectFormats
         {
             try
             {
+                // force msoFillMixed to msoFillSolid
+                // freshly created textboxes have the msoFillMixed type for unknown reasons
+                // otherwise, msoFillMixed only appears when multiple shapes are selected
+                // manual conversion is needed as msoFillMixed textboxes risk system forced conversions to msoFillSolid
+                // system forced conversions will set fill color to black
+                if (formatShape.Fill.Type == Microsoft.Office.Core.MsoFillType.msoFillMixed)
+                {
+                    int oldColor = formatShape.Fill.ForeColor.RGB;
+                    float oldTransparency = formatShape.Fill.Transparency;
+                    formatShape.Fill.Solid();
+                    formatShape.Fill.ForeColor.RGB = oldColor;
+                    formatShape.Fill.Transparency = oldTransparency;
+                }
+                
                 if (formatShape.Fill.Type == Microsoft.Office.Core.MsoFillType.msoFillPatterned)
                 {
                     newShape.Fill.Patterned(formatShape.Fill.Pattern);

--- a/PowerPointLabs/Test/FunctionalTest/SyncLabTest.cs
+++ b/PowerPointLabs/Test/FunctionalTest/SyncLabTest.cs
@@ -80,7 +80,7 @@ namespace Test.FunctionalTest
         private void TestSync(ISyncLabController syncLab)
         {
             Sync(syncLab, OriginalSyncGroupToShapeSlideNo, ExpectedSyncGroupToShapeSlideNo, CopyFromShape, RotatedArrow, 1, 0);
-            Sync(syncLab, OriginalSyncShapeToGroupSlideNo, ExpectedSyncShapeToGroupSlideNo, Line, Oval, 1, 4);
+            Sync(syncLab, OriginalSyncShapeToGroupSlideNo, ExpectedSyncShapeToGroupSlideNo, Line, Oval, 0, 4);
         }
 
         private void Sync(ISyncLabController syncLab, int originalSlide, int expectedSlide,


### PR DESCRIPTION
fixes #1595 
fixes #1375 

