### PR TITLE
#1439 Shape Lab will not affect clipboard

### DIFF
--- a/PowerPointLabs/PowerPointLabs/Models/PowerPointShapeGalleryPresentation.cs
+++ b/PowerPointLabs/PowerPointLabs/Models/PowerPointShapeGalleryPresentation.cs
@@ -36,7 +36,7 @@ namespace PowerPointLabs.Models
         private const string UntitledCategoryNameFormat = "Untitled Category {0}";
 
         private const int MaxUndoAmount = 20;
-
+        
         private PowerPointSlide _defaultCategory;
         private readonly List<Shape> _categoryNameBoxCollection = new List<Shape>();
 
@@ -66,18 +66,18 @@ namespace PowerPointLabs.Models
         # endregion
 
         # region Constructor
-        public PowerPointShapeGalleryPresentation(string path, string name) : base(path, name) 
+        public PowerPointShapeGalleryPresentation(string path, string name) : base(path, name)
         {
             Categories = new List<string>();
         }
-        public PowerPointShapeGalleryPresentation(Presentation presentation) : base(presentation) 
+        public PowerPointShapeGalleryPresentation(Presentation presentation) : base(presentation)
         {
             Categories = new List<string>();
         }
         # endregion
 
         # region API
-        public void AddCategory(string name, bool setAsDefault = true, bool fromClipBoard = false) 
+        public void AddCategory(string name, bool setAsDefault = true, bool fromClipBoard = false)
         {
             int index = FindCategoryIndex(name, setAsDefault);
 


### PR DESCRIPTION
Resolves #1439. Solves parent issue #1597.
Shape lab will not affect clipboard when:

1. A shape is added on the context menu
2. A shape is added on the side pane using the Add button
3. Shape gallery is imported to shape lab presentation in the background
4. A shape in shape lab gallery is double clicked and is added to the current slide
