### PR TITLE
#1721 tutorial does not open after installation

### DIFF
--- a/PowerPointLabs/PowerPointLabs/app.config
+++ b/PowerPointLabs/PowerPointLabs/app.config
@@ -14,10 +14,10 @@
     <value>online</value>
    </setting>
    <setting name="ReleaseAddr" serializeAs="String">
-    <value>http://www.comp.nus.edu.sg/~pptlabs/download-78563/</value>
+    <value>https://www.comp.nus.edu.sg/~pptlabs/download-78563/</value>
    </setting>
    <setting name="DevAddr" serializeAs="String">
-    <value>http://www.comp.nus.edu.sg/~pptlabs/download/dev/</value>
+    <value>https://www.comp.nus.edu.sg/~pptlabs/download/dev/</value>
    </setting>
    <setting name="Version" serializeAs="String">
     <value>4.3.0.1</value>


### PR DESCRIPTION
Fixes #1721

I provided a temporary fix to the issue by changing `Process.start("POWERPNT", sourceFile)` to `Process.start(sourceFile)`. This will open the link in broswer, and prompt user to choose whether to open it directly or save locally. User can choose to open directly and access the tutorial file.

This issue is likely caused by incompatible SSL/TLS configuration between server and the security protocol used by .NET. I have tried to read contents of the tutorial file as byte array using `WebClient.DownloadData` or `HTTPRequest.GetResponse` but neither works.

Another possible walkaround is to include tutorial.pptx file in the download package, so that `Process.start('POWERPNT', sourceFile)` can open the local pptx file directly.