### PR TITLE
#1662 Make Agenda Reference Slide sync Design's Slide Master (Theme of the slide) with other agenda slides

### DIFF
--- a/PowerPointLabs/PowerPointLabs/Utils/SlideUtil.cs
+++ b/PowerPointLabs/PowerPointLabs/Utils/SlideUtil.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Runtime.InteropServices;
 
 using Microsoft.Office.Core;
 using Microsoft.Office.Interop.PowerPoint;
@@ -7,6 +8,7 @@ using PowerPointLabs.Models;
 
 using Shape = Microsoft.Office.Interop.PowerPoint.Shape;
 using ShapeRange = Microsoft.Office.Interop.PowerPoint.ShapeRange;
+
 
 namespace PowerPointLabs.Utils
 {
@@ -119,12 +121,13 @@ namespace PowerPointLabs.Utils
         public static void CopyToDesign(string designName, PowerPointSlide refSlide)
         {
             Design design = GetDesign(designName);
-            if (design == null)
+            if (design != null)
             {
-                design = CreateDesign(designName);
+                design.Delete();
             }
-            design.SlideMaster.Background.Fill.ForeColor = refSlide.GetNativeSlide().Background.Fill.ForeColor;
-            design.SlideMaster.Background.Fill.BackColor = refSlide.GetNativeSlide().Background.Fill.BackColor;
+
+            Design newDesign = PowerPointPresentation.Current.Presentation.Designs.Clone(refSlide.Design);
+            newDesign.Name = designName;
         }
 
         # endregion

--- a/PowerPointLabs/PowerPointLabs/Utils/SlideUtil.cs
+++ b/PowerPointLabs/PowerPointLabs/Utils/SlideUtil.cs
@@ -3,7 +3,7 @@ using System.Runtime.InteropServices;
 
 using Microsoft.Office.Core;
 using Microsoft.Office.Interop.PowerPoint;
-
+using PowerPointLabs.ActionFramework.Common.Log;
 using PowerPointLabs.Models;
 
 using Shape = Microsoft.Office.Interop.PowerPoint.Shape;
@@ -123,9 +123,15 @@ namespace PowerPointLabs.Utils
             Design design = GetDesign(designName);
             if (design != null)
             {
-                design.Delete();
+                try
+                {
+                    design.Delete();
+                } 
+                catch (COMException e) 
+                {
+                    Logger.LogException(e, "CopyToDesign: Design cannot be deleted.");
+                }
             }
-
             Design newDesign = PowerPointPresentation.Current.Presentation.Designs.Clone(refSlide.Design);
             newDesign.Name = designName;
         }


### PR DESCRIPTION
Fixes #1662

**Outline of Solution**
Fixed agenda reference slide's Design not syncing entire Slide Master (which is the theme of the slide) to other agenda slides by:
1. Cloning the Design of the reference slide and then renaming it.
2. If Design already exist then it is deleted first.

**Failed Methods**
- refSlide.GetNativeSlide().Background.Shapes() and then copying over and pasting to design.SlideMaster.Background.Shapes() created more problems
- refSlide.GetNativeSlide().Design.SlideMaster.Background.Shapes() and then copying over and pasting to design.SlideMaster.Background.Shapes() also created more problems
- Copying other Background.Fill types over to design.SlideMaster.Background.Fill was not working because often the types could only be "get" but not "set"

**Testing**
Tested on PPT 2016 and works well even after syncing agenda multiple times. To test this PR, should try **changing the theme of the agenda's reference slide** and then syncing agenda multiple times manually and ensure nothing is breaking (since the design is cloned...)
Passes Text Agenda tests on PPT 2016.

@damithc This should fix your issue!