### PR TITLE
#1544-Copy-Operation-Made-The-Text-Disappear

### DIFF
--- a/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/FontColorFormat.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/FontColorFormat.cs
@@ -1,9 +1,10 @@
 ﻿using System;
 using System.Drawing;
-
-using Microsoft.Office.Interop.PowerPoint;
+using Microsoft.Office.Core;
 using PowerPointLabs.ActionFramework.Common.Log;
 using PowerPointLabs.Utils;
+using Shape = Microsoft.Office.Interop.PowerPoint.Shape;
+using Shapes = Microsoft.Office.Interop.PowerPoint.Shapes;
 
 namespace PowerPointLabs.SyncLab.ObjectFormats
 {
@@ -11,7 +12,7 @@ namespace PowerPointLabs.SyncLab.ObjectFormats
     {
         public static bool CanCopy(Shape formatShape)
         {
-            return Sync(formatShape, formatShape);
+            return formatShape.HasTextFrame == MsoTriState.msoTrue;
         }
 
         public static void SyncFormat(Shape formatShape, Shape newShape)
@@ -30,8 +31,10 @@ namespace PowerPointLabs.SyncLab.ObjectFormats
                     SyncFormatConstants.DisplayImageSize.Width,
                     SyncFormatConstants.DisplayImageSize.Height);
             shape.Line.Visible = Microsoft.Office.Core.MsoTriState.msoFalse;
-            shape.Fill.ForeColor.RGB = formatShape.TextFrame.TextRange.Font.Color.RGB;
-            shape.Fill.BackColor.RGB = formatShape.TextFrame.TextRange.Font.Color.RGB;
+            
+            int guessedColor = ShapeUtil.GuessTextColor(formatShape);
+            shape.Fill.ForeColor.RGB = guessedColor;
+            shape.Fill.BackColor.RGB = guessedColor;
             shape.Fill.Solid();
             Bitmap image = GraphicsUtil.ShapeToBitmap(shape);
             shape.Delete();
@@ -42,7 +45,8 @@ namespace PowerPointLabs.SyncLab.ObjectFormats
         {
             try
             {
-                newShape.TextFrame.TextRange.Font.Color.RGB = formatShape.TextFrame.TextRange.Font.Color.RGB;
+                int guessedColor = ShapeUtil.GuessTextColor(formatShape);
+                newShape.TextFrame.TextRange.Font.Color.RGB = guessedColor;
             }
             catch (Exception)
             {

--- a/PowerPointLabs/PowerPointLabs/Utils/ShapeUtil.cs
+++ b/PowerPointLabs/PowerPointLabs/Utils/ShapeUtil.cs
@@ -988,18 +988,18 @@ namespace PowerPointLabs.Utils
         /// Useful when shape has text with more than one color
         /// Getting color in that case without a workabout will return black
         /// Assumes that shape has a TextRange
-        /// 
-        /// Unsuccessful workabouts:
-        /// Taking a sub TextRange of the shape
-        /// Trimming text to the first character
         /// </summary>
         /// <param name="shape">RGB color, seems to be the color of the last character</param>
         /// <returns></returns>
         public static int GuessTextColor(Shape shape)
         {
-            Shape duplicate = shape.Duplicate()[1];
             // clear the text, to clear presence of more than 1 color
             // TextRange.Font.Color.RGB then returns the same color of as new text that is added to the shape
+            // 
+            // Unsuccessful workabouts:
+            // Taking a sub TextRange of the shape
+            // Trimming text to the first character
+            Shape duplicate = shape.Duplicate()[1];
             duplicate.TextFrame.TextRange.Text = "";
             int color = duplicate.TextFrame.TextRange.Font.Color.RGB;
             duplicate.Delete();

--- a/PowerPointLabs/PowerPointLabs/Utils/ShapeUtil.cs
+++ b/PowerPointLabs/PowerPointLabs/Utils/ShapeUtil.cs
@@ -993,7 +993,7 @@ namespace PowerPointLabs.Utils
         /// Taking a sub TextRange of the shape
         /// Trimming text to the first character
         /// </summary>
-        /// <param name="shape">RGB color</param>
+        /// <param name="shape">RGB color, seems to be the color of the last character</param>
         /// <returns></returns>
         public static int GuessTextColor(Shape shape)
         {

--- a/PowerPointLabs/PowerPointLabs/Utils/ShapeUtil.cs
+++ b/PowerPointLabs/PowerPointLabs/Utils/ShapeUtil.cs
@@ -984,6 +984,28 @@ namespace PowerPointLabs.Utils
             return shape == null ? null : shape.TextFrame.TextRange;
         }
 
+        /// <summary>
+        /// Useful when shape has text with more than one color
+        /// Getting color in that case without a workabout will return black
+        /// Assumes that shape has a TextRange
+        /// 
+        /// Unsuccessful workabouts:
+        /// Taking a sub TextRange of the shape
+        /// Trimming text to the first character
+        /// </summary>
+        /// <param name="shape">RGB color</param>
+        /// <returns></returns>
+        public static int GuessTextColor(Shape shape)
+        {
+            Shape duplicate = shape.Duplicate()[1];
+            // clear the text, to clear presence of more than 1 color
+            // TextRange.Font.Color.RGB then returns the same color of as new text that is added to the shape
+            duplicate.TextFrame.TextRange.Text = "";
+            int color = duplicate.TextFrame.TextRange.Font.Color.RGB;
+            duplicate.Delete();
+            return color;
+        }
+
         #endregion
         
         /// <summary>


### PR DESCRIPTION
fixes #1544 

Summary of issue: 
MS returns black when shape's text has more than one color.
This turns text black when we try to sync.

There was also an error in the code. 
We try to check if syncing of text color is possible, by syncing the shape text's color with itself. This sets the color to black.

Changes in code: 
- Use a more sensible sync check.
- Guess the color by clear the texting so only one color remains & checking the color afterwards.