### PR TITLE
Fix: #1638 Positions Lab Bug (Align) 

### DIFF
--- a/PowerPointLabs/PowerPointLabs/PositionsLab/PositionsPaneWPF.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/PositionsLab/PositionsPaneWPF.xaml.cs
@@ -1062,7 +1062,8 @@ namespace PowerPointLabs.PositionsLab
                     this.StartNewUndoEntry();
                 }
 
-                simulatedShapes = DuplicateShapes(selectedShapes); // selectedShapes.Duplicate() may return a list with revresed sequence  
+                // selectedShapes.Duplicate() may return a list with reversed sequence  
+                simulatedShapes = DuplicateShapes(selectedShapes); 
 
                 if (PositionsLabSettings.AlignReference == PositionsLabSettings.AlignReferenceObject.PowerpointDefaults)
                 {
@@ -1733,7 +1734,10 @@ namespace PowerPointLabs.PositionsLab
             {
                 Shape shape = range[i + 1];
                 Shape duplicated = shape.Duplicate()[1];
+
+                // Add a number at end of name in case the name of shapes are same
                 duplicated.Name = shape.Name + "_Copy_" + i.ToString();
+
                 duplicated.Left = shape.Left;
                 duplicated.Top = shape.Top;
                 duplicatedShapeNames[i] = duplicated.Name;

--- a/PowerPointLabs/PowerPointLabs/PositionsLab/PositionsPaneWPF.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/PositionsLab/PositionsPaneWPF.xaml.cs
@@ -1062,7 +1062,7 @@ namespace PowerPointLabs.PositionsLab
                     this.StartNewUndoEntry();
                 }
 
-                simulatedShapes = DuplicateShapes(selectedShapes);
+                simulatedShapes = DuplicateShapes(selectedShapes); // selectedShapes.Duplicate() may return a list with revresed sequence  
 
                 if (PositionsLabSettings.AlignReference == PositionsLabSettings.AlignReferenceObject.PowerpointDefaults)
                 {
@@ -1733,7 +1733,7 @@ namespace PowerPointLabs.PositionsLab
             {
                 Shape shape = range[i + 1];
                 Shape duplicated = shape.Duplicate()[1];
-                duplicated.Name = shape.Name + "_Copy";
+                duplicated.Name = shape.Name + "_Copy_" + i.ToString();
                 duplicated.Left = shape.Left;
                 duplicated.Top = shape.Top;
                 duplicatedShapeNames[i] = duplicated.Name;


### PR DESCRIPTION
Fixes #1638

1. Fixed bugs for specific images using Positions Lab (Align part)

2. Fixed bug for PositionsPaneWPF.xaml.cs -> DuplicateShapes function. Before this fix, the function will return a list of same shapes if the name of input shapes are same. Now this function give duplicated shapes a index number in its Name property. This may fix other bugs related. Inline comments added.

3. Added comments for ShapeRange.Duplicate() function. The return sequence of this function is not guaranteed

5. Tested in Office 2016