### PR TITLE
#1596 Fix error for adding captions without notes in PPT 2010

### DIFF
--- a/PowerPointLabs/PowerPointLabs/CaptionsLab/NotesToCaptions.cs
+++ b/PowerPointLabs/PowerPointLabs/CaptionsLab/NotesToCaptions.cs
@@ -182,7 +182,10 @@ namespace PowerPointLabs.CaptionsLab
 
         private static void ShowNotesPane()
         {
-            Globals.ThisAddIn.Application.CommandBars.ExecuteMso("ShowNotes");
+            if (!Globals.ThisAddIn.IsApplicationVersion2010())
+            {
+                Globals.ThisAddIn.Application.CommandBars.ExecuteMso("ShowNotes");
+            }
         }
     }
 }

--- a/PowerPointLabs/PowerPointLabs/ShapesLab/CustomShapePane.cs
+++ b/PowerPointLabs/PowerPointLabs/ShapesLab/CustomShapePane.cs
@@ -115,7 +115,7 @@ namespace PowerPointLabs.ShapesLab
 
                 // do this optimization only for office 2010 since painting speed on 2013 is
                 // really slow
-                if (Globals.ThisAddIn.Application.Version == Globals.ThisAddIn.OfficeVersion2010)
+                if (Globals.ThisAddIn.IsApplicationVersion2010())
                 {
                     createParams.ExStyle |= (int)Native.Message.WS_EX_COMPOSITED;  // Turn on WS_EX_COMPOSITED
                 }
@@ -279,7 +279,7 @@ namespace PowerPointLabs.ShapesLab
             }
 
             // double buffer starts
-            if (Globals.ThisAddIn.Application.Version == Globals.ThisAddIn.OfficeVersion2013)
+            if (Globals.ThisAddIn.IsApplicationVersion2013())
             {
                 GraphicsUtil.SuspendDrawing(myShapeFlowLayout);
             }
@@ -294,7 +294,7 @@ namespace PowerPointLabs.ShapesLab
             myShapeFlowLayout.Focus();
 
             // double buffer ends
-            if (Globals.ThisAddIn.Application.Version == Globals.ThisAddIn.OfficeVersion2013)
+            if (Globals.ThisAddIn.IsApplicationVersion2013())
             {
                 GraphicsUtil.ResumeDrawing(myShapeFlowLayout);
             }

--- a/PowerPointLabs/PowerPointLabs/ThisAddIn.cs
+++ b/PowerPointLabs/PowerPointLabs/ThisAddIn.cs
@@ -77,6 +77,16 @@ namespace PowerPointLabs
 
         #region API
 
+        public bool IsApplicationVersion2010() 
+        {
+            return Application.Version == OfficeVersion2010;
+        }
+
+        public bool IsApplicationVersion2013()
+        {
+            return Application.Version == OfficeVersion2013;
+        }
+
         public Control GetActiveControl(Type type)
         {
             CustomTaskPane taskPane = GetActivePane(type);
@@ -998,7 +1008,7 @@ namespace PowerPointLabs
         {
             Trace.TraceInformation("Closing " + pres.Name);
 
-            if (Application.Version == OfficeVersion2010 &&
+            if (IsApplicationVersion2010() &&
                 _deactivatedPresFullName == pres.FullName &&
                 Application.Presentations.Count == 2 &&
                 ShapePresentation != null &&
@@ -1407,7 +1417,7 @@ namespace PowerPointLabs
 
                 if (selection.Type == PowerPoint.PpSelectionType.ppSelectionShapes)
                 {
-                    if (Application.Version == OfficeVersion2010)
+                    if (IsApplicationVersion2010())
                     {
                         OpenPropertyWindowForOffice10();
                     }


### PR DESCRIPTION
Fixes #1596 
ExecuteMso("Show Notes") should only be done in versions not 2010.

Also refactored other similar version checks to an API function in ThisAddIn.