### PR TITLE
#1623 replace with clipboard: preserve shape settings (existing sync formats only)

### DIFF
--- a/PowerPointLabs/PowerPointLabs/PasteLab/ReplaceWithClipboard.cs
+++ b/PowerPointLabs/PowerPointLabs/PasteLab/ReplaceWithClipboard.cs
@@ -29,6 +29,7 @@ namespace PowerPointLabs.PasteLab
 
                 slide.DeleteShapeAnimations(pastingShape);
                 slide.TransferAnimation(selectedShape, pastingShape);
+                ShapeUtil.ApplyAllPossibleFormats(selectedShape, pastingShape);
                 selectedShape.Delete();
 
                 return slide.ToShapeRange(pastingShape);
@@ -63,6 +64,7 @@ namespace PowerPointLabs.PasteLab
                         shapeAbove = shape;
                     }
                 }
+                ShapeUtil.ApplyAllPossibleFormats(selectedChildShape, shapeAbove);
 
                 // Remove selected child since it is being replaced
                 ShapeRange shapesToGroup = slide.ToShapeRange(selectedGroupShapeList);

--- a/PowerPointLabs/PowerPointLabs/PasteLab/ReplaceWithClipboard.cs
+++ b/PowerPointLabs/PowerPointLabs/PasteLab/ReplaceWithClipboard.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Microsoft.Office.Interop.PowerPoint;
 
 using PowerPointLabs.Models;
+using PowerPointLabs.SyncLab.ObjectFormats;
 using PowerPointLabs.Utils;
 
 namespace PowerPointLabs.PasteLab
@@ -29,7 +30,7 @@ namespace PowerPointLabs.PasteLab
 
                 slide.DeleteShapeAnimations(pastingShape);
                 slide.TransferAnimation(selectedShape, pastingShape);
-                ShapeUtil.ApplyAllPossibleFormats(selectedShape, pastingShape);
+                ShapeUtil.ApplyAllPossibleFormats(selectedShape, pastingShape, new List<Format>());
                 selectedShape.Delete();
 
                 return slide.ToShapeRange(pastingShape);
@@ -64,7 +65,15 @@ namespace PowerPointLabs.PasteLab
                         shapeAbove = shape;
                     }
                 }
-                ShapeUtil.ApplyAllPossibleFormats(selectedChildShape, shapeAbove);
+
+                // apply all styles from shapes to be pasted, but ignore x,y positions
+                // x,y must be applied individually each shape in PasteIntoGroup.Execute(...),
+                // each item replaced has a different position
+                List<Format> positionFormats = new List<Format> {new PositionXFormat(), new PositionYFormat()};
+                for (int i = 1; i <= pastingShapes.Count; i++)
+                {
+                    ShapeUtil.ApplyAllPossibleFormats(selectedChildShape, pastingShapes[i], positionFormats);
+                }
 
                 // Remove selected child since it is being replaced
                 ShapeRange shapesToGroup = slide.ToShapeRange(selectedGroupShapeList);

--- a/PowerPointLabs/PowerPointLabs/PasteLab/ReplaceWithClipboard.cs
+++ b/PowerPointLabs/PowerPointLabs/PasteLab/ReplaceWithClipboard.cs
@@ -14,6 +14,9 @@ namespace PowerPointLabs.PasteLab
         public static ShapeRange Execute(PowerPointPresentation presentation, PowerPointSlide slide, 
                                         ShapeRange selectedShapes, ShapeRange selectedChildShapes, ShapeRange pastingShapes)
         {
+            // ignore height & width, it doesn't always make sense to sync the height & width especially for circles, squares
+            List<Format> formatsToIgnore = new List<Format> {new PositionHeightFormat(), new PositionWidthFormat()};
+            
             // Replacing individual shape
             if (selectedChildShapes.Count == 0)
             {
@@ -30,7 +33,7 @@ namespace PowerPointLabs.PasteLab
 
                 slide.DeleteShapeAnimations(pastingShape);
                 slide.TransferAnimation(selectedShape, pastingShape);
-                ShapeUtil.ApplyAllPossibleFormats(selectedShape, pastingShape, new List<Format>());
+                ShapeUtil.ApplyAllPossibleFormats(selectedShape, pastingShape, formatsToIgnore);
                 selectedShape.Delete();
 
                 return slide.ToShapeRange(pastingShape);
@@ -67,12 +70,15 @@ namespace PowerPointLabs.PasteLab
                 }
 
                 // apply all styles from shapes to be pasted, but ignore x,y positions
-                // x,y must be applied individually each shape in PasteIntoGroup.Execute(...),
-                // each item replaced has a different position
+                // x,y must be applied individually
+                // each item replaced has a different positioneach shape in PasteIntoGroup.Execute(...),
+
                 List<Format> positionFormats = new List<Format> {new PositionXFormat(), new PositionYFormat()};
+                formatsToIgnore.AddRange(positionFormats);
+                
                 for (int i = 1; i <= pastingShapes.Count; i++)
                 {
-                    ShapeUtil.ApplyAllPossibleFormats(selectedChildShape, pastingShapes[i], positionFormats);
+                    ShapeUtil.ApplyAllPossibleFormats(selectedChildShape, pastingShapes[i], formatsToIgnore);
                 }
 
                 // Remove selected child since it is being replaced

--- a/PowerPointLabs/PowerPointLabs/Utils/ShapeUtil.cs
+++ b/PowerPointLabs/PowerPointLabs/Utils/ShapeUtil.cs
@@ -1069,6 +1069,24 @@ namespace PowerPointLabs.Utils
             }
         }
         
