### PR TITLE
#1661 Error when not selecting any slide and any Paste Lab function is run

### DIFF
--- a/PowerPointLabs/PowerPointLabs/ActionFramework/PasteLab/PasteLabActionHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/PasteLab/PasteLabActionHandler.cs
@@ -32,6 +32,13 @@ namespace PowerPointLabs.ActionFramework.PasteLab
                 return;
             }
 
+            if (slide == null)
+            {
+                Logger.Log(ribbonId + " failed. Selection is empty.");
+                MessageBox.Show(PasteLabText.ErrorNoSelection, PasteLabText.ErrorDialogTitle);
+                return;
+            }
+
             ShapeRange passedSelectedShapes = null;
             ShapeRange passedSelectedChildShapes = null;
 

--- a/PowerPointLabs/PowerPointLabs/TextCollection/PasteLabText.cs
+++ b/PowerPointLabs/PowerPointLabs/TextCollection/PasteLabText.cs
@@ -45,5 +45,6 @@
         public const string ErrorDialogTitle = "Unable to execute action";
         public const string ErrorEmptyClipboard = "Error: Clipboard is empty.";
         public const string ErrorPaste = "Error: Unable to paste content in clipboard. Try pasting it normally in PowerPoint and then copying the item again.";
+        public const string ErrorNoSelection = "Select at least one slide to apply paste actions.";
     }
 }


### PR DESCRIPTION
Fixes #1661 

Fix by first checking if current slide is null before calling any paste lab functions.

