### PR TITLE
#1704 Shapes Lab: Exception when adding a group of shapes

### DIFF
--- a/PowerPointLabs/PowerPointLabs/ShapesLab/CustomShapePane.cs
+++ b/PowerPointLabs/PowerPointLabs/ShapesLab/CustomShapePane.cs
@@ -193,12 +193,17 @@ namespace PowerPointLabs.ShapesLab
             // Utilises deprecated classes as CustomShapePane does not utilise ActionFramework
             PowerPointSlide currentSlide = PowerPointCurrentPresentationInfo.CurrentSlide;
             PowerPointPresentation pres = PowerPointPresentation.Current;
+
             // add shape into shape gallery first to reduce flicker
             string shapeName = addIn.ShapePresentation.AddShape(pres, currentSlide, selectedShapes, selectedShapes[1].Name);
 
             // add the selection into pane and save it as .png locally
             string shapeFullName = Path.Combine(CurrentShapeFolderPath, shapeName + ".png");
-            ConvertToPicture.ConvertAndSave(selection, shapeFullName);
+            bool success = ConvertToPicture.ConvertAndSave(selectedShapes, shapeFullName);
+            if (!success)
+            {
+                return;
+            }
 
             // sync the shape among all opening panels
             addIn.SyncShapeAdd(shapeName, shapeFullName, CurrentCategory);

--- a/PowerPointLabs/PowerPointLabs/ShortcutsLab/ConvertToPicture.cs
+++ b/PowerPointLabs/PowerPointLabs/ShortcutsLab/ConvertToPicture.cs
@@ -37,14 +37,20 @@ namespace PowerPointLabs.ShortcutsLab
 
         public static bool ConvertAndSave(ShapeRange selectedShapes, string fileName)
         {
+            if (ShapeUtil.IsShapeRangeShapeOrText(selectedShapes))
+            {
+                MessageBox.Show(ShortcutsLabText.ErrorTypeNotSupported, ShortcutsLabText.ErrorWindowTitle);
+                return false;
+            }
+
             try
             {
                 GraphicsUtil.ExportShape(selectedShapes, fileName);
                 return true;
             }
-            catch
+            catch (Exception e)
             {
-                MessageBox.Show(ShortcutsLabText.ErrorTypeNotSupported, ShortcutsLabText.ErrorWindowTitle);
+                MessageBox.Show("Exception during export shapes: " + e.Message, ShortcutsLabText.ErrorWindowTitle);
                 return false;
             }
         }

--- a/PowerPointLabs/PowerPointLabs/ShortcutsLab/ConvertToPicture.cs
+++ b/PowerPointLabs/PowerPointLabs/ShortcutsLab/ConvertToPicture.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Windows.Forms;
 
+using Microsoft.Office.Interop.PowerPoint;
 using PowerPointLabs.ActionFramework.Common.Log;
 using PowerPointLabs.Models;
 using PowerPointLabs.TextCollection;
@@ -34,22 +35,17 @@ namespace PowerPointLabs.ShortcutsLab
             }
         }
 
-        public static void ConvertAndSave(PowerPoint.Selection selection, string fileName)
+        public static bool ConvertAndSave(ShapeRange selectedShapes, string fileName)
         {
-            if (ShapeUtil.IsSelectionShapeOrText(selection))
+            try
             {
-                if (selection.HasChildShapeRange)
-                {
-                    GraphicsUtil.ExportShape(selection.ChildShapeRange, fileName);
-                }
-                else
-                {
-                    GraphicsUtil.ExportShape(selection.ShapeRange, fileName);
-                }
+                GraphicsUtil.ExportShape(selectedShapes, fileName);
+                return true;
             }
-            else
+            catch
             {
                 MessageBox.Show(ShortcutsLabText.ErrorTypeNotSupported, ShortcutsLabText.ErrorWindowTitle);
+                return false;
             }
         }
 

--- a/PowerPointLabs/PowerPointLabs/Utils/ShapeUtil.cs
+++ b/PowerPointLabs/PowerPointLabs/Utils/ShapeUtil.cs
@@ -160,7 +160,17 @@ namespace PowerPointLabs.Utils
                 return false;
             }
 
-            foreach (Shape shape in selection.ShapeRange)
+            return IsShapeRangeShapeOrText(selection.ShapeRange);
+        }
+
+        public static bool IsShapeRangeShapeOrText(ShapeRange selectedShapes)
+        {
+            if ((selectedShapes == null))
+            {
+                return false;
+            }
+
+            foreach (Shape shape in selectedShapes)
             {
                 if (shape.Type == MsoShapeType.msoPlaceholder)
                 {


### PR DESCRIPTION
Fixes #1704 

1. Fixed bugs for Shapes Lab: Exception when adding a group of shapes

2. Fixed bug for ConvertToPicture.cs -> ConvertAndSave(). Before this function execute, the clipboard is necessarily cleared and restored. During this process of clipboard, the Selection objects are cleared outside the function even though it is a local variable. Thus ConvertAndSave() should use selectedShapes instead of selection.

3. Tested in Office 2016

4. Refer to: https://docs.microsoft.com/en-us/previous-versions/office/developer/office-2010/ff762597(v%3doffice.14)