### PR TITLE
dev-release-4.3.0.1

### DIFF
--- a/PowerPointLabs/PowerPointLabs/PowerPointLabs.csproj
+++ b/PowerPointLabs/PowerPointLabs/PowerPointLabs.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <!--
     This section defines project-level properties.
@@ -41,10 +41,10 @@
     </NuGetPackageImportStamp>
     <StyleCopTreatErrorsAsWarnings>false</StyleCopTreatErrorsAsWarnings>
     <BootstrapperEnabled>true</BootstrapperEnabled>
-    <PublishUrl>C:\publish\</PublishUrl>
+    <PublishUrl>C:\publish_online\</PublishUrl>
     <InstallUrl>http://www.comp.nus.edu.sg/~pptlabs/download/dev/</InstallUrl>
     <TargetCulture>en</TargetCulture>
-    <ApplicationVersion>4.3.0.0</ApplicationVersion>
+    <ApplicationVersion>4.3.0.1</ApplicationVersion>
     <AutoIncrementApplicationRevision>false</AutoIncrementApplicationRevision>
     <UpdateEnabled>true</UpdateEnabled>
     <UpdateInterval>0</UpdateInterval>

--- a/PowerPointLabs/PowerPointLabs/Properties/Settings.Designer.cs
+++ b/PowerPointLabs/PowerPointLabs/Properties/Settings.Designer.cs
@@ -61,7 +61,7 @@ namespace PowerPointLabs.Properties {
         
         [global::System.Configuration.ApplicationScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("4.3.0.0")]
+        [global::System.Configuration.DefaultSettingValueAttribute("4.3.0.1")]
         public string Version {
             get {
                 return ((string)(this["Version"]));
@@ -70,7 +70,7 @@ namespace PowerPointLabs.Properties {
         
         [global::System.Configuration.ApplicationScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("14 April 2018")]
+        [global::System.Configuration.DefaultSettingValueAttribute("18 April 2018")]
         public string ReleaseDate {
             get {
                 return ((string)(this["ReleaseDate"]));

--- a/PowerPointLabs/PowerPointLabs/Properties/Settings.settings
+++ b/PowerPointLabs/PowerPointLabs/Properties/Settings.settings
@@ -15,10 +15,10 @@
       <Value Profile="(Default)">http://www.comp.nus.edu.sg/~pptlabs/download/dev/</Value>
     </Setting>
     <Setting Name="Version" Type="System.String" Scope="Application">
-      <Value Profile="(Default)">4.3.0.0</Value>
+      <Value Profile="(Default)">4.3.0.1</Value>
     </Setting>
     <Setting Name="ReleaseDate" Type="System.String" Scope="Application">
-      <Value Profile="(Default)">14 April 2018</Value>
+      <Value Profile="(Default)">18 April 2018</Value>
     </Setting>
   </Settings>
 </SettingsFile>

--- a/PowerPointLabs/PowerPointLabs/app.config
+++ b/PowerPointLabs/PowerPointLabs/app.config
@@ -20,10 +20,10 @@
     <value>http://www.comp.nus.edu.sg/~pptlabs/download/dev/</value>
    </setting>
    <setting name="Version" serializeAs="String">
-    <value>4.3.0.0</value>
+    <value>4.3.0.1</value>
    </setting>
    <setting name="ReleaseDate" serializeAs="String">
-    <value>14 April 2018</value>
+    <value>18 April 2018</value>
    </setting>
   </PowerPointLabs.Properties.Settings>
 	</applicationSettings>


### PR DESCRIPTION
dev-release-4.3.0.1

For `<PublishUrl>C:\publish_online\</PublishUrl>, `
I often change `C:\publish `to` C:\publish_online `and` C:\publish_offline` when doing online and offline releases respectively to prevent conflict. Thought that it will be good to change it to C:\publish_online first so remind myself of this.

I will update the google drive deployment documents to reflect this.