### PR TITLE
#1606 Fix pasting of web pictures

### DIFF
--- a/PowerPointLabs/PowerPointLabs/ActionFramework/PasteLab/PasteAtCursorPosition/PasteAtCursorPositionActionHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/PasteLab/PasteAtCursorPosition/PasteAtCursorPositionActionHandler.cs
@@ -1,7 +1,9 @@
-﻿using Microsoft.Office.Interop.PowerPoint;
+﻿using System.Windows;
+using Microsoft.Office.Interop.PowerPoint;
 
 using PowerPointLabs.ActionFramework.Common.Attribute;
 using PowerPointLabs.ActionFramework.Common.Extension;
+using PowerPointLabs.ActionFramework.Common.Log;
 using PowerPointLabs.Models;
 using PowerPointLabs.PasteLab;
 using PowerPointLabs.TextCollection;
@@ -34,6 +36,8 @@ namespace PowerPointLabs.ActionFramework.PasteLab
             ShapeRange pastingShapes = ClipboardUtil.PasteShapesFromClipboard(presentation, slide);
             if (pastingShapes == null)
             {
+                Logger.Log("PasteLab: Could not paste clipboard contents.");
+                MessageBox.Show(PasteLabText.ErrorPaste, PasteLabText.ErrorDialogTitle);
                 return null;
             }
 

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/PasteLab/PasteAtCursorPosition/PasteAtCursorPositionActionHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/PasteLab/PasteAtCursorPosition/PasteAtCursorPositionActionHandler.cs
@@ -31,7 +31,7 @@ namespace PowerPointLabs.ActionFramework.PasteLab
                 positionY = ((coordinates.Y - activeWindow.PointsToScreenPixelsY(0)) / yref) * 100;
             }
 
-            ShapeRange pastingShapes = ClipboardUtil.PasteShapesFromClipboard(slide);
+            ShapeRange pastingShapes = ClipboardUtil.PasteShapesFromClipboard(presentation, slide);
             if (pastingShapes == null)
             {
                 return null;

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/PasteLab/PasteAtOriginalPosition/PasteAtOriginalPositionActionHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/PasteLab/PasteAtOriginalPosition/PasteAtOriginalPositionActionHandler.cs
@@ -1,6 +1,8 @@
-﻿using Microsoft.Office.Interop.PowerPoint;
+﻿using System.Windows;
+using Microsoft.Office.Interop.PowerPoint;
 
 using PowerPointLabs.ActionFramework.Common.Attribute;
+using PowerPointLabs.ActionFramework.Common.Log;
 using PowerPointLabs.Models;
 using PowerPointLabs.TextCollection;
 using PowerPointLabs.Utils;
@@ -18,7 +20,13 @@ namespace PowerPointLabs.ActionFramework.PasteLab
             if (tempPastingShapes == null)
             {
                 tempSlide.Delete();
-                return ClipboardUtil.PasteShapesFromClipboard(presentation, slide);
+                ShapeRange shapes = ClipboardUtil.PasteShapesFromClipboard(presentation, slide);
+                if (shapes == null) 
+                {
+                    Logger.Log("PasteLab: Could not paste clipboard contents.");
+                    MessageBox.Show(PasteLabText.ErrorPaste, PasteLabText.ErrorDialogTitle);
+                }
+                return shapes;
             }
 
             ShapeRange pastingShapes = slide.CopyShapesToSlide(tempPastingShapes);

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/PasteLab/PasteAtOriginalPosition/PasteAtOriginalPositionActionHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/PasteLab/PasteAtOriginalPosition/PasteAtOriginalPositionActionHandler.cs
@@ -14,11 +14,11 @@ namespace PowerPointLabs.ActionFramework.PasteLab
                                                         ShapeRange selectedShapes, ShapeRange selectedChildShapes)
         {
             PowerPointSlide tempSlide = presentation.AddSlide(index: slide.Index);
-            ShapeRange tempPastingShapes = ClipboardUtil.PasteShapesFromClipboard(tempSlide);
+            ShapeRange tempPastingShapes = ClipboardUtil.PasteShapesFromClipboard(presentation, tempSlide);
             if (tempPastingShapes == null)
             {
                 tempSlide.Delete();
-                return ClipboardUtil.PasteShapesFromClipboard(slide);
+                return ClipboardUtil.PasteShapesFromClipboard(presentation, slide);
             }
 
             ShapeRange pastingShapes = slide.CopyShapesToSlide(tempPastingShapes);

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/PasteLab/PasteIntoGroup/PasteIntoGroupActionHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/PasteLab/PasteIntoGroup/PasteIntoGroupActionHandler.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Office.Interop.PowerPoint;
+﻿using System.Windows;
+using Microsoft.Office.Interop.PowerPoint;
 
 using PowerPointLabs.ActionFramework.Common.Attribute;
 using PowerPointLabs.ActionFramework.Common.Log;
@@ -30,6 +31,8 @@ namespace PowerPointLabs.ActionFramework.PasteLab
             ShapeRange pastingShapes = ClipboardUtil.PasteShapesFromClipboard(presentation, slide);
             if (pastingShapes == null)
             {
+                Logger.Log("PasteLab: Could not paste clipboard contents.");
+                MessageBox.Show(PasteLabText.ErrorPaste, PasteLabText.ErrorDialogTitle);
                 return null;
             }
 

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/PasteLab/PasteIntoGroup/PasteIntoGroupActionHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/PasteLab/PasteIntoGroup/PasteIntoGroupActionHandler.cs
@@ -27,7 +27,7 @@ namespace PowerPointLabs.ActionFramework.PasteLab
                 return null;
             }
 
