### PR TITLE
#1622: Correctly-Log-Failure-To-Sync-Font-Format

### DIFF
--- a/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/FontFormat.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/FontFormat.cs
@@ -15,7 +15,7 @@ namespace PowerPointLabs.SyncLab.ObjectFormats
 
         public static void SyncFormat(Shape formatShape, Shape newShape)
         {
-            if (Sync(formatShape, newShape))
+            if (!Sync(formatShape, newShape))
             {
                 Logger.Log(newShape.Type + " unable to sync Font Format");
             }


### PR DESCRIPTION
fixes #1622 
Just a quick fix for an erroneous boolean value to properly log syncing of font format.