### PR TITLE
#1384 Format name can overflow or go behind buttons

### DIFF
--- a/PowerPointLabs/PowerPointLabs/SyncLab/Views/SyncFormatPaneItem.xaml
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/Views/SyncFormatPaneItem.xaml
@@ -7,14 +7,16 @@
              mc:Ignorable="d" 
              d:DesignHeight="60" d:DesignWidth="300"
              MouseDoubleClick="OnMouseDoubleClick">
-    <Grid x:Name="grid">
+    <Grid x:Name="grid" ClipToBounds="True">
         <Grid.ColumnDefinitions>
             <ColumnDefinition x:Name="col1" Width="60" MaxWidth="60"/>
             <ColumnDefinition x:Name="col2" Width="*"/>
             <ColumnDefinition x:Name="col3" Width="100" MaxWidth="100"/>
         </Grid.ColumnDefinitions>
         <Image x:Name="imageBox" Grid.Column="0" Margin="10,10,0,10" OpacityMask="{DynamicResource {x:Static SystemColors.ControlBrushKey}}" HorizontalAlignment="Left" Width="40" Height="40"/>
-        <TextBlock x:Name="textBlock" Grid.Column="1" Margin="0,10,0,10" MaxWidth="100" HorizontalAlignment="Stretch" VerticalAlignment="Center" TextTrimming="CharacterEllipsis"/>
+        <Canvas x:Name="canvas" Grid.Column="1" >
+            <TextBlock x:Name="textBlock" Margin="0,20,0,20" MaxWidth="{Binding ActualWidth, ElementName=canvas}" HorizontalAlignment="Stretch" VerticalAlignment="Center" TextTrimming="CharacterEllipsis"/>
+        </Canvas>
         <Button x:Name="pasteButton" Grid.Column="2" Margin="0,10,65,10" Click="PasteButton_Click" HorizontalAlignment="Right" MinWidth="25" MaxWidth="25" MinHeight="25" MaxHeight="25">
             <Image x:Name="pasteImage" Source="pack://siteoforigin:,,,/Resources/SyncLabPasteButton.png" Stretch="Fill"/>
             <Button.ToolTip>

--- a/PowerPointLabs/PowerPointLabs/SyncLab/Views/SyncFormatPaneItem.xaml
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/Views/SyncFormatPaneItem.xaml
@@ -8,9 +8,14 @@
              d:DesignHeight="60" d:DesignWidth="300"
              MouseDoubleClick="OnMouseDoubleClick">
     <Grid x:Name="grid">
-        <Image x:Name="imageBox" Margin="10,10,0,10" OpacityMask="{DynamicResource {x:Static SystemColors.ControlBrushKey}}" HorizontalAlignment="Left" Width="40" Height="40"/>
-        <Label x:Name="label" Margin="45,10,0,10" HorizontalAlignment="Left" HorizontalContentAlignment="Left" VerticalContentAlignment="Center" MinWidth="160" MaxWidth="160"/>
-        <Button x:Name="pasteButton" Margin="0,10,65,10" Click="PasteButton_Click" HorizontalAlignment="Right" MinWidth="25" MaxWidth="25" MinHeight="25" MaxHeight="25">
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition x:Name="col1" Width="60" MaxWidth="60"/>
+            <ColumnDefinition x:Name="col2" Width="*"/>
+            <ColumnDefinition x:Name="col3" Width="100" MaxWidth="100"/>
+        </Grid.ColumnDefinitions>
+        <Image x:Name="imageBox" Grid.Column="0" Margin="10,10,0,10" OpacityMask="{DynamicResource {x:Static SystemColors.ControlBrushKey}}" HorizontalAlignment="Left" Width="40" Height="40"/>
+        <TextBlock x:Name="textBlock" Grid.Column="1" Margin="0,10,0,10" MaxWidth="140" HorizontalAlignment="Stretch" VerticalAlignment="Center" TextTrimming="CharacterEllipsis"/>
+        <Button x:Name="pasteButton" Grid.Column="2" Margin="0,10,65,10" Click="PasteButton_Click" HorizontalAlignment="Right" MinWidth="25" MaxWidth="25" MinHeight="25" MaxHeight="25">
             <Image x:Name="pasteImage" Source="pack://siteoforigin:,,,/Resources/SyncLabPasteButton.png" Stretch="Fill"/>
             <Button.ToolTip>
                 <StackPanel>
@@ -22,7 +27,7 @@
                 </StackPanel>
             </Button.ToolTip>
         </Button>