-            ShapeRange pastingShapes = ClipboardUtil.PasteShapesFromClipboard(slide);
+            ShapeRange pastingShapes = ClipboardUtil.PasteShapesFromClipboard(presentation, slide);
             if (pastingShapes == null)
             {
                 return null;

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/PasteLab/PasteLabActionHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/PasteLab/PasteLabActionHandler.cs
@@ -1,11 +1,12 @@
 ﻿using System.Collections.Generic;
-
+using System.Windows;
 using Microsoft.Office.Interop.PowerPoint;
 
 using PowerPointLabs.ActionFramework.Common.Extension;
 using PowerPointLabs.ActionFramework.Common.Interface;
 using PowerPointLabs.ActionFramework.Common.Log;
 using PowerPointLabs.Models;
+using PowerPointLabs.TextCollection;
 using PowerPointLabs.Utils;
 
 namespace PowerPointLabs.ActionFramework.PasteLab
@@ -27,6 +28,7 @@ namespace PowerPointLabs.ActionFramework.PasteLab
             if (ClipboardUtil.IsClipboardEmpty())
             {
                 Logger.Log(ribbonId + " failed. Clipboard is empty.");
+                MessageBox.Show(PasteLabText.ErrorEmptyClipboard, PasteLabText.ErrorDialogTitle);
                 return;
             }
 

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/PasteLab/PasteToFillSlide/PasteToFillSlideActionHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/PasteLab/PasteToFillSlide/PasteToFillSlideActionHandler.cs
@@ -1,6 +1,8 @@
-﻿using Microsoft.Office.Interop.PowerPoint;
+﻿using System.Windows;
+using Microsoft.Office.Interop.PowerPoint;
 
 using PowerPointLabs.ActionFramework.Common.Attribute;
+using PowerPointLabs.ActionFramework.Common.Log;
 using PowerPointLabs.Models;
 using PowerPointLabs.PasteLab;
 using PowerPointLabs.TextCollection;
@@ -17,6 +19,8 @@ namespace PowerPointLabs.ActionFramework.PasteLab
             ShapeRange pastingShapes = ClipboardUtil.PasteShapesFromClipboard(presentation, slide);
             if (pastingShapes == null)
             {
+                Logger.Log("PasteLab: Could not paste clipboard contents.");
+                MessageBox.Show(PasteLabText.ErrorPaste, PasteLabText.ErrorDialogTitle);
                 return null;
             }
 

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/PasteLab/PasteToFillSlide/PasteToFillSlideActionHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/PasteLab/PasteToFillSlide/PasteToFillSlideActionHandler.cs
@@ -14,7 +14,7 @@ namespace PowerPointLabs.ActionFramework.PasteLab
         protected override ShapeRange ExecutePasteAction(string ribbonId, PowerPointPresentation presentation, PowerPointSlide slide,
                                                         ShapeRange selectedShapes, ShapeRange selectedChildShapes)
         {
-            ShapeRange pastingShapes = ClipboardUtil.PasteShapesFromClipboard(slide);
+            ShapeRange pastingShapes = ClipboardUtil.PasteShapesFromClipboard(presentation, slide);
             if (pastingShapes == null)
             {
                 return null;

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/PasteLab/PasteToFitSlide/PasteToFitSlideActionHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/PasteLab/PasteToFitSlide/PasteToFitSlideActionHandler.cs
@@ -14,7 +14,7 @@ namespace PowerPointLabs.ActionFramework.PasteLab
         protected override ShapeRange ExecutePasteAction(string ribbonId, PowerPointPresentation presentation, PowerPointSlide slide,
                                                         ShapeRange selectedShapes, ShapeRange selectedChildShapes)
         {
-            ShapeRange pastingShapes = ClipboardUtil.PasteShapesFromClipboard(slide);
+            ShapeRange pastingShapes = ClipboardUtil.PasteShapesFromClipboard(presentation, slide);
             if (pastingShapes == null)
             {
                 return pastingShapes;

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/PasteLab/PasteToFitSlide/PasteToFitSlideActionHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/PasteLab/PasteToFitSlide/PasteToFitSlideActionHandler.cs
@@ -1,6 +1,8 @@
-﻿using Microsoft.Office.Interop.PowerPoint;
+﻿using System.Windows;
+using Microsoft.Office.Interop.PowerPoint;
 
 using PowerPointLabs.ActionFramework.Common.Attribute;
+using PowerPointLabs.ActionFramework.Common.Log;
 using PowerPointLabs.Models;
 using PowerPointLabs.PasteLab;
 using PowerPointLabs.TextCollection;
@@ -17,6 +19,8 @@ namespace PowerPointLabs.ActionFramework.PasteLab
             ShapeRange pastingShapes = ClipboardUtil.PasteShapesFromClipboard(presentation, slide);
             if (pastingShapes == null)
             {
+                Logger.Log("PasteLab: Could not paste clipboard contents.");
+                MessageBox.Show(PasteLabText.ErrorPaste, PasteLabText.ErrorDialogTitle);
                 return pastingShapes;
             }
 

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/PasteLab/ReplaceWithClipboard/ReplaceWithClipboardActionHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/PasteLab/ReplaceWithClipboard/ReplaceWithClipboardActionHandler.cs
@@ -22,7 +22,7 @@ namespace PowerPointLabs.ActionFramework.PasteLab
                 return null;
             }
 
-            ShapeRange pastingShapes = ClipboardUtil.PasteShapesFromClipboard(slide);
+            ShapeRange pastingShapes = ClipboardUtil.PasteShapesFromClipboard(presentation, slide);
             if (pastingShapes == null)
             {
                 return null;

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/PasteLab/ReplaceWithClipboard/ReplaceWithClipboardActionHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/PasteLab/ReplaceWithClipboard/ReplaceWithClipboardActionHandler.cs
@@ -3,6 +3,7 @@
 using Microsoft.Office.Interop.PowerPoint;
 
 using PowerPointLabs.ActionFramework.Common.Attribute;
+using PowerPointLabs.ActionFramework.Common.Log;
 using PowerPointLabs.Models;
 using PowerPointLabs.PasteLab;
 using PowerPointLabs.TextCollection;
@@ -25,6 +26,8 @@ namespace PowerPointLabs.ActionFramework.PasteLab
             ShapeRange pastingShapes = ClipboardUtil.PasteShapesFromClipboard(presentation, slide);
             if (pastingShapes == null)
             {
+                Logger.Log("PasteLab: Could not paste clipboard contents.");
+                MessageBox.Show(PasteLabText.ErrorPaste, PasteLabText.ErrorDialogTitle);
                 return null;
             }
 

--- a/PowerPointLabs/PowerPointLabs/TextCollection/PasteLabText.cs
+++ b/PowerPointLabs/PowerPointLabs/TextCollection/PasteLabText.cs
@@ -41,5 +41,9 @@
         #endregion
 
         public const string ReplaceWithClipboardActionHandlerReminderText = "Please select at least one shape.";
+        
+        public const string ErrorDialogTitle = "Unable to execute action";
+        public const string ErrorEmptyClipboard = "Error: Clipboard is empty.";
+        public const string ErrorPaste = "Error: Unable to paste content in clipboard. Try pasting it normally in PowerPoint and then copying the item again.";
     }
 }

--- a/PowerPointLabs/PowerPointLabs/Utils/ClipboardUtil.cs
+++ b/PowerPointLabs/PowerPointLabs/Utils/ClipboardUtil.cs
@@ -241,22 +241,6 @@ namespace PowerPointLabs.Utils
                 return null;
             }
         }
-
-        private static ShapeRange TryPastingAsBitmap(PowerPointSlide slide)
-        {
-            try
-            {
-                // try pasting as general bitmap picture
-                return PasteWithCorrectSlideCheck(slide, true, PpPasteDataType.ppPasteBitmap);
-            }
-            catch (COMException e)
-            {
-                // May be thrown if clipboard is not a picture
-                Logger.LogException(e, "TryPastingAsBitmap");
-                return null;
-            }
-        }
-
         /// <summary>
         /// Pastes clipboard content into new temp slide using the DocumentWindow's View.Paste()
         /// Though this paste will work for most clipboard objects (even web pictures), it could possibly change the undo history.

--- a/PowerPointLabs/PowerPointLabs/Utils/ClipboardUtil.cs
+++ b/PowerPointLabs/PowerPointLabs/Utils/ClipboardUtil.cs
@@ -45,6 +45,10 @@ namespace PowerPointLabs.Utils
                     {
                         picture = TryPastingAsBitmap(slide);
                     }
+                    if (picture == null)
+                    {
+                        picture = TryPastingOntoView(pres, slide);
+                    }
                     return picture;
                 }
             }