+        public static Format[] GetCopyableFormats(Shape shape)
+        {
+            return (from format in SyncFormatConstants.Formats where format.CanCopy(shape) select format)
+                .ToArray();
+        }
+        
+        /// <summary>
+        /// Applies all applyable formats from one shape to another
+        /// </summary>
+        /// <param name="formatShape">source shape</param>
+        /// <param name="newShape">destination shape</param>
+        public static void ApplyAllPossibleFormats(Shape formatShape, Shape newShape)
+        {
+            // gather all formats
+            Format[] copyableFormats = GetCopyableFormats(formatShape);
+            ApplyFormats(copyableFormats, formatShape, newShape);
+        }
+        
         #region PlaceHolder utils
 
         public static bool CanCopyMsoPlaceHolder(Shape placeholder, Shapes shapesSource)

--- a/PowerPointLabs/PowerPointLabs/Utils/ShapeUtil.cs
+++ b/PowerPointLabs/PowerPointLabs/Utils/ShapeUtil.cs
@@ -1080,11 +1080,13 @@ namespace PowerPointLabs.Utils
         /// </summary>
         /// <param name="formatShape">source shape</param>
         /// <param name="newShape">destination shape</param>
-        public static void ApplyAllPossibleFormats(Shape formatShape, Shape newShape)
+        /// <param name="ignoredFormats">formats to ignore</param>
+        public static void ApplyAllPossibleFormats(Shape formatShape, Shape newShape, List<Format> ignoredFormats)
         {
             // gather all formats
-            Format[] copyableFormats = GetCopyableFormats(formatShape);
-            ApplyFormats(copyableFormats, formatShape, newShape);
+            List<Format> copyableFormats = GetCopyableFormats(formatShape).ToList();
+            Format[] withoutIgnored = copyableFormats.Except(ignoredFormats).ToArray();
+            ApplyFormats(withoutIgnored, formatShape, newShape);
         }
         
         #region PlaceHolder utils

--- a/PowerPointLabs/Test/UnitTest/PlaceHolderCopyTest.cs
+++ b/PowerPointLabs/Test/UnitTest/PlaceHolderCopyTest.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Office.Interop.PowerPoint;
@@ -118,20 +119,14 @@ namespace Test.UnitTest
         private void EnsureFormatsAreRetainedAfterCopy(Shape placeHolder)
         {
             // ensure that each placeholder's copy supports the same or more formats
-            Format[] formatsFromOriginal = GetCopyableFormats(placeHolder);
+            Format[] formatsFromOriginal = ShapeUtil.GetCopyableFormats(placeHolder);
             
             Shape copy = ShapeUtil.CopyMsoPlaceHolder(formatsFromOriginal, placeHolder, _templateShapes);
-            Format[] formatsFromCopy = GetCopyableFormats(copy);
+            Format[] formatsFromCopy = ShapeUtil.GetCopyableFormats(copy);
 
             IEnumerable<Format> formatsInBoth = formatsFromCopy.Intersect(formatsFromOriginal);
             Assert.AreEqual(formatsInBoth.Count(), formatsFromOriginal.Count());
         }
 
-        private Format[] GetCopyableFormats(Shape shape)
-        {
-            return (from format in SyncFormatConstants.Formats 
-                    where format.CanCopy(shape) select format)
-                .ToArray();
-        }
     }
 }


### PR DESCRIPTION
resolves #1623

- [x] preserve settings for shapes (fill, color, text, whatever synclab already has, excluding size), single shape
- [x] as above, for grouped shape
- [x] <s>remove redundant existing code in Replace With Clipboard, if any</s> (no redundant code found, the position code present is required to correctly shift the new image)

We currently lack code for shadows, bezels etc. See #1213 

Test Cases:
1) ensure that replacing a shape preserves all settings other than size (test replacing with both a single shape & > 1 shape in clipboard)
2) ensure that replacing a shape inside a group preserves all settings other than size (test replacing with both a single shape & > 1 shape in clipboard)