-        <Button x:Name="editButton" Margin="0,10,35,10" Click="EditButton_Click" HorizontalAlignment="Right" MinWidth="25" MaxWidth="25" MinHeight="25" MaxHeight="25">
+        <Button x:Name="editButton" Grid.Column="2" Margin="0,10,35,10" Click="EditButton_Click" HorizontalAlignment="Right" MinWidth="25" MaxWidth="25" MinHeight="25" MaxHeight="25">
             <Image x:Name="editImage" Source="pack://siteoforigin:,,,/Resources/SyncLabEditButton.png" Stretch="Fill"/>
             <Button.ToolTip>
                 <StackPanel>
@@ -36,7 +41,7 @@
                 </StackPanel>
             </Button.ToolTip>
         </Button>
-        <Button x:Name="deleteButton" Margin="0,10,5,10" Click="DeleteButton_Click" HorizontalAlignment="Right" MinWidth="25" MaxWidth="25" MinHeight="25" MaxHeight="25">
+        <Button x:Name="deleteButton" Grid.Column="2" Margin="0,10,5,10" Click="DeleteButton_Click" HorizontalAlignment="Right" MinWidth="25" MaxWidth="25" MinHeight="25" MaxHeight="25">
             <Image x:Name="deleteImage" Source="pack://siteoforigin:,,,/Resources/SyncLabDeleteButton.png" Stretch="Fill"/>
             <Button.ToolTip>
                 <StackPanel>

--- a/PowerPointLabs/PowerPointLabs/SyncLab/Views/SyncFormatPaneItem.xaml
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/Views/SyncFormatPaneItem.xaml
@@ -14,7 +14,7 @@
             <ColumnDefinition x:Name="col3" Width="100" MaxWidth="100"/>
         </Grid.ColumnDefinitions>
         <Image x:Name="imageBox" Grid.Column="0" Margin="10,10,0,10" OpacityMask="{DynamicResource {x:Static SystemColors.ControlBrushKey}}" HorizontalAlignment="Left" Width="40" Height="40"/>
-        <TextBlock x:Name="textBlock" Grid.Column="1" Margin="0,10,0,10" MaxWidth="140" HorizontalAlignment="Stretch" VerticalAlignment="Center" TextTrimming="CharacterEllipsis"/>
+        <TextBlock x:Name="textBlock" Grid.Column="1" Margin="0,10,0,10" MaxWidth="100" HorizontalAlignment="Stretch" VerticalAlignment="Center" TextTrimming="CharacterEllipsis"/>
         <Button x:Name="pasteButton" Grid.Column="2" Margin="0,10,65,10" Click="PasteButton_Click" HorizontalAlignment="Right" MinWidth="25" MaxWidth="25" MinHeight="25" MaxHeight="25">
             <Image x:Name="pasteImage" Source="pack://siteoforigin:,,,/Resources/SyncLabPasteButton.png" Stretch="Fill"/>
             <Button.ToolTip>

--- a/PowerPointLabs/PowerPointLabs/SyncLab/Views/SyncFormatPaneItem.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/Views/SyncFormatPaneItem.xaml.cs
@@ -98,8 +98,7 @@ namespace PowerPointLabs.SyncLab.Views
             if (image == null)
             {
                 imageBox.Visibility = Visibility.Hidden;
-                label.Margin = new Thickness(30, label.Margin.Top,
-                            label.Margin.Right, label.Margin.Bottom);
+                col1.Width = new GridLength(0);
                 return;
             }
             else
@@ -111,8 +110,7 @@ namespace PowerPointLabs.SyncLab.Views
                                         BitmapSizeOptions.FromEmptyOptions());
                 imageBox.Source = source;
                 imageBox.Visibility = Visibility.Visible;
-                label.Margin = new Thickness(65, label.Margin.Top,
-                            label.Margin.Right, label.Margin.Bottom);
+                col1.Width = new GridLength(60);
             }
         }
 
@@ -120,11 +118,12 @@ namespace PowerPointLabs.SyncLab.Views
         {
             get
             {
-                return label.Content.ToString();
+                return textBlock.Text;
             }
             set
             {
-                label.Content = value;
+                textBlock.Text = value;
+                textBlock.ToolTip = value;
             }
         }
 


### PR DESCRIPTION
Fixes #1384

Ready for review. (No tests written for this)

![image](https://user-images.githubusercontent.com/40821389/49872189-4a793c00-fe53-11e8-84ef-c613d29d9526.png)

Format names were able to overflow into buttons previously. To address the issue:
1. Use TextBlock to trim text with ellipses.
2. Use 3 grid columns to partition and separate the image, text and the 3 buttons.
3. Tooltip is updated whenever the text is changed. (not using binding)

Minor issue with this method:
When resizing the panel on the right, the TextBlock does not resize to fully utilize the space. This may be addressed by not limiting the width of the TextBlock (Just a suggestion). The text will trail off the screen, but the user can scroll to access the buttons, shown below (Might not be better off). Edit: Removed suggested alternative's image to reduce ambiguity.