@@ -68,7 +72,6 @@ namespace PowerPointLabs.Utils
                 PowerPointSlide tempClipboardSlide = null;
                 ShapeRange tempClipboardShapes = null;
                 SlideRange tempPastedSlide = null;
-                Shape tempClipboardShape = null;
 
                 Logger.Log("RestoreClipboardAfterAction: Trying to paste as slide.", ActionFramework.Common.Logger.LogType.Info);
                 tempPastedSlide = TryPastingAsSlide(pres, origSlide);
@@ -101,12 +104,12 @@ namespace PowerPointLabs.Utils
                 if (CheckIfPastingFailed(tempPastedSlide, tempClipboardShapes))
                 {
                     Logger.Log("RestoreClipboardAfterAction: Trying to paste onto view", ActionFramework.Common.Logger.LogType.Info);
-                    tempClipboardShape = TryPastingOntoView(pres, tempClipboardSlide, origSlide);
+                    tempClipboardShapes = TryPastingOntoView(pres, tempClipboardSlide, origSlide);
                 }
 
                 result = action();
 
-                RestoreClipboard(tempClipboardShape, tempClipboardShapes, tempPastedSlide);
+                RestoreClipboard(tempClipboardShapes, tempPastedSlide);
                 if (tempClipboardSlide != null)
                 {
                     tempClipboardSlide.Delete();
@@ -132,7 +135,7 @@ namespace PowerPointLabs.Utils
         /// Note that clipboard cannot be restored if last copied item was a placeholder (for now)
         /// </summary>
         /// <returns>True if successfully restored</returns>
-        private static void RestoreClipboard(Shape shape = null, ShapeRange shapes = null, SlideRange slides = null) 
+        private static void RestoreClipboard(ShapeRange shapes = null, SlideRange slides = null) 
         {
             try
             {
@@ -145,11 +148,6 @@ namespace PowerPointLabs.Utils
                 {
                     shapes.Copy();
                     shapes.Delete();
-                }
-                else if (shape != null)
-                {
-                    shape.Copy();
-                    shape.Delete();
                 }
             }
             catch (COMException e) 
@@ -273,7 +271,7 @@ namespace PowerPointLabs.Utils
         /// Pastes clipboard content into new temp slide using the DocumentWindow's View.Paste()
         /// Though this paste will work for most clipboard objects (even web pictures), it could possibly change the undo history.
         /// </summary>
-        private static Shape TryPastingOntoView(PowerPointPresentation pres, PowerPointSlide tempSlide, PowerPointSlide origSlide = null)
+        private static ShapeRange TryPastingOntoView(PowerPointPresentation pres, PowerPointSlide tempSlide, PowerPointSlide origSlide = null)
         {
             try
             {
@@ -288,10 +286,17 @@ namespace PowerPointLabs.Utils
                 {
                     pres.GotoSlide(origSlide.Index);
                 }
+
                 int finalShapesCount = tempSlide.Shapes.Count;
                 if (finalShapesCount > origShapesCount) 
                 {
-                    return tempSlide.Shapes.Range()[finalShapesCount];
+                    int newShapesNo = finalShapesCount - origShapesCount;
+                    int[] shapesToGet = new int[newShapesNo];
+                    for (int i = 0; i < shapesToGet.Length; i++)
+                    {
+                        shapesToGet[i] = origShapesCount + i + 1;
+                    }
+                    return tempSlide.Shapes.Range(shapesToGet);
                 } 
                 else 
                 {

--- a/PowerPointLabs/PowerPointLabs/Utils/ClipboardUtil.cs
+++ b/PowerPointLabs/PowerPointLabs/Utils/ClipboardUtil.cs
@@ -36,7 +36,10 @@ namespace PowerPointLabs.Utils
                 {
                     Logger.LogException(e, "PasteShapesFromClipboard");
                     // Delete previously pasted "shapes" because it is not a valid shape
-                    shapes[1].Delete();
+                    if (shapes != null)
+                    {
+                        shapes[1].Delete();
+                    }
                     ShapeRange picture = TryPastingAsPNG(slide);
                     if (picture == null)
                     {
@@ -77,25 +80,25 @@ namespace PowerPointLabs.Utils
                     tempClipboardShapes = TryPastingAsText(tempClipboardSlide);
                 }
 
-                if (tempPastedSlide == null && (tempClipboardShapes == null || tempClipboardShapes.Count < 1))
+                if (CheckIfPastingFailed(tempPastedSlide, tempClipboardShapes))
                 {
                     Logger.Log("RestoreClipboardAfterAction: Trying to paste as shape.", ActionFramework.Common.Logger.LogType.Info);
                     tempClipboardShapes = TryPastingAsShape(tempClipboardSlide);
                 }
 
-                if (tempPastedSlide == null && (tempClipboardShapes == null || tempClipboardShapes.Count < 1))
+                if (CheckIfPastingFailed(tempPastedSlide, tempClipboardShapes))
                 {
                     Logger.Log("RestoreClipboardAfterAction: Trying to paste as PNG picture", ActionFramework.Common.Logger.LogType.Info);
                     tempClipboardShapes = TryPastingAsPNG(tempClipboardSlide);
                 }
 
-                if (tempPastedSlide == null && (tempClipboardShapes == null || tempClipboardShapes.Count < 1))
+                if (CheckIfPastingFailed(tempPastedSlide, tempClipboardShapes))
                 {
                     Logger.Log("RestoreClipboardAfterAction: Trying to paste as bitmap picture", ActionFramework.Common.Logger.LogType.Info);
                     tempClipboardShapes = TryPastingAsBitmap(tempClipboardSlide);
                 }
 
-                if (tempPastedSlide == null && (tempClipboardShapes == null || tempClipboardShapes.Count < 1))
+                if (CheckIfPastingFailed(tempPastedSlide, tempClipboardShapes))
                 {
                     Logger.Log("RestoreClipboardAfterAction: Trying to paste onto view", ActionFramework.Common.Logger.LogType.Info);
                     tempClipboardShape = TryPastingOntoView(pres, tempClipboardSlide, origSlide);
@@ -116,6 +119,12 @@ namespace PowerPointLabs.Utils
             }
             return result;
         }
+
+        private static bool CheckIfPastingFailed(SlideRange slide, ShapeRange shapes)
+        {
+            return (slide == null && (shapes == null || shapes.Count < 1));
+        }
+
         #endregion
 
         /// <summary>

--- a/PowerPointLabs/PowerPointLabs/Utils/ClipboardUtil.cs
+++ b/PowerPointLabs/PowerPointLabs/Utils/ClipboardUtil.cs
@@ -253,6 +253,22 @@ namespace PowerPointLabs.Utils
                 return null;
             }
         }
+
+        private static ShapeRange TryPastingAsBitmap(PowerPointSlide slide)
+        {
+            try
+            {
+                // try pasting as general bitmap picture
+                return PasteWithCorrectSlideCheck(slide, true, PpPasteDataType.ppPasteBitmap);
+            }
+            catch (COMException e)
+            {
+                // May be thrown if clipboard is not a picture
+                Logger.LogException(e, "TryPastingAsBitmap");
+                return null;
+            }
+        }
+
         /// <summary>
         /// Pastes clipboard content into new temp slide using the DocumentWindow's View.Paste()
         /// Though this paste will work for most clipboard objects (even web pictures), it could possibly change the undo history.

--- a/PowerPointLabs/PowerPointLabs/Utils/ClipboardUtil.cs
+++ b/PowerPointLabs/PowerPointLabs/Utils/ClipboardUtil.cs
@@ -290,8 +290,8 @@ namespace PowerPointLabs.Utils
                 int finalShapesCount = tempSlide.Shapes.Count;
                 if (finalShapesCount > origShapesCount) 
                 {
-                    int newShapesNo = finalShapesCount - origShapesCount;
-                    int[] shapesToGet = new int[newShapesNo];
+                    int newShapesCount = finalShapesCount - origShapesCount;
+                    int[] shapesToGet = new int[newShapesCount];
                     for (int i = 0; i < shapesToGet.Length; i++)
                     {
                         shapesToGet[i] = origShapesCount + i + 1;


### PR DESCRIPTION
Resolves #1606 which will allow web pictures to be pasted with all the Paste Lab functions without errors being thrown.

Side effect: This also resolves #1380 because it will paste slide objects as a picture instead.

Also changes RestoreClipboardAfterAction for web pictures in clipboard because it will now try to paste as a PNG picture, then bitmap picture and then try View.Paste(). The benefits of trying to paste as PNG picture is that the transparency of the picture will not be lost in case it is a PNG picture.

To test web pictures with RestoreClipboardAfterAction, use ConvertToPicture with web pictures in the clipboard.


To Test: 
1. Paste Lab functions with web pictures in clipboard (can try PNG pictures)
2. Paste Lab functions with slide objects in clipboard
3. ConvertToPicture with web pictures in clipboard (can try PNG pictures)


There is a weird powerpoint bug where sometimes it cannot detect that the web picture it is pasting is a PNG picture until I try to paste it using the clipboard pane first. This seems to be a problem with powerpoint itself because even the default paste / paste special does not allow me to paste the web picture as PNG. Thus in this case, Paste Lab will just have to paste it as bitmap picture (without transparency) :(