### PR TITLE
#1533 using Directive should follow OSS-Generics coding standard

### DIFF
--- a/PowerPointLabs/PowerPointLabs/ActionFramework/CaptionsLab/RemoveCaptions/RemoveCaptionsEnabledHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/CaptionsLab/RemoveCaptions/RemoveCaptionsEnabledHandler.cs
@@ -1,5 +1,4 @@
 ﻿using PowerPointLabs.ActionFramework.Common.Attribute;
-using PowerPointLabs.ActionFramework.Common.Extension;
 using PowerPointLabs.ActionFramework.Common.Interface;
 using PowerPointLabs.CaptionsLab;
 using PowerPointLabs.TextCollection;

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/Common/Attribute/ExportActionRibbonIdAttribute.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/Common/Attribute/ExportActionRibbonIdAttribute.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.Linq;
+
 using PowerPointLabs.ActionFramework.Common.Interface;
 
 namespace PowerPointLabs.ActionFramework.Common.Attribute

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/Common/Attribute/ExportCheckBoxActionRibbonIdAttribute.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/Common/Attribute/ExportCheckBoxActionRibbonIdAttribute.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.Linq;
+
 using PowerPointLabs.ActionFramework.Common.Interface;
 
 namespace PowerPointLabs.ActionFramework.Common.Attribute

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/Common/Attribute/ExportContentRibbonIdAttribute.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/Common/Attribute/ExportContentRibbonIdAttribute.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.Linq;
+
 using PowerPointLabs.ActionFramework.Common.Interface;
 
 namespace PowerPointLabs.ActionFramework.Common.Attribute

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/Common/Attribute/ExportEnabledRibbonIdAttribute.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/Common/Attribute/ExportEnabledRibbonIdAttribute.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.Linq;
+
 using PowerPointLabs.ActionFramework.Common.Interface;
 
 namespace PowerPointLabs.ActionFramework.Common.Attribute

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/Common/Attribute/ExportImageRibbonIdAttribute.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/Common/Attribute/ExportImageRibbonIdAttribute.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.Linq;
+
 using PowerPointLabs.ActionFramework.Common.Interface;
 
 namespace PowerPointLabs.ActionFramework.Common.Attribute

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/Common/Attribute/ExportLabelRibbonIdAttribute.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/Common/Attribute/ExportLabelRibbonIdAttribute.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.Linq;
+
 using PowerPointLabs.ActionFramework.Common.Interface;
 
 namespace PowerPointLabs.ActionFramework.Common.Attribute

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/Common/Attribute/ExportPressedRibbonIdAttribute.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/Common/Attribute/ExportPressedRibbonIdAttribute.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.Linq;
+
 using PowerPointLabs.ActionFramework.Common.Interface;
 
 namespace PowerPointLabs.ActionFramework.Common.Attribute

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/Common/Attribute/ExportSupertipRibbonIdAttribute.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/Common/Attribute/ExportSupertipRibbonIdAttribute.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.Linq;
+
 using PowerPointLabs.ActionFramework.Common.Interface;
 
 namespace PowerPointLabs.ActionFramework.Common.Attribute

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/Common/Extension/ActionFrameworkExtensions.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/Common/Extension/ActionFrameworkExtensions.cs
@@ -1,8 +1,11 @@
 ﻿using System;
 using System.Windows.Forms;
+
 using Microsoft.Office.Interop.PowerPoint;
 using Microsoft.Office.Tools;
+
 using PowerPointLabs.Models;
+
 using Application = Microsoft.Office.Interop.PowerPoint.Application;
 
 namespace PowerPointLabs.ActionFramework.Common.Extension

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/Common/Extension/ContentControlExtensions.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/Common/Extension/ContentControlExtensions.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Windows.Controls;
+
 using Microsoft.Office.Interop.PowerPoint;
 using Microsoft.Office.Tools;
+
 using PowerPointLabs.Models;
 
 namespace PowerPointLabs.ActionFramework.Common.Extension

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/Common/Extension/FunctionalTestExtensions.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/Common/Extension/FunctionalTestExtensions.cs
@@ -1,6 +1,8 @@
 ﻿using System;
+
 using Microsoft.Office.Interop.PowerPoint;
 using Microsoft.Office.Tools;
+
 using PowerPointLabs.Models;
 
 namespace PowerPointLabs.ActionFramework.Common.Extension

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/Common/Factory/BaseHandlerFactory.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/Common/Factory/BaseHandlerFactory.cs
@@ -4,6 +4,7 @@ using System.ComponentModel.Composition;
 using System.ComponentModel.Composition.Hosting;
 using System.Linq;
 using System.Reflection;
+
 using PowerPointLabs.ActionFramework.Common.Interface;
 
 namespace PowerPointLabs.ActionFramework.Common.Factory

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/Common/Handlers/EmptyImageHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/Common/Handlers/EmptyImageHandler.cs
@@ -1,4 +1,5 @@
 ﻿using System.Drawing;
+
 using PowerPointLabs.ActionFramework.Common.Interface;
 
 namespace PowerPointLabs.ActionFramework.Common.Handlers

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/Common/Log/LogType.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/Common/Log/LogType.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-namespace PowerPointLabs.ActionFramework.Common.Logger
+﻿namespace PowerPointLabs.ActionFramework.Common.Logger
 {
     public enum LogType
     {

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/Common/Log/Logger.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/Common/Log/Logger.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics;
+
 using PowerPointLabs.ActionFramework.Common.Logger;
 
 namespace PowerPointLabs.ActionFramework.Common.Log

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/EffectsLab/Magnify/MagnifyActionHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/EffectsLab/Magnify/MagnifyActionHandler.cs
@@ -10,7 +10,6 @@ using PowerPointLabs.CropLab;
 using PowerPointLabs.TextCollection;
 
 using Office = Microsoft.Office.Core;
-using PowerPoint = Microsoft.Office.Interop.PowerPoint;
 
 namespace PowerPointLabs.ActionFramework.EffectsLab
 {

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/EffectsLab/MakeTransparent/MakeTransparentActionHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/EffectsLab/MakeTransparent/MakeTransparentActionHandler.cs
@@ -10,7 +10,6 @@ using PowerPointLabs.TextCollection;
 using PowerPointLabs.Utils;
 
 using Office = Microsoft.Office.Core;
-using PowerPoint = Microsoft.Office.Interop.PowerPoint;
 
 
 namespace PowerPointLabs.ActionFramework.EffectsLab

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/EffectsLab/RecolorMenuContent/EffectsLabRecolorActionHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/EffectsLab/RecolorMenuContent/EffectsLabRecolorActionHandler.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Office.Interop.PowerPoint;
+
 using PowerPointLabs.ActionFramework.Common.Attribute;
 using PowerPointLabs.ActionFramework.Common.Extension;
 using PowerPointLabs.ActionFramework.Common.Interface;

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/EffectsLab/Spotlight/SpotlightMenu/SpotlightMenuImageHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/EffectsLab/Spotlight/SpotlightMenu/SpotlightMenuImageHandler.cs
@@ -1,4 +1,5 @@
 ﻿using System.Drawing;
+
 using PowerPointLabs.ActionFramework.Common.Attribute;
 using PowerPointLabs.ActionFramework.Common.Interface;
 using PowerPointLabs.TextCollection;

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/HighlightLab/HighlightBackground/HighlightBackgroundEnabledHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/HighlightLab/HighlightBackground/HighlightBackgroundEnabledHandler.cs
@@ -1,5 +1,4 @@
 ﻿using PowerPointLabs.ActionFramework.Common.Attribute;
-using PowerPointLabs.ActionFramework.Common.Extension;
 using PowerPointLabs.ActionFramework.Common.Interface;
 using PowerPointLabs.HighlightLab;
 using PowerPointLabs.TextCollection;

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/HighlightLab/HighlightText/HighlightTextEnabledHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/HighlightLab/HighlightText/HighlightTextEnabledHandler.cs
@@ -3,7 +3,6 @@
 using PowerPointLabs.ActionFramework.Common.Attribute;
 using PowerPointLabs.ActionFramework.Common.Extension;
 using PowerPointLabs.ActionFramework.Common.Interface;
-using PowerPointLabs.ActionFramework.Common.Log;
 using PowerPointLabs.HighlightLab;
 using PowerPointLabs.TextCollection;
 

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/HighlightLab/HighlightText/HighlightTextImageHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/HighlightLab/HighlightText/HighlightTextImageHandler.cs
@@ -1,4 +1,5 @@
 ﻿using System.Drawing;
+
 using PowerPointLabs.ActionFramework.Common.Attribute;
 using PowerPointLabs.ActionFramework.Common.Interface;
 using PowerPointLabs.TextCollection;

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/NarrationsLab/AddNarrations/AddNarrationsImageHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/NarrationsLab/AddNarrations/AddNarrationsImageHandler.cs
@@ -1,4 +1,5 @@
 ﻿using System.Drawing;
+
 using PowerPointLabs.ActionFramework.Common.Attribute;
 using PowerPointLabs.ActionFramework.Common.Interface;
 using PowerPointLabs.TextCollection;

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/NarrationsLab/RemoveNarrations/RemoveNarrationsEnabledHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/NarrationsLab/RemoveNarrations/RemoveNarrationsEnabledHandler.cs
@@ -1,5 +1,4 @@
 ﻿using PowerPointLabs.ActionFramework.Common.Attribute;
-using PowerPointLabs.ActionFramework.Common.Extension;
 using PowerPointLabs.ActionFramework.Common.Interface;
 using PowerPointLabs.NarrationsLab;
 using PowerPointLabs.TextCollection;

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/NarrationsLab/RemoveNarrations/RemoveNarrationsImageHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/NarrationsLab/RemoveNarrations/RemoveNarrationsImageHandler.cs
@@ -1,4 +1,5 @@
 ﻿using System.Drawing;
+
 using PowerPointLabs.ActionFramework.Common.Attribute;
 using PowerPointLabs.ActionFramework.Common.Interface;
 using PowerPointLabs.TextCollection;

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/PasteLab/PasteAtCursorPosition/PasteAtCursorPositionActionHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/PasteLab/PasteAtCursorPosition/PasteAtCursorPositionActionHandler.cs
@@ -1,4 +1,5 @@
 ﻿using System.Windows;
+
 using Microsoft.Office.Interop.PowerPoint;
 
 using PowerPointLabs.ActionFramework.Common.Attribute;

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/PasteLab/PasteAtCursorPosition/PasteAtCursorPositionImageHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/PasteLab/PasteAtCursorPosition/PasteAtCursorPositionImageHandler.cs
@@ -1,4 +1,5 @@
 ﻿using System.Drawing;
+
 using PowerPointLabs.ActionFramework.Common.Attribute;
 using PowerPointLabs.ActionFramework.Common.Interface;
 using PowerPointLabs.TextCollection;

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/PasteLab/PasteAtOriginalPosition/PasteAtOriginalPositionActionHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/PasteLab/PasteAtOriginalPosition/PasteAtOriginalPositionActionHandler.cs
@@ -1,4 +1,5 @@
 ﻿using System.Windows;
+
 using Microsoft.Office.Interop.PowerPoint;
 
 using PowerPointLabs.ActionFramework.Common.Attribute;

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/PasteLab/PasteAtOriginalPosition/PasteAtOriginalPositionImageHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/PasteLab/PasteAtOriginalPosition/PasteAtOriginalPositionImageHandler.cs
@@ -1,4 +1,5 @@
 ﻿using System.Drawing;
+
 using PowerPointLabs.ActionFramework.Common.Attribute;
 using PowerPointLabs.ActionFramework.Common.Interface;
 using PowerPointLabs.TextCollection;

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/PasteLab/PasteIntoGroup/PasteIntoGroupActionHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/PasteLab/PasteIntoGroup/PasteIntoGroupActionHandler.cs
@@ -1,4 +1,5 @@
 ﻿using System.Windows;
+
 using Microsoft.Office.Interop.PowerPoint;
 
 using PowerPointLabs.ActionFramework.Common.Attribute;

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/PasteLab/PasteIntoGroup/PasteIntoGroupImageHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/PasteLab/PasteIntoGroup/PasteIntoGroupImageHandler.cs
@@ -1,4 +1,5 @@
 ﻿using System.Drawing;
+
 using PowerPointLabs.ActionFramework.Common.Attribute;
 using PowerPointLabs.ActionFramework.Common.Interface;
 using PowerPointLabs.TextCollection;

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/PasteLab/PasteLabActionHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/PasteLab/PasteLabActionHandler.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Windows;
+
 using Microsoft.Office.Interop.PowerPoint;
 
 using PowerPointLabs.ActionFramework.Common.Extension;

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/PasteLab/PasteLabMenu/PasteLabMenuImageHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/PasteLab/PasteLabMenu/PasteLabMenuImageHandler.cs
@@ -1,4 +1,5 @@
 ﻿using System.Drawing;
+
 using PowerPointLabs.ActionFramework.Common.Attribute;
 using PowerPointLabs.ActionFramework.Common.Interface;
 using PowerPointLabs.TextCollection;

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/PasteLab/PasteToFillSlide/PasteToFillSlideActionHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/PasteLab/PasteToFillSlide/PasteToFillSlideActionHandler.cs
@@ -1,4 +1,5 @@
 using System.Windows;
+
 using Microsoft.Office.Interop.PowerPoint;
 
 using PowerPointLabs.ActionFramework.Common.Attribute;

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/PasteLab/PasteToFillSlide/PasteToFillSlideImageHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/PasteLab/PasteToFillSlide/PasteToFillSlideImageHandler.cs
@@ -1,4 +1,5 @@
 ﻿using System.Drawing;
+
 using PowerPointLabs.ActionFramework.Common.Attribute;
 using PowerPointLabs.ActionFramework.Common.Interface;
 using PowerPointLabs.TextCollection;

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/PasteLab/PasteToFitSlide/PasteToFitSlideActionHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/PasteLab/PasteToFitSlide/PasteToFitSlideActionHandler.cs
@@ -1,4 +1,5 @@
 ﻿using System.Windows;
+
 using Microsoft.Office.Interop.PowerPoint;
 
 using PowerPointLabs.ActionFramework.Common.Attribute;

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/PasteLab/PasteToFitSlide/PasteToFitSlideImageHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/PasteLab/PasteToFitSlide/PasteToFitSlideImageHandler.cs
@@ -1,4 +1,5 @@
 ﻿using System.Drawing;
+
 using PowerPointLabs.ActionFramework.Common.Attribute;
 using PowerPointLabs.ActionFramework.Common.Interface;
 using PowerPointLabs.TextCollection;

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/PasteLab/ReplaceWithClipboard/ReplaceWithClipboardImageHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/PasteLab/ReplaceWithClipboard/ReplaceWithClipboardImageHandler.cs
@@ -1,4 +1,5 @@
 ﻿using System.Drawing;
+
 using PowerPointLabs.ActionFramework.Common.Attribute;
 using PowerPointLabs.ActionFramework.Common.Interface;
 using PowerPointLabs.TextCollection;

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/ShapesLab/AddShape/AddShapeActionHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/ShapesLab/AddShape/AddShapeActionHandler.cs
@@ -1,6 +1,4 @@
-﻿using System.IO;
-using System.Windows.Forms;
-
+﻿
 using Microsoft.Office.Interop.PowerPoint;
 
 using PowerPointLabs.ActionFramework.Common.Attribute;

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/ShapesLab/AddShape/AddShapeImageHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/ShapesLab/AddShape/AddShapeImageHandler.cs
@@ -1,4 +1,5 @@
 ﻿using System.Drawing;
+
 using PowerPointLabs.ActionFramework.Common.Attribute;
 using PowerPointLabs.ActionFramework.Common.Interface;
 using PowerPointLabs.TextCollection;

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/ShortcutsLab/ConvertToPicture/ConvertToPictureImageHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/ShortcutsLab/ConvertToPicture/ConvertToPictureImageHandler.cs
@@ -1,4 +1,5 @@
 ﻿using System.Drawing;
+
 using PowerPointLabs.ActionFramework.Common.Attribute;
 using PowerPointLabs.ActionFramework.Common.Interface;
 using PowerPointLabs.TextCollection;

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/ShortcutsLab/EditName/EditNameImageHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/ShortcutsLab/EditName/EditNameImageHandler.cs
@@ -1,4 +1,5 @@
 ﻿using System.Drawing;
+
 using PowerPointLabs.ActionFramework.Common.Attribute;
 using PowerPointLabs.ActionFramework.Common.Interface;
 using PowerPointLabs.TextCollection;

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/ShortcutsLab/FillSlide/FillSlideImageHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/ShortcutsLab/FillSlide/FillSlideImageHandler.cs
@@ -1,4 +1,5 @@
 ﻿using System.Drawing;
+
 using PowerPointLabs.ActionFramework.Common.Attribute;
 using PowerPointLabs.ActionFramework.Common.Interface;
 using PowerPointLabs.TextCollection;

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/ShortcutsLab/HideShape/HideShapeImageHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/ShortcutsLab/HideShape/HideShapeImageHandler.cs
@@ -1,4 +1,5 @@
 ﻿using System.Drawing;
+
 using PowerPointLabs.ActionFramework.Common.Attribute;
 using PowerPointLabs.ActionFramework.Common.Interface;
 using PowerPointLabs.TextCollection;

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/ShortcutsLab/SpeakSelected/SpeakSelectedImageHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/ShortcutsLab/SpeakSelected/SpeakSelectedImageHandler.cs
@@ -1,4 +1,5 @@
 ﻿using System.Drawing;
+
 using PowerPointLabs.ActionFramework.Common.Attribute;
 using PowerPointLabs.ActionFramework.Common.Interface;
 using PowerPointLabs.TextCollection;

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/ZoomLab/DrillDown/DrillDownImageHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/ZoomLab/DrillDown/DrillDownImageHandler.cs
@@ -1,4 +1,5 @@
 ﻿using System.Drawing;
+
 using PowerPointLabs.ActionFramework.Common.Attribute;
 using PowerPointLabs.ActionFramework.Common.Interface;
 using PowerPointLabs.TextCollection;

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/ZoomLab/StepBack/StepBackImageHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/ZoomLab/StepBack/StepBackImageHandler.cs
@@ -1,4 +1,5 @@
 ﻿using System.Drawing;
+
 using PowerPointLabs.ActionFramework.Common.Attribute;
 using PowerPointLabs.ActionFramework.Common.Interface;
 using PowerPointLabs.TextCollection;

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/ZoomLab/ZoomLabMenu/ZoomLabMenuImageHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/ZoomLab/ZoomLabMenu/ZoomLabMenuImageHandler.cs
@@ -1,4 +1,5 @@
 ﻿using System.Drawing;
+
 using PowerPointLabs.ActionFramework.Common.Attribute;
 using PowerPointLabs.ActionFramework.Common.Interface;
 using PowerPointLabs.TextCollection;

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/ZoomLab/ZoomLabSettings/ZoomLabSettingsImageHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/ZoomLab/ZoomLabSettings/ZoomLabSettingsImageHandler.cs
@@ -1,4 +1,5 @@
 ﻿using System.Drawing;
+
 using PowerPointLabs.ActionFramework.Common.Attribute;
 using PowerPointLabs.ActionFramework.Common.Interface;
 using PowerPointLabs.TextCollection;

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/ZoomLab/ZoomToArea/ZoomToAreaImageHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/ZoomLab/ZoomToArea/ZoomToAreaImageHandler.cs
@@ -1,4 +1,5 @@
 ﻿using System.Drawing;
+
 using PowerPointLabs.ActionFramework.Common.Attribute;
 using PowerPointLabs.ActionFramework.Common.Interface;
 using PowerPointLabs.TextCollection;

--- a/PowerPointLabs/PowerPointLabs/AgendaLab/AgendaLabSyncFunctions.cs
+++ b/PowerPointLabs/PowerPointLabs/AgendaLab/AgendaLabSyncFunctions.cs
@@ -11,7 +11,6 @@ using PowerPointLabs.Models;
 using PowerPointLabs.Utils;
 using PowerPointLabs.ZoomLab;
 
-using GraphicsUtil = PowerPointLabs.Utils.GraphicsUtil;
 using Shape = Microsoft.Office.Interop.PowerPoint.Shape;
 using ShapeRange = Microsoft.Office.Interop.PowerPoint.ShapeRange;
 

--- a/PowerPointLabs/PowerPointLabs/AgendaLab/AgendaShape.cs
+++ b/PowerPointLabs/PowerPointLabs/AgendaLab/AgendaShape.cs
@@ -1,8 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Runtime.InteropServices;
-using System.Text;
+
 using Microsoft.Office.Interop.PowerPoint;
 
 namespace PowerPointLabs.AgendaLab

--- a/PowerPointLabs/PowerPointLabs/AgendaLab/Templates/AgendaSectionTemplates.cs
+++ b/PowerPointLabs/PowerPointLabs/AgendaLab/Templates/AgendaSectionTemplates.cs
@@ -1,8 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Linq;
-using System.Text;
+
 using PowerPointLabs.Models;
 
 namespace PowerPointLabs.AgendaLab.Templates

--- a/PowerPointLabs/PowerPointLabs/AgendaLab/Templates/TemplateIndexTable.cs
+++ b/PowerPointLabs/PowerPointLabs/AgendaLab/Templates/TemplateIndexTable.cs
@@ -1,8 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Linq;
-using System.Text;
 
 using PowerPointLabs.Models;
 

--- a/PowerPointLabs/PowerPointLabs/AnimationLab/AutoAnimate.cs
+++ b/PowerPointLabs/PowerPointLabs/AnimationLab/AutoAnimate.cs
@@ -1,10 +1,10 @@
-﻿﻿using System;
+﻿using System;
 using System.Windows.Forms;
 
 using PowerPointLabs.ActionFramework.Common.Log;
 using PowerPointLabs.Models;
-using PowerPointLabs.Views;
 using PowerPointLabs.TextCollection;
+using PowerPointLabs.Views;
 
 using PowerPoint = Microsoft.Office.Interop.PowerPoint;
 

--- a/PowerPointLabs/PowerPointLabs/AudioMisc/AudioHelper.cs
+++ b/PowerPointLabs/PowerPointLabs/AudioMisc/AudioHelper.cs
@@ -1,11 +1,10 @@
 ﻿using System;
-using System.IO;
-using System.Linq;
 using System.Text;
 
 using Microsoft.Office.Core;
-using NAudio.Wave;
+
 using PowerPointLabs.Models;
+
 using PPExtraEventHelper;
 
 using Shape = Microsoft.Office.Interop.PowerPoint.Shape;

--- a/PowerPointLabs/PowerPointLabs/AutoUpdate/Downloader.cs
+++ b/PowerPointLabs/PowerPointLabs/AutoUpdate/Downloader.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Net;
 using System.Threading.Tasks;
+
 using PowerPointLabs.ActionFramework.Common.Log;
 using PowerPointLabs.AutoUpdate.Interface;
 

--- a/PowerPointLabs/PowerPointLabs/AutoUpdate/Interface/IDownloader.cs
+++ b/PowerPointLabs/PowerPointLabs/AutoUpdate/Interface/IDownloader.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace PowerPointLabs.AutoUpdate.Interface
+﻿namespace PowerPointLabs.AutoUpdate.Interface
 {
     public interface IDownloader
     {

--- a/PowerPointLabs/PowerPointLabs/Converters/ColorPane/SelectedColorToAnalogousHigher.cs
+++ b/PowerPointLabs/PowerPointLabs/Converters/ColorPane/SelectedColorToAnalogousHigher.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Windows.Data;
+
 using PowerPointLabs.ColorPicker;
 
 namespace PowerPointLabs.Converters.ColorPane

--- a/PowerPointLabs/PowerPointLabs/Converters/ColorPane/SelectedColorToAnalogousLower.cs
+++ b/PowerPointLabs/PowerPointLabs/Converters/ColorPane/SelectedColorToAnalogousLower.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Windows.Data;
+
 using PowerPointLabs.ColorPicker;
 
 namespace PowerPointLabs.Converters.ColorPane

--- a/PowerPointLabs/PowerPointLabs/Converters/ColorPane/SelectedColorToComplementaryColor.cs
+++ b/PowerPointLabs/PowerPointLabs/Converters/ColorPane/SelectedColorToComplementaryColor.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Windows.Data;
+
 using PowerPointLabs.ColorPicker;
 
 namespace PowerPointLabs.Converters.ColorPane

--- a/PowerPointLabs/PowerPointLabs/Converters/ColorPane/SelectedColorToSaturationValue.cs
+++ b/PowerPointLabs/PowerPointLabs/Converters/ColorPane/SelectedColorToSaturationValue.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Drawing;
 using System.Windows.Data;
 
 namespace PowerPointLabs.Converters.ColorPane

--- a/PowerPointLabs/PowerPointLabs/Converters/ColorPane/SelectedColorToSplitComplementaryHigher.cs
+++ b/PowerPointLabs/PowerPointLabs/Converters/ColorPane/SelectedColorToSplitComplementaryHigher.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Windows.Data;
+
 using PowerPointLabs.ColorPicker;
 
 namespace PowerPointLabs.Converters.ColorPane

--- a/PowerPointLabs/PowerPointLabs/Converters/ColorPane/SelectedColorToSplitComplementaryLower.cs
+++ b/PowerPointLabs/PowerPointLabs/Converters/ColorPane/SelectedColorToSplitComplementaryLower.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Windows.Data;
+
 using PowerPointLabs.ColorPicker;
 
 namespace PowerPointLabs.Converters.ColorPane

--- a/PowerPointLabs/PowerPointLabs/Converters/ColorPane/SelectedColorToTetradicOne.cs
+++ b/PowerPointLabs/PowerPointLabs/Converters/ColorPane/SelectedColorToTetradicOne.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Windows.Data;
+
 using PowerPointLabs.ColorPicker;
 
 namespace PowerPointLabs.Converters.ColorPane

--- a/PowerPointLabs/PowerPointLabs/Converters/ColorPane/SelectedColorToTetradicThree.cs
+++ b/PowerPointLabs/PowerPointLabs/Converters/ColorPane/SelectedColorToTetradicThree.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Windows.Data;
+
 using PowerPointLabs.ColorPicker;
 
 namespace PowerPointLabs.Converters.ColorPane

--- a/PowerPointLabs/PowerPointLabs/Converters/ColorPane/SelectedColorToTetradicTwo.cs
+++ b/PowerPointLabs/PowerPointLabs/Converters/ColorPane/SelectedColorToTetradicTwo.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Windows.Data;
+
 using PowerPointLabs.ColorPicker;
 
 namespace PowerPointLabs.Converters.ColorPane

--- a/PowerPointLabs/PowerPointLabs/Converters/ColorPane/SelectedColorToTriadicHigher.cs
+++ b/PowerPointLabs/PowerPointLabs/Converters/ColorPane/SelectedColorToTriadicHigher.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Windows.Data;
+
 using PowerPointLabs.ColorPicker;
 
 namespace PowerPointLabs.Converters.ColorPane

--- a/PowerPointLabs/PowerPointLabs/Converters/ColorPane/SelectedColorToTriadicLower.cs
+++ b/PowerPointLabs/PowerPointLabs/Converters/ColorPane/SelectedColorToTriadicLower.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Windows.Data;
+
 using PowerPointLabs.ColorPicker;
 
 namespace PowerPointLabs.Converters.ColorPane

--- a/PowerPointLabs/PowerPointLabs/CropLab/CropLabException.cs
+++ b/PowerPointLabs/PowerPointLabs/CropLab/CropLabException.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace PowerPointLabs.CropLab
 {

--- a/PowerPointLabs/PowerPointLabs/CropLab/CropLabOperationException.cs
+++ b/PowerPointLabs/PowerPointLabs/CropLab/CropLabOperationException.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+
 using PowerPointLabs.ActionFramework.Common.Log;
 using PowerPointLabs.ActionFramework.Common.Logger;
 

--- a/PowerPointLabs/PowerPointLabs/CustomBinding.cs
+++ b/PowerPointLabs/PowerPointLabs/CustomBinding.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.Linq;
-using System.Text;
+﻿using System.Globalization;
 using System.Threading;
 using System.Windows.Data;
 using System.Windows.Forms;

--- a/PowerPointLabs/PowerPointLabs/DataSources/ShapesLabSettingsDataSource.cs
+++ b/PowerPointLabs/PowerPointLabs/DataSources/ShapesLabSettingsDataSource.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Linq;
-using System.Text;
+﻿using System.ComponentModel;
 
 namespace PowerPointLabs.DataSources
 {

--- a/PowerPointLabs/PowerPointLabs/EffectsLab/EffectsLabUtil.cs
+++ b/PowerPointLabs/PowerPointLabs/EffectsLab/EffectsLabUtil.cs
@@ -4,6 +4,7 @@ using System.Runtime.InteropServices;
 using System.Windows.Forms;
 
 using Microsoft.Office.Interop.PowerPoint;
+
 using PowerPointLabs.Models;
 using PowerPointLabs.TextCollection;
 using PowerPointLabs.Utils;

--- a/PowerPointLabs/PowerPointLabs/FitToSlide.cs
+++ b/PowerPointLabs/PowerPointLabs/FitToSlide.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Office = Microsoft.Office.Core;
+
 using PowerPoint = Microsoft.Office.Interop.PowerPoint;
 
 namespace PowerPointLabs

--- a/PowerPointLabs/PowerPointLabs/FunctionalTestInterface.Impl/Controller/ShapesLabController.cs
+++ b/PowerPointLabs/PowerPointLabs/FunctionalTestInterface.Impl/Controller/ShapesLabController.cs
@@ -1,13 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Windows.Forms;
 
 using Microsoft.Office.Interop.PowerPoint;
 
 using PowerPointLabs.ActionFramework.Common.Extension;
 using PowerPointLabs.ShapesLab;
 using PowerPointLabs.TextCollection;
+
 using TestInterface;
 
 

--- a/PowerPointLabs/PowerPointLabs/FunctionalTestInterface.Impl/Controller/SyncLabController.cs
+++ b/PowerPointLabs/PowerPointLabs/FunctionalTestInterface.Impl/Controller/SyncLabController.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;

--- a/PowerPointLabs/PowerPointLabs/FunctionalTestInterface.Impl/EffectData.cs
+++ b/PowerPointLabs/PowerPointLabs/FunctionalTestInterface.Impl/EffectData.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 
 using Microsoft.Office.Interop.PowerPoint;
+
 using TestInterface;
 
 namespace PowerPointLabs.FunctionalTestInterface.Impl

--- a/PowerPointLabs/PowerPointLabs/FunctionalTestInterface.Impl/PowerPointLabsFT.cs
+++ b/PowerPointLabs/PowerPointLabs/FunctionalTestInterface.Impl/PowerPointLabsFT.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+
 using TestInterface;
 
 namespace PowerPointLabs.FunctionalTestInterface.Impl

--- a/PowerPointLabs/PowerPointLabs/FunctionalTestInterface.Impl/PowerPointLabsFeatures.cs
+++ b/PowerPointLabs/PowerPointLabs/FunctionalTestInterface.Impl/PowerPointLabsFeatures.cs
@@ -6,6 +6,7 @@ using PowerPointLabs.EffectsLab;
 using PowerPointLabs.FunctionalTestInterface.Impl.Controller;
 using PowerPointLabs.TextCollection;
 using PowerPointLabs.ZoomLab;
+
 using TestInterface;
 
 namespace PowerPointLabs.FunctionalTestInterface.Impl

--- a/PowerPointLabs/PowerPointLabs/FunctionalTestInterface.Impl/PowerPointOperations.cs
+++ b/PowerPointLabs/PowerPointLabs/FunctionalTestInterface.Impl/PowerPointOperations.cs
@@ -6,8 +6,10 @@ using System.Windows.Forms;
 
 using Microsoft.Office.Core;
 using Microsoft.Office.Interop.PowerPoint;
+
 using PowerPointLabs.ActionFramework.Common.Extension;
 using PowerPointLabs.Utils;
+
 using TestInterface;
 
 using Shape = Microsoft.Office.Interop.PowerPoint.Shape;

--- a/PowerPointLabs/PowerPointLabs/FunctionalTestInterface.Impl/SlideData.cs
+++ b/PowerPointLabs/PowerPointLabs/FunctionalTestInterface.Impl/SlideData.cs
@@ -1,9 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IO;
 
 using Microsoft.Office.Interop.PowerPoint;
+
 using PowerPointLabs.Utils;
+
 using TestInterface;
 
 namespace PowerPointLabs.FunctionalTestInterface.Impl

--- a/PowerPointLabs/PowerPointLabs/HighlightLab/HighlightBulletsText.cs
+++ b/PowerPointLabs/PowerPointLabs/HighlightLab/HighlightBulletsText.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Drawing;
 using System.Linq;
 
 using PowerPointLabs.ActionFramework.Common.Log;

--- a/PowerPointLabs/PowerPointLabs/HighlightLab/RemoveHighlighting.cs
+++ b/PowerPointLabs/PowerPointLabs/HighlightLab/RemoveHighlighting.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Office.Interop.PowerPoint;
+
 using PowerPointLabs.Models;
 
 namespace PowerPointLabs.HighlightLab

--- a/PowerPointLabs/PowerPointLabs/LegacyShapeUtil.cs
+++ b/PowerPointLabs/PowerPointLabs/LegacyShapeUtil.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+
 using Office = Microsoft.Office.Core;
 using PowerPoint = Microsoft.Office.Interop.PowerPoint;
 

--- a/PowerPointLabs/PowerPointLabs/Models/PowerPointAckSlide.cs
+++ b/PowerPointLabs/PowerPointLabs/Models/PowerPointAckSlide.cs
@@ -1,8 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text;
 
 using Office = Microsoft.Office.Core;
 using PowerPoint = Microsoft.Office.Interop.PowerPoint;

--- a/PowerPointLabs/PowerPointLabs/Models/PowerPointCurrentPresentationInfo.cs
+++ b/PowerPointLabs/PowerPointLabs/Models/PowerPointCurrentPresentationInfo.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
+
 using Microsoft.Office.Interop.PowerPoint;
 
 namespace PowerPointLabs.Models

--- a/PowerPointLabs/PowerPointLabs/Models/PowerPointMagnifiedSlide.cs
+++ b/PowerPointLabs/PowerPointLabs/Models/PowerPointMagnifiedSlide.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
+
 using Office = Microsoft.Office.Core;
 using PowerPoint = Microsoft.Office.Interop.PowerPoint;
 

--- a/PowerPointLabs/PowerPointLabs/Models/PowerPointPresentation.cs
+++ b/PowerPointLabs/PowerPointLabs/Models/PowerPointPresentation.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
+
 using Microsoft.Office.Core;
 using Microsoft.Office.Interop.PowerPoint;
 

--- a/PowerPointLabs/PowerPointLabs/Models/TaggedText.cs
+++ b/PowerPointLabs/PowerPointLabs/Models/TaggedText.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Speech.Synthesis;
 using System.Text;
 using System.Text.RegularExpressions;
+
 using PowerPointLabs.TagMatchers;
 using PowerPointLabs.Tags;
 using PowerPointLabs.Utils;

--- a/PowerPointLabs/PowerPointLabs/NarrationsLab/NotesToAudio.cs
+++ b/PowerPointLabs/PowerPointLabs/NarrationsLab/NotesToAudio.cs
@@ -9,6 +9,7 @@ using System.Windows.Forms;
 
 using Microsoft.Office.Core;
 using Microsoft.Office.Interop.PowerPoint;
+
 using PowerPointLabs.ActionFramework.Common.Log;
 using PowerPointLabs.AudioMisc;
 using PowerPointLabs.Models;

--- a/PowerPointLabs/PowerPointLabs/PPExtraEventHelper/PPKeyboard.cs
+++ b/PowerPointLabs/PowerPointLabs/PPExtraEventHelper/PPKeyboard.cs
@@ -1,13 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Drawing;
 using System.Linq;
-using System.Runtime.InteropServices;
-using System.Text;
-using System.Windows.Forms;
 
-using PowerPointLabs;
 using PowerPoint = Microsoft.Office.Interop.PowerPoint;
 
 namespace PPExtraEventHelper

--- a/PowerPointLabs/PowerPointLabs/PPExtraEventHelper/PPMouse.cs
+++ b/PowerPointLabs/PowerPointLabs/PPExtraEventHelper/PPMouse.cs
@@ -2,10 +2,8 @@
 using System.Diagnostics;
 using System.Drawing;
 using System.Runtime.InteropServices;
-using System.Text;
 using System.Windows.Forms;
 
-using PowerPointLabs;
 using PowerPoint = Microsoft.Office.Interop.PowerPoint;
 
 namespace PPExtraEventHelper

--- a/PowerPointLabs/PowerPointLabs/PasteLab/PasteLabConstants.cs
+++ b/PowerPointLabs/PowerPointLabs/PasteLab/PasteLabConstants.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-namespace PowerPointLabs.PasteLab
+﻿namespace PowerPointLabs.PasteLab
 {
     static class PasteLabConstants
     {

--- a/PowerPointLabs/PowerPointLabs/PasteLab/PasteToFillSlide.cs
+++ b/PowerPointLabs/PowerPointLabs/PasteLab/PasteToFillSlide.cs
@@ -1,10 +1,7 @@
-﻿using System.Drawing;
-using System.IO;
-
+﻿
 using Microsoft.Office.Interop.PowerPoint;
 
 using PowerPointLabs.Models;
-using PowerPointLabs.TextCollection;
 using PowerPointLabs.Utils;
 
 namespace PowerPointLabs.PasteLab

--- a/PowerPointLabs/PowerPointLabs/PasteLab/ReplaceWithClipboard.cs
+++ b/PowerPointLabs/PowerPointLabs/PasteLab/ReplaceWithClipboard.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 using Microsoft.Office.Interop.PowerPoint;
 

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Model/ImageItem.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Model/ImageItem.cs
@@ -1,4 +1,5 @@
 ﻿using System.Windows;
+
 using PowerPointLabs.PictureSlidesLab.Util;
 
 namespace PowerPointLabs.PictureSlidesLab.Model

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Model/Settings.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Model/Settings.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel;
+
 using PowerPointLabs.PictureSlidesLab.Service.Effect;
 
 namespace PowerPointLabs.PictureSlidesLab.Model

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Model/StyleOption.Partial/StyleOption.BannerStyle.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Model/StyleOption.Partial/StyleOption.BannerStyle.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel;
+
 using PowerPointLabs.PictureSlidesLab.Service.Effect;
 
 namespace PowerPointLabs.PictureSlidesLab.Model

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Model/StyleOption.Partial/StyleOption.PictureCitation.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Model/StyleOption.Partial/StyleOption.PictureCitation.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel;
+
 using PowerPointLabs.PictureSlidesLab.Service.Effect;
 
 namespace PowerPointLabs.PictureSlidesLab.Model

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Model/StyleOption.Partial/StyleOption.SpecialEffects.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Model/StyleOption.Partial/StyleOption.SpecialEffects.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel;
+
 using ImageProcessor.Imaging.Filters;
 
 namespace PowerPointLabs.PictureSlidesLab.Model

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Model/StyleOption.Partial/StyleOption.Text.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Model/StyleOption.Partial/StyleOption.Text.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel;
+
 using PowerPointLabs.PictureSlidesLab.Service.Effect;
 
 namespace PowerPointLabs.PictureSlidesLab.Model

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Model/StyleOption.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Model/StyleOption.cs
@@ -2,6 +2,7 @@
 using System.ComponentModel;
 using System.IO;
 using System.Xml.Serialization;
+
 using PowerPointLabs.ActionFramework.Common.Log;
 
 namespace PowerPointLabs.PictureSlidesLab.Model

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/ModelFactory/Options/BaseStyleOptions.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/ModelFactory/Options/BaseStyleOptions.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+
 using PowerPointLabs.PictureSlidesLab.Model;
 using PowerPointLabs.PictureSlidesLab.ModelFactory.Options.Interface;
 

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/ModelFactory/Options/Interface/IStyleOptions.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/ModelFactory/Options/Interface/IStyleOptions.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+
 using PowerPointLabs.PictureSlidesLab.Model;
 
 namespace PowerPointLabs.PictureSlidesLab.ModelFactory.Options.Interface

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/ModelFactory/StyleOptionsFactory.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/ModelFactory/StyleOptionsFactory.cs
@@ -4,6 +4,7 @@ using System.ComponentModel.Composition;
 using System.ComponentModel.Composition.Hosting;
 using System.Linq;
 using System.Reflection;
+
 using PowerPointLabs.PictureSlidesLab.Model;
 using PowerPointLabs.PictureSlidesLab.ModelFactory.Options.Interface;
 

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/ModelFactory/StyleVariantsFactory.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/ModelFactory/StyleVariantsFactory.cs
@@ -4,6 +4,7 @@ using System.ComponentModel.Composition;
 using System.ComponentModel.Composition.Hosting;
 using System.Linq;
 using System.Reflection;
+
 using PowerPointLabs.PictureSlidesLab.Model;
 using PowerPointLabs.PictureSlidesLab.ModelFactory.Variants.Interface;
 

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/ModelFactory/VariantWorker/Interface/IVariantWorker.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/ModelFactory/VariantWorker/Interface/IVariantWorker.cs
@@ -1,5 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
+
 using PowerPointLabs.PictureSlidesLab.Model;
 
 namespace PowerPointLabs.PictureSlidesLab.ModelFactory.VariantWorker.Interface

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/ModelFactory/VariantWorker/TextBoxTransparencyVariantWorker.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/ModelFactory/VariantWorker/TextBoxTransparencyVariantWorker.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿using System.Collections.Generic;
 
 using PowerPointLabs.PictureSlidesLab.Model;
 using PowerPointLabs.PictureSlidesLab.ModelFactory.VariantWorker.Interface;

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/ModelFactory/Variants/BaseStyleVariants.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/ModelFactory/Variants/BaseStyleVariants.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.Linq;
+
 using PowerPointLabs.PictureSlidesLab.Model;
 using PowerPointLabs.PictureSlidesLab.ModelFactory.Variants.Interface;
 using PowerPointLabs.PictureSlidesLab.ModelFactory.VariantWorker.Interface;

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/ModelFactory/Variants/Interface/IStyleVariants.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/ModelFactory/Variants/Interface/IStyleVariants.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+
 using PowerPointLabs.PictureSlidesLab.Model;
 
 namespace PowerPointLabs.PictureSlidesLab.ModelFactory.Variants.Interface

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/Effect/TextBoxes.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/Effect/TextBoxes.cs
@@ -1,7 +1,9 @@
 ﻿using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+
 using Microsoft.Office.Core;
+
 using PowerPointLabs.Utils;
 
 using Shape = Microsoft.Office.Interop.PowerPoint.Shape;

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/EffectsDesigner.Partial/EffectsDesigner.AlbumFrame.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/EffectsDesigner.Partial/EffectsDesigner.AlbumFrame.cs
@@ -1,6 +1,8 @@
 ﻿using Microsoft.Office.Core;
+
 using PowerPointLabs.PictureSlidesLab.Service.Effect;
 using PowerPointLabs.Utils;
+
 using PowerPoint = Microsoft.Office.Interop.PowerPoint;
 
 namespace PowerPointLabs.PictureSlidesLab.Service

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/EffectsDesigner.Partial/EffectsDesigner.Background.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/EffectsDesigner.Partial/EffectsDesigner.Background.cs
@@ -1,5 +1,7 @@
 ﻿using Microsoft.Office.Core;
+
 using PowerPointLabs.PictureSlidesLab.Service.Effect;
+
 using PowerPoint = Microsoft.Office.Interop.PowerPoint;
 
 namespace PowerPointLabs.PictureSlidesLab.Service

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/EffectsDesigner.Partial/EffectsDesigner.Blur.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/EffectsDesigner.Partial/EffectsDesigner.Blur.cs
@@ -1,7 +1,10 @@
 ﻿using System;
 using System.Drawing;
+
 using ImageProcessor;
+
 using PowerPointLabs.PictureSlidesLab.Service.Effect;
+
 using PowerPoint = Microsoft.Office.Interop.PowerPoint;
 
 namespace PowerPointLabs.PictureSlidesLab.Service

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/EffectsDesigner.Partial/EffectsDesigner.CircleBanner.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/EffectsDesigner.Partial/EffectsDesigner.CircleBanner.cs
@@ -1,7 +1,10 @@
 ﻿using System;
+
 using Microsoft.Office.Core;
+
 using PowerPointLabs.PictureSlidesLab.Service.Effect;
 using PowerPointLabs.Utils;
+
 using PowerPoint = Microsoft.Office.Interop.PowerPoint;
 
 namespace PowerPointLabs.PictureSlidesLab.Service

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/EffectsDesigner.Partial/EffectsDesigner.Common.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/EffectsDesigner.Partial/EffectsDesigner.Common.cs
@@ -1,8 +1,11 @@
 ﻿using System;
+
 using Microsoft.Office.Core;
+
 using PowerPointLabs.ActionFramework.Common.Log;
 using PowerPointLabs.PictureSlidesLab.Service.Effect;
 using PowerPointLabs.PictureSlidesLab.Util;
+
 using PowerPoint = Microsoft.Office.Interop.PowerPoint;
 
 namespace PowerPointLabs.PictureSlidesLab.Service

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/EffectsDesigner.Partial/EffectsDesigner.EmbedStyleOption.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/EffectsDesigner.Partial/EffectsDesigner.EmbedStyleOption.cs
@@ -2,10 +2,13 @@
 using System.Collections.Generic;
 using System.Globalization;
 using System.Windows;
+
 using Microsoft.Office.Core;
+
 using PowerPointLabs.ActionFramework.Common.Log;
 using PowerPointLabs.PictureSlidesLab.Model;
 using PowerPointLabs.PictureSlidesLab.Service.Effect;
+
 using PowerPoint = Microsoft.Office.Interop.PowerPoint;
 
 namespace PowerPointLabs.PictureSlidesLab.Service

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/EffectsDesigner.Partial/EffectsDesigner.FrostedGlass.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/EffectsDesigner.Partial/EffectsDesigner.FrostedGlass.cs
@@ -1,7 +1,8 @@
 ﻿using Microsoft.Office.Core;
+
 using PowerPointLabs.PictureSlidesLab.Service.Effect;
-using PowerPointLabs.PictureSlidesLab.Util;
 using PowerPointLabs.Utils;
+
 using Shape = Microsoft.Office.Interop.PowerPoint.Shape;
 
 namespace PowerPointLabs.PictureSlidesLab.Service

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/EffectsDesigner.Partial/EffectsDesigner.Outline.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/EffectsDesigner.Partial/EffectsDesigner.Outline.cs
@@ -1,5 +1,7 @@
 ﻿using Microsoft.Office.Core;
+
 using PowerPointLabs.PictureSlidesLab.Service.Effect;
+
 using PowerPoint = Microsoft.Office.Interop.PowerPoint;
 
 namespace PowerPointLabs.PictureSlidesLab.Service

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/EffectsDesigner.Partial/EffectsDesigner.Overlay.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/EffectsDesigner.Partial/EffectsDesigner.Overlay.cs
@@ -1,6 +1,8 @@
 ﻿using Microsoft.Office.Core;
+
 using PowerPointLabs.PictureSlidesLab.Service.Effect;
 using PowerPointLabs.Utils;
+
 using PowerPoint = Microsoft.Office.Interop.PowerPoint;
 
 namespace PowerPointLabs.PictureSlidesLab.Service

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/EffectsDesigner.Partial/EffectsDesigner.PictureCitation.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/EffectsDesigner.Partial/EffectsDesigner.PictureCitation.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Text.RegularExpressions;
+
 using Microsoft.Office.Core;
+
 using PowerPointLabs.PictureSlidesLab.Service.Effect;
 using PowerPointLabs.Utils;
 

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/EffectsDesigner.Partial/EffectsDesigner.RectangleBanner.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/EffectsDesigner.Partial/EffectsDesigner.RectangleBanner.cs
@@ -1,5 +1,7 @@
 ﻿using Microsoft.Office.Core;
+
 using PowerPointLabs.PictureSlidesLab.Service.Effect;
+
 using PowerPoint = Microsoft.Office.Interop.PowerPoint;
 
 namespace PowerPointLabs.PictureSlidesLab.Service

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/EffectsDesigner.Partial/EffectsDesigner.SpecialEffects.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/EffectsDesigner.Partial/EffectsDesigner.SpecialEffects.cs
@@ -1,7 +1,10 @@
 ﻿using System.Drawing;
+
 using ImageProcessor;
 using ImageProcessor.Imaging.Filters;
+
 using PowerPointLabs.PictureSlidesLab.Service.Effect;
+
 using PowerPoint = Microsoft.Office.Interop.PowerPoint;
 
 namespace PowerPointLabs.PictureSlidesLab.Service

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/EffectsDesigner.Partial/EffectsDesigner.TextBox.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/EffectsDesigner.Partial/EffectsDesigner.TextBox.cs
@@ -1,6 +1,6 @@
 ﻿using Microsoft.Office.Core;
+
 using PowerPointLabs.PictureSlidesLab.Service.Effect;
-using PowerPointLabs.PictureSlidesLab.Util;
 using PowerPointLabs.Utils;
 
 namespace PowerPointLabs.PictureSlidesLab.Service

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/EffectsDesigner.Partial/EffectsDesigner.TriangleBanner.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/EffectsDesigner.Partial/EffectsDesigner.TriangleBanner.cs
@@ -1,6 +1,8 @@
 ﻿using Microsoft.Office.Core;
+
 using PowerPointLabs.PictureSlidesLab.Service.Effect;
 using PowerPointLabs.Utils;
+
 using PowerPoint = Microsoft.Office.Interop.PowerPoint;
 
 namespace PowerPointLabs.PictureSlidesLab.Service

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/Interface/IStylesDesigner.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/Interface/IStylesDesigner.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Office.Interop.PowerPoint;
+
 using PowerPointLabs.PictureSlidesLab.Model;
 using PowerPointLabs.PictureSlidesLab.Service.Preview;
 

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/PictureCitationSlide.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/PictureCitationSlide.cs
@@ -2,11 +2,14 @@
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Text;
+
 using Microsoft.Office.Core;
 using Microsoft.Office.Interop.PowerPoint;
+
 using PowerPointLabs.ActionFramework.Common.Log;
 using PowerPointLabs.Models;
 using PowerPointLabs.PictureSlidesLab.Service.Effect;
+
 using Shape = Microsoft.Office.Interop.PowerPoint.Shape;
 
 namespace PowerPointLabs.PictureSlidesLab.Service

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/StylesDesigner.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/StylesDesigner.cs
@@ -3,8 +3,10 @@ using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.ComponentModel.Composition.Hosting;
 using System.Reflection;
+
 using Microsoft.Office.Core;
 using Microsoft.Office.Interop.PowerPoint;
+
 using PowerPointLabs.ActionFramework.Common.Log;
 using PowerPointLabs.Models;
 using PowerPointLabs.PictureSlidesLab.Model;
@@ -12,6 +14,7 @@ using PowerPointLabs.PictureSlidesLab.Service.Interface;
 using PowerPointLabs.PictureSlidesLab.Service.Preview;
 using PowerPointLabs.PictureSlidesLab.Service.StylesWorker.Factory;
 using PowerPointLabs.PictureSlidesLab.Util;
+
 using Shape = Microsoft.Office.Interop.PowerPoint.Shape;
 
 namespace PowerPointLabs.PictureSlidesLab.Service

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/StylesWorker/BannerStyleWorker.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/StylesWorker/BannerStyleWorker.cs
@@ -1,6 +1,8 @@
 ﻿using System.Collections.Generic;
 using System.ComponentModel.Composition;
+
 using Microsoft.Office.Interop.PowerPoint;
+
 using PowerPointLabs.PictureSlidesLab.Model;
 using PowerPointLabs.PictureSlidesLab.Service.StylesWorker.Interface;
 

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/StylesWorker/BlurStyleWorker.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/StylesWorker/BlurStyleWorker.cs
@@ -1,6 +1,8 @@
 ﻿using System.Collections.Generic;
 using System.ComponentModel.Composition;
+
 using Microsoft.Office.Interop.PowerPoint;
+
 using PowerPointLabs.PictureSlidesLab.Model;
 using PowerPointLabs.PictureSlidesLab.Service.StylesWorker.Interface;
 

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/StylesWorker/CircleStyleWorker.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/StylesWorker/CircleStyleWorker.cs
@@ -1,6 +1,8 @@
 ﻿using System.Collections.Generic;
 using System.ComponentModel.Composition;
+
 using Microsoft.Office.Interop.PowerPoint;
+
 using PowerPointLabs.PictureSlidesLab.Model;
 using PowerPointLabs.PictureSlidesLab.Service.StylesWorker.Interface;
 

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/StylesWorker/Factory/StyleWorkerFactory.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/StylesWorker/Factory/StyleWorkerFactory.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.Linq;
+
 using PowerPointLabs.PictureSlidesLab.Service.StylesWorker.Interface;
 
 namespace PowerPointLabs.PictureSlidesLab.Service.StylesWorker.Factory

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/StylesWorker/FrameStyleWorker.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/StylesWorker/FrameStyleWorker.cs
@@ -1,6 +1,8 @@
 ﻿using System.Collections.Generic;
 using System.ComponentModel.Composition;
+
 using Microsoft.Office.Interop.PowerPoint;
+
 using PowerPointLabs.PictureSlidesLab.Model;
 using PowerPointLabs.PictureSlidesLab.Service.StylesWorker.Interface;
 

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/StylesWorker/FrostedGlassBannerStyleWorker.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/StylesWorker/FrostedGlassBannerStyleWorker.cs
@@ -1,6 +1,8 @@
 ﻿using System.Collections.Generic;
 using System.ComponentModel.Composition;
+
 using Microsoft.Office.Interop.PowerPoint;
+
 using PowerPointLabs.PictureSlidesLab.Model;
 using PowerPointLabs.PictureSlidesLab.Service.StylesWorker.Interface;
 

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/StylesWorker/FrostedGlassTextBoxStyleWorker.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/StylesWorker/FrostedGlassTextBoxStyleWorker.cs
@@ -1,6 +1,8 @@
 ﻿using System.Collections.Generic;
 using System.ComponentModel.Composition;
+
 using Microsoft.Office.Interop.PowerPoint;
+
 using PowerPointLabs.PictureSlidesLab.Model;
 using PowerPointLabs.PictureSlidesLab.Service.StylesWorker.Interface;
 

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/StylesWorker/Interface/IStyleWorker.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/StylesWorker/Interface/IStyleWorker.cs
@@ -1,5 +1,7 @@
 ﻿using System.Collections.Generic;
+
 using PowerPointLabs.PictureSlidesLab.Model;
+
 using PowerPoint = Microsoft.Office.Interop.PowerPoint;
 
 namespace PowerPointLabs.PictureSlidesLab.Service.StylesWorker.Interface

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/StylesWorker/OutlineStyleWorker.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/StylesWorker/OutlineStyleWorker.cs
@@ -1,6 +1,8 @@
 ﻿using System.Collections.Generic;
 using System.ComponentModel.Composition;
+
 using Microsoft.Office.Interop.PowerPoint;
+
 using PowerPointLabs.PictureSlidesLab.Model;
 using PowerPointLabs.PictureSlidesLab.Service.StylesWorker.Interface;
 

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/StylesWorker/OverlayStyleWorker.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/StylesWorker/OverlayStyleWorker.cs
@@ -1,6 +1,8 @@
 ﻿using System.Collections.Generic;
 using System.ComponentModel.Composition;
+
 using Microsoft.Office.Interop.PowerPoint;
+
 using PowerPointLabs.PictureSlidesLab.Model;
 using PowerPointLabs.PictureSlidesLab.Service.StylesWorker.Interface;
 

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/StylesWorker/PictureCitationStyleWorker.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/StylesWorker/PictureCitationStyleWorker.cs
@@ -1,6 +1,8 @@
 ﻿using System.Collections.Generic;
 using System.ComponentModel.Composition;
+
 using Microsoft.Office.Interop.PowerPoint;
+
 using PowerPointLabs.PictureSlidesLab.Model;
 using PowerPointLabs.PictureSlidesLab.Service.StylesWorker.Interface;
 

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/StylesWorker/StyleEmbeddingWorker.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/StylesWorker/StyleEmbeddingWorker.cs
@@ -1,6 +1,8 @@
 ﻿using System.Collections.Generic;
 using System.ComponentModel.Composition;
+
 using Microsoft.Office.Interop.PowerPoint;
+
 using PowerPointLabs.PictureSlidesLab.Model;
 using PowerPointLabs.PictureSlidesLab.Service.StylesWorker.Interface;
 

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/StylesWorker/TextBoxStyleWorker.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/StylesWorker/TextBoxStyleWorker.cs
@@ -1,6 +1,8 @@
 ﻿using System.Collections.Generic;
 using System.ComponentModel.Composition;
+
 using Microsoft.Office.Interop.PowerPoint;
+
 using PowerPointLabs.PictureSlidesLab.Model;
 using PowerPointLabs.PictureSlidesLab.Service.StylesWorker.Interface;
 

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/StylesWorker/TriangleStyleWorker.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Service/StylesWorker/TriangleStyleWorker.cs
@@ -1,6 +1,8 @@
 ﻿using System.Collections.Generic;
 using System.ComponentModel.Composition;
+
 using Microsoft.Office.Interop.PowerPoint;
+
 using PowerPointLabs.PictureSlidesLab.Model;
 using PowerPointLabs.PictureSlidesLab.Service.StylesWorker.Interface;
 

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Thread/ThreadContext.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Thread/ThreadContext.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Windows.Threading;
+
 using PowerPointLabs.PictureSlidesLab.Thread.Interface;
 
 namespace PowerPointLabs.PictureSlidesLab.Thread

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Util/ImageUtil.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Util/ImageUtil.cs
@@ -2,6 +2,7 @@
 using System.Drawing;
 using System.IO;
 using System.Windows.Media.Imaging;
+
 using ImageProcessor;
 
 namespace PowerPointLabs.PictureSlidesLab.Util

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Util/ShapeUtil.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Util/ShapeUtil.cs
@@ -1,7 +1,10 @@
 ﻿using System;
+
 using Microsoft.Office.Core;
+
 using PowerPointLabs.PictureSlidesLab.Service.Effect;
 using PowerPointLabs.Utils;
+
 using PowerPoint = Microsoft.Office.Interop.PowerPoint;
 
 namespace PowerPointLabs.PictureSlidesLab.Util

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Util/StoragePath.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Util/StoragePath.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
 using System.Xml.Serialization;
+
 using PowerPointLabs.ActionFramework.Common.Log;
 using PowerPointLabs.PictureSlidesLab.Model;
 using PowerPointLabs.Properties;

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Util/TempPath.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Util/TempPath.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+
 using PowerPointLabs.Views;
 
 namespace PowerPointLabs.PictureSlidesLab.Util

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Util/UrlUtil.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Util/UrlUtil.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Text.RegularExpressions;
+
 using PowerPointLabs.PictureSlidesLab.Model;
+
 using RestSharp.Contrib;
 
 namespace PowerPointLabs.PictureSlidesLab.Util

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/ViewModel/SliderPropHandler/BlurrinessSliderPropHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/ViewModel/SliderPropHandler/BlurrinessSliderPropHandler.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel.Composition;
+
 using PowerPointLabs.PictureSlidesLab.Model;
 using PowerPointLabs.PictureSlidesLab.ViewModel.SliderPropHandler.Interface;
 

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/ViewModel/SliderPropHandler/BrightnessSliderPropHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/ViewModel/SliderPropHandler/BrightnessSliderPropHandler.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel.Composition;
+
 using PowerPointLabs.PictureSlidesLab.Model;
 using PowerPointLabs.PictureSlidesLab.ViewModel.SliderPropHandler.Interface;
 

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/ViewModel/SliderPropHandler/TransparencySliderPropHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/ViewModel/SliderPropHandler/TransparencySliderPropHandler.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel.Composition;
+
 using PowerPointLabs.PictureSlidesLab.Model;
 using PowerPointLabs.PictureSlidesLab.ViewModel.SliderPropHandler.Interface;
 

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Views/Interface/IPictureSlidesLabWindowView.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Views/Interface/IPictureSlidesLabWindowView.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Threading.Tasks;
 using System.Windows.Media;
+
 using MahApps.Metro.Controls.Dialogs;
+
 using PowerPointLabs.PictureSlidesLab.Model;
 using PowerPointLabs.PictureSlidesLab.Thread.Interface;
 

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Views/PictureSlidesLabWindow.xaml.ErrorDialog.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Views/PictureSlidesLabWindow.xaml.ErrorDialog.cs
@@ -1,5 +1,7 @@
 ﻿using System.Reflection;
+
 using MahApps.Metro.Controls.Dialogs;
+
 using PowerPointLabs.ActionFramework.Common.Log;
 
 namespace PowerPointLabs.PictureSlidesLab.Views

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Views/PictureSlidesLabWindow.xaml.GotoSlide.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Views/PictureSlidesLabWindow.xaml.GotoSlide.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Reflection;
 using System.Windows;
+
 using MahApps.Metro.Controls.Dialogs;
+
 using PowerPointLabs.ActionFramework.Common.Extension;
 using PowerPointLabs.ActionFramework.Common.Log;
 

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Views/QuickDropDialog.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Views/QuickDropDialog.xaml.cs
@@ -1,7 +1,9 @@
 ﻿using System.ComponentModel;
 using System.Windows;
 using System.Windows.Input;
+
 using MahApps.Metro.Controls;
+
 using PowerPointLabs.PictureSlidesLab.Util;
 
 namespace PowerPointLabs.PictureSlidesLab.Views

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Views/SettingsFlyout.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Views/SettingsFlyout.xaml.cs
@@ -4,8 +4,10 @@ using System.Windows.Controls;
 using System.Windows.Forms;
 using System.Windows.Input;
 using System.Windows.Media;
+
 using PowerPointLabs.PictureSlidesLab.Model;
 using PowerPointLabs.Utils;
+
 using Color = System.Drawing.Color;
 
 namespace PowerPointLabs.PictureSlidesLab.Views

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Views/SlideSelectionDialog.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Views/SlideSelectionDialog.xaml.cs
@@ -3,6 +3,7 @@ using System.Collections.ObjectModel;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
+
 using PowerPointLabs.ActionFramework.Common.Extension;
 using PowerPointLabs.Models;
 using PowerPointLabs.PictureSlidesLab.Model;

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Views/TextBlockDialog.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Views/TextBlockDialog.xaml.cs
@@ -1,4 +1,5 @@
 ﻿using System.Windows;
+
 using PowerPointLabs.WPF.Observable;
 
 namespace PowerPointLabs.PictureSlidesLab.Views

--- a/PowerPointLabs/PowerPointLabs/PositionsLab/PositionShapeProperties.cs
+++ b/PowerPointLabs/PowerPointLabs/PositionsLab/PositionShapeProperties.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using Microsoft.Office.Core;
+﻿using Microsoft.Office.Core;
 
 namespace PowerPointLabs.PositionsLab
 {

--- a/PowerPointLabs/PowerPointLabs/PositionsLab/Views/ReorderSettingsDialog.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/PositionsLab/Views/ReorderSettingsDialog.xaml.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Windows;
+﻿using System.Windows;
 
 namespace PowerPointLabs.PositionsLab.Views
 {

--- a/PowerPointLabs/PowerPointLabs/Properties/AssemblyInfo.cs
+++ b/PowerPointLabs/PowerPointLabs/Properties/AssemblyInfo.cs
@@ -1,7 +1,6 @@
 ﻿using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using System.Security;
 
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information

--- a/PowerPointLabs/PowerPointLabs/Properties/Resources.Designer.cs
+++ b/PowerPointLabs/PowerPointLabs/Properties/Resources.Designer.cs
@@ -8,10 +8,10 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-namespace PowerPointLabs.Properties {
-    using System;
-    
-    
+namespace PowerPointLabs.Properties
+{
+
+
     /// <summary>
     ///   A strongly-typed resource class, for looking up localized strings, etc.
     /// </summary>

--- a/PowerPointLabs/PowerPointLabs/Properties/Settings.Designer.cs
+++ b/PowerPointLabs/PowerPointLabs/Properties/Settings.Designer.cs
@@ -8,9 +8,10 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-namespace PowerPointLabs.Properties {
-    
-    
+namespace PowerPointLabs.Properties
+{
+
+
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "14.0.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {

--- a/PowerPointLabs/PowerPointLabs/ResizeLab/IResizeLabPane.cs
+++ b/PowerPointLabs/PowerPointLabs/ResizeLab/IResizeLabPane.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+
 using PowerPoint = Microsoft.Office.Interop.PowerPoint;
 
 namespace PowerPointLabs.ResizeLab

--- a/PowerPointLabs/PowerPointLabs/ResizeLab/ResizeLabMain.AdjustProportionally.cs
+++ b/PowerPointLabs/PowerPointLabs/ResizeLab/ResizeLabMain.AdjustProportionally.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 
 using Microsoft.Office.Core;
+
 using PowerPointLabs.ActionFramework.Common.Log;
 using PowerPointLabs.Utils;
 

--- a/PowerPointLabs/PowerPointLabs/ResizeLab/ResizeLabMain.Equalize.cs
+++ b/PowerPointLabs/PowerPointLabs/ResizeLab/ResizeLabMain.Equalize.cs
@@ -1,8 +1,11 @@
 ﻿using System;
 using System.Drawing;
+
 using Microsoft.Office.Core;
+
 using PowerPointLabs.ActionFramework.Common.Log;
 using PowerPointLabs.Utils;
+
 using PowerPoint = Microsoft.Office.Interop.PowerPoint;
 
 namespace PowerPointLabs.ResizeLab

--- a/PowerPointLabs/PowerPointLabs/ResizeLab/ResizeLabMain.FitToSlide.cs
+++ b/PowerPointLabs/PowerPointLabs/ResizeLab/ResizeLabMain.FitToSlide.cs
@@ -1,6 +1,8 @@
 ﻿using System;
+
 using PowerPointLabs.ActionFramework.Common.Log;
 using PowerPointLabs.Utils;
+
 using PowerPoint = Microsoft.Office.Interop.PowerPoint;
 
 namespace PowerPointLabs.ResizeLab

--- a/PowerPointLabs/PowerPointLabs/ResizeLab/ResizeLabMain.MainSettings.cs
+++ b/PowerPointLabs/PowerPointLabs/ResizeLab/ResizeLabMain.MainSettings.cs
@@ -1,9 +1,11 @@
 ﻿using System;
 using System.Drawing;
-using System.Security.Cryptography.X509Certificates;
+
 using Microsoft.Office.Core;
+
 using PowerPointLabs.ActionFramework.Common.Log;
 using PowerPointLabs.Utils;
+
 using PowerPoint = Microsoft.Office.Interop.PowerPoint;
 
 namespace PowerPointLabs.ResizeLab

--- a/PowerPointLabs/PowerPointLabs/ResizeLab/ResizeLabMain.Match.cs
+++ b/PowerPointLabs/PowerPointLabs/ResizeLab/ResizeLabMain.Match.cs
@@ -1,7 +1,10 @@
 ﻿using System;
+
 using Microsoft.Office.Core;
+
 using PowerPointLabs.ActionFramework.Common.Log;
 using PowerPointLabs.Utils;
+
 using PowerPoint = Microsoft.Office.Interop.PowerPoint;
 
 namespace PowerPointLabs.ResizeLab

--- a/PowerPointLabs/PowerPointLabs/ResizeLab/ResizeLabMain.SlightAdjust.cs
+++ b/PowerPointLabs/PowerPointLabs/ResizeLab/ResizeLabMain.SlightAdjust.cs
@@ -1,6 +1,8 @@
 ﻿using System;
+
 using PowerPointLabs.ActionFramework.Common.Log;
 using PowerPointLabs.Utils;
+
 using PowerPoint = Microsoft.Office.Interop.PowerPoint;
 
 namespace PowerPointLabs.ResizeLab

--- a/PowerPointLabs/PowerPointLabs/ResizeLab/ResizeLabMain.cs
+++ b/PowerPointLabs/PowerPointLabs/ResizeLab/ResizeLabMain.cs
@@ -1,6 +1,5 @@
-﻿using System;
-using System.Runtime.Remoting.Channels;
-using PowerPointLabs.Utils;
+﻿using PowerPointLabs.Utils;
+
 using PowerPoint = Microsoft.Office.Interop.PowerPoint;
 
 namespace PowerPointLabs.ResizeLab

--- a/PowerPointLabs/PowerPointLabs/ResizeLab/Symmetric.cs
+++ b/PowerPointLabs/PowerPointLabs/ResizeLab/Symmetric.cs
@@ -1,7 +1,10 @@
 ﻿using System;
+
 using Microsoft.Office.Core;
+
 using PowerPointLabs.ActionFramework.Common.Log;
 using PowerPointLabs.Utils;
+
 using PowerPoint = Microsoft.Office.Interop.PowerPoint;
 
 namespace PowerPointLabs.ResizeLab

--- a/PowerPointLabs/PowerPointLabs/SaveLab/SaveLabMain.cs
+++ b/PowerPointLabs/PowerPointLabs/SaveLab/SaveLabMain.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text;
+﻿using System.Collections.Generic;
 using System.Windows.Forms;
 
 using Microsoft.Office.Interop.PowerPoint;

--- a/PowerPointLabs/PowerPointLabs/SaveLab/SaveLabSettings.cs
+++ b/PowerPointLabs/PowerPointLabs/SaveLab/SaveLabSettings.cs
@@ -1,5 +1,4 @@
-﻿using System.Drawing;
-using System.IO;
+﻿using System.IO;
 
 using PowerPointLabs.SaveLab.Views;
 

--- a/PowerPointLabs/PowerPointLabs/SaveLab/Views/SaveLabSettingsDialogBox.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/SaveLab/Views/SaveLabSettingsDialogBox.xaml.cs
@@ -5,7 +5,6 @@ using System.Windows.Interop;
 using System.Windows.Media.Imaging;
 
 using PowerPointLabs.TextCollection;
-using PowerPointLabs.Utils;
 using PowerPointLabs.Views;
 
 using Forms = System.Windows.Forms;

--- a/PowerPointLabs/PowerPointLabs/Settings.cs
+++ b/PowerPointLabs/PowerPointLabs/Settings.cs
@@ -1,7 +1,7 @@
 ﻿namespace PowerPointLabs.Properties
 {
-    
-    
+
+
     // This class allows you to handle specific events on the settings class:
     //  The SettingChanging event is raised before a setting's value is changed.
     //  The PropertyChanged event is raised after a setting's value is changed.

--- a/PowerPointLabs/PowerPointLabs/ShapesLab/ShapesLabConfigSaveFile.cs
+++ b/PowerPointLabs/PowerPointLabs/ShapesLab/ShapesLabConfigSaveFile.cs
@@ -1,10 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text;
+
 using PowerPointLabs.FunctionalTestInterface.Impl;
-using PowerPointLabs.Models;
 using PowerPointLabs.Utils;
 
 namespace PowerPointLabs.ShapesLab

--- a/PowerPointLabs/PowerPointLabs/ShortcutsLab/FillSlide.cs
+++ b/PowerPointLabs/PowerPointLabs/ShortcutsLab/FillSlide.cs
@@ -1,12 +1,6 @@
-﻿using System;
-using System.Windows.Forms;
-
-using PowerPointLabs.ActionFramework.Common.Log;
-using PowerPointLabs.Models;
-using PowerPointLabs.TextCollection;
+﻿using PowerPointLabs.Models;
 using PowerPointLabs.Utils;
 
-using Office = Microsoft.Office.Core;
 using PowerPoint = Microsoft.Office.Interop.PowerPoint;
 
 namespace PowerPointLabs.ShortcutsLab

--- a/PowerPointLabs/PowerPointLabs/SpeechEngine/TextToSpeech.cs
+++ b/PowerPointLabs/PowerPointLabs/SpeechEngine/TextToSpeech.cs
@@ -1,9 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Security.Cryptography;
 using System.Speech.Synthesis;
-using System.Text;
+
 using PowerPointLabs.Models;
 
 namespace PowerPointLabs.SpeechEngine

--- a/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/ArtisticEffectFormat.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/ArtisticEffectFormat.cs
@@ -1,11 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Drawing;
+
 using Microsoft.Office.Core;
+
 using PowerPointLabs.ActionFramework.Common.Log;
 using PowerPointLabs.Utils;
+
 using Shape = Microsoft.Office.Interop.PowerPoint.Shape;
-using Shapes = Microsoft.Office.Interop.PowerPoint.Shapes;
 
 namespace PowerPointLabs.SyncLab.ObjectFormats
 {

--- a/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/BevelBottomFormat.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/BevelBottomFormat.cs
@@ -1,9 +1,10 @@
-﻿using System.ComponentModel.Design;
-using System.Drawing;
-using System.Windows.Forms.VisualStyles;
+﻿using System.Drawing;
+
 using Microsoft.Office.Core;
+
 using PowerPointLabs.ActionFramework.Common.Log;
 using PowerPointLabs.Utils;
+
 using Shape = Microsoft.Office.Interop.PowerPoint.Shape;
 using Shapes = Microsoft.Office.Interop.PowerPoint.Shapes;
 using ThreeDFormat = Microsoft.Office.Interop.PowerPoint.ThreeDFormat;

--- a/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/BevelTopFormat.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/BevelTopFormat.cs
@@ -1,10 +1,10 @@
-﻿using System;
-using System.ComponentModel.Design;
-using System.Drawing;
-using System.Windows.Forms.VisualStyles;
+﻿using System.Drawing;
+
 using Microsoft.Office.Core;
+
 using PowerPointLabs.ActionFramework.Common.Log;
 using PowerPointLabs.Utils;
+
 using Shape = Microsoft.Office.Interop.PowerPoint.Shape;
 using Shapes = Microsoft.Office.Interop.PowerPoint.Shapes;
 using ThreeDFormat = Microsoft.Office.Interop.PowerPoint.ThreeDFormat;

--- a/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/ContourColorFormat.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/ContourColorFormat.cs
@@ -1,7 +1,10 @@
 ﻿using System.Drawing;
+
 using Microsoft.Office.Core;
+
 using PowerPointLabs.ActionFramework.Common.Log;
 using PowerPointLabs.Utils;
+
 using Shape = Microsoft.Office.Interop.PowerPoint.Shape;
 using Shapes = Microsoft.Office.Interop.PowerPoint.Shapes;
 using ThreeDFormat = Microsoft.Office.Interop.PowerPoint.ThreeDFormat;

--- a/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/ContourWidthFormat.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/ContourWidthFormat.cs
@@ -1,8 +1,8 @@
 ﻿using System;
 using System.Drawing;
-using Microsoft.Office.Core;
+
 using PowerPointLabs.ActionFramework.Common.Log;
-using PowerPointLabs.Utils;
+
 using Shape = Microsoft.Office.Interop.PowerPoint.Shape;
 using ThreeDFormat = Microsoft.Office.Interop.PowerPoint.ThreeDFormat;
 

--- a/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/DepthColorFormat.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/DepthColorFormat.cs
@@ -1,9 +1,10 @@
-﻿using System;
-using System.ComponentModel.Design;
-using System.Drawing;
+﻿using System.Drawing;
+
 using Microsoft.Office.Core;
+
 using PowerPointLabs.ActionFramework.Common.Log;
 using PowerPointLabs.Utils;
+
 using Shape = Microsoft.Office.Interop.PowerPoint.Shape;
 using Shapes = Microsoft.Office.Interop.PowerPoint.Shapes;
 using ThreeDFormat = Microsoft.Office.Interop.PowerPoint.ThreeDFormat;

--- a/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/DepthSizeFormat.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/DepthSizeFormat.cs
@@ -1,9 +1,10 @@
 ﻿using System;
-using System.ComponentModel.Design;
 using System.Drawing;
+
 using Microsoft.Office.Core;
+
 using PowerPointLabs.ActionFramework.Common.Log;
-using PowerPointLabs.Utils;
+
 using Shape = Microsoft.Office.Interop.PowerPoint.Shape;
 using ThreeDFormat = Microsoft.Office.Interop.PowerPoint.ThreeDFormat;
 

--- a/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/FillFormat.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/FillFormat.cs
@@ -2,6 +2,7 @@
 using System.Drawing;
 
 using Microsoft.Office.Interop.PowerPoint;
+
 using PowerPointLabs.ActionFramework.Common.Log;
 using PowerPointLabs.Utils;
 

--- a/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/FillTransparencyFormat.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/FillTransparencyFormat.cs
@@ -2,9 +2,8 @@
 using System.Drawing;
 
 using Microsoft.Office.Interop.PowerPoint;
-using PowerPointLabs.ActionFramework.Common.Log;
 
-using Graphics = PowerPointLabs.Utils.GraphicsUtil;
+using PowerPointLabs.ActionFramework.Common.Log;
 
 namespace PowerPointLabs.SyncLab.ObjectFormats
 {

--- a/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/FontColorFormat.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/FontColorFormat.cs
@@ -1,8 +1,11 @@
 ﻿using System;
 using System.Drawing;
+
 using Microsoft.Office.Core;
+
 using PowerPointLabs.ActionFramework.Common.Log;
 using PowerPointLabs.Utils;
+
 using Shape = Microsoft.Office.Interop.PowerPoint.Shape;
 using Shapes = Microsoft.Office.Interop.PowerPoint.Shapes;
 

--- a/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/FontFormat.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/FontFormat.cs
@@ -2,6 +2,7 @@
 using System.Drawing;
 
 using Microsoft.Office.Interop.PowerPoint;
+
 using PowerPointLabs.ActionFramework.Common.Log;
 
 namespace PowerPointLabs.SyncLab.ObjectFormats

--- a/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/FontSizeFormat.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/FontSizeFormat.cs
@@ -2,6 +2,7 @@
 using System.Drawing;
 
 using Microsoft.Office.Interop.PowerPoint;
+
 using PowerPointLabs.ActionFramework.Common.Log;
 
 namespace PowerPointLabs.SyncLab.ObjectFormats

--- a/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/FontStyleFormat.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/FontStyleFormat.cs
@@ -2,6 +2,7 @@
 using System.Drawing;
 
 using Microsoft.Office.Interop.PowerPoint;
+
 using PowerPointLabs.ActionFramework.Common.Log;
 
 namespace PowerPointLabs.SyncLab.ObjectFormats

--- a/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/Format.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/Format.cs
@@ -1,4 +1,5 @@
 ﻿using System.Drawing;
+
 using Microsoft.Office.Interop.PowerPoint;
 
 namespace PowerPointLabs.SyncLab.ObjectFormats

--- a/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/GlowColorFormat.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/GlowColorFormat.cs
@@ -1,8 +1,11 @@
 ﻿using System;
 using System.Drawing;
+
 using Microsoft.Office.Core;
+
 using PowerPointLabs.ActionFramework.Common.Log;
 using PowerPointLabs.Utils;
+
 using Shape = Microsoft.Office.Interop.PowerPoint.Shape;
 using Shapes = Microsoft.Office.Interop.PowerPoint.Shapes;
 

--- a/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/GlowSizeFormat.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/GlowSizeFormat.cs
@@ -1,10 +1,11 @@
 ﻿using System;
 using System.Drawing;
+
 using Microsoft.Office.Core;
+
 using PowerPointLabs.ActionFramework.Common.Log;
-using PowerPointLabs.Utils;
+
 using Shape = Microsoft.Office.Interop.PowerPoint.Shape;
-using Shapes = Microsoft.Office.Interop.PowerPoint.Shapes;
 
 namespace PowerPointLabs.SyncLab.ObjectFormats
 {

--- a/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/GlowTransparencyFormat.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/GlowTransparencyFormat.cs
@@ -1,10 +1,11 @@
 ﻿using System;
 using System.Drawing;
+
 using Microsoft.Office.Core;
+
 using PowerPointLabs.ActionFramework.Common.Log;
-using PowerPointLabs.Utils;
+
 using Shape = Microsoft.Office.Interop.PowerPoint.Shape;
-using Shapes = Microsoft.Office.Interop.PowerPoint.Shapes;
 
 namespace PowerPointLabs.SyncLab.ObjectFormats
 {

--- a/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/LightingAngleFormat.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/LightingAngleFormat.cs
@@ -1,10 +1,7 @@
-﻿using System;
-using System.ComponentModel.Design;
-using System.Drawing;
-using System.Text.RegularExpressions;
-using Microsoft.Office.Core;
+﻿using System.Drawing;
+
 using PowerPointLabs.ActionFramework.Common.Log;
-using PowerPointLabs.Utils;
+
 using Shape = Microsoft.Office.Interop.PowerPoint.Shape;
 using ThreeDFormat = Microsoft.Office.Interop.PowerPoint.ThreeDFormat;
 

--- a/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/LightingEffectFormat.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/LightingEffectFormat.cs
@@ -1,7 +1,10 @@
 ﻿using System.Drawing;
+
 using Microsoft.Office.Core;
+
 using PowerPointLabs.ActionFramework.Common.Log;
 using PowerPointLabs.Utils;
+
 using Shape = Microsoft.Office.Interop.PowerPoint.Shape;
 using Shapes = Microsoft.Office.Interop.PowerPoint.Shapes;
 using ThreeDFormat = Microsoft.Office.Interop.PowerPoint.ThreeDFormat;

--- a/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/LineArrowFormat.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/LineArrowFormat.cs
@@ -2,6 +2,7 @@
 using System.Drawing;
 
 using Microsoft.Office.Interop.PowerPoint;
+
 using PowerPointLabs.ActionFramework.Common.Log;
 using PowerPointLabs.Utils;
 

--- a/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/LineCompoundTypeFormat.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/LineCompoundTypeFormat.cs
@@ -2,6 +2,7 @@
 using System.Drawing;
 
 using Microsoft.Office.Interop.PowerPoint;
+
 using PowerPointLabs.ActionFramework.Common.Log;
 using PowerPointLabs.Utils;
 

--- a/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/LineDashTypeFormat.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/LineDashTypeFormat.cs
@@ -2,6 +2,7 @@
 using System.Drawing;
 
 using Microsoft.Office.Interop.PowerPoint;
+
 using PowerPointLabs.ActionFramework.Common.Log;
 using PowerPointLabs.Utils;
 

--- a/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/LineFillFormat.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/LineFillFormat.cs
@@ -2,6 +2,7 @@
 using System.Drawing;
 
 using Microsoft.Office.Interop.PowerPoint;
+
 using PowerPointLabs.ActionFramework.Common.Log;
 using PowerPointLabs.Utils;
 

--- a/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/LineTransparencyFormat.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/LineTransparencyFormat.cs
@@ -2,9 +2,8 @@
 using System.Drawing;
 
 using Microsoft.Office.Interop.PowerPoint;
-using PowerPointLabs.ActionFramework.Common.Log;
 
-using Graphics = PowerPointLabs.Utils.GraphicsUtil;
+using PowerPointLabs.ActionFramework.Common.Log;
 
 namespace PowerPointLabs.SyncLab.ObjectFormats
 {

--- a/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/LineWeightFormat.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/LineWeightFormat.cs
@@ -2,6 +2,7 @@
 using System.Drawing;
 
 using Microsoft.Office.Interop.PowerPoint;
+
 using PowerPointLabs.ActionFramework.Common.Log;
 
 namespace PowerPointLabs.SyncLab.ObjectFormats

--- a/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/MaterialEffectFormat.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/MaterialEffectFormat.cs
@@ -1,8 +1,10 @@
 ﻿using System.Drawing;
-using System.Xml;
+
 using Microsoft.Office.Core;
+
 using PowerPointLabs.ActionFramework.Common.Log;
 using PowerPointLabs.Utils;
+
 using Shape = Microsoft.Office.Interop.PowerPoint.Shape;
 using Shapes = Microsoft.Office.Interop.PowerPoint.Shapes;
 using ThreeDFormat = Microsoft.Office.Interop.PowerPoint.ThreeDFormat;

--- a/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/PositionHeightFormat.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/PositionHeightFormat.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Drawing;
+
 using Microsoft.Office.Core;
+
 using Shape = Microsoft.Office.Interop.PowerPoint.Shape;
 
 namespace PowerPointLabs.SyncLab.ObjectFormats

--- a/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/PositionWidthFormat.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/PositionWidthFormat.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Drawing;
+
 using Microsoft.Office.Core;
+
 using Shape = Microsoft.Office.Interop.PowerPoint.Shape;
 
 namespace PowerPointLabs.SyncLab.ObjectFormats

--- a/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/ReflectionBlurFormat.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/ReflectionBlurFormat.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using System.Drawing;
+
 using Microsoft.Office.Core;
+
 using PowerPointLabs.ActionFramework.Common.Log;
-using Graphics = PowerPointLabs.Utils.GraphicsUtil;
+
 using Shape = Microsoft.Office.Interop.PowerPoint.Shape;
 
 namespace PowerPointLabs.SyncLab.ObjectFormats

--- a/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/ReflectionDistanceFormat.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/ReflectionDistanceFormat.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using System.Drawing;
+
 using Microsoft.Office.Core;
+
 using PowerPointLabs.ActionFramework.Common.Log;
-using Graphics = PowerPointLabs.Utils.GraphicsUtil;
+
 using Shape = Microsoft.Office.Interop.PowerPoint.Shape;
 
 namespace PowerPointLabs.SyncLab.ObjectFormats

--- a/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/ReflectionSizeFormat.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/ReflectionSizeFormat.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using System.Drawing;
+
 using Microsoft.Office.Core;
+
 using PowerPointLabs.ActionFramework.Common.Log;
-using Graphics = PowerPointLabs.Utils.GraphicsUtil;
+
 using Shape = Microsoft.Office.Interop.PowerPoint.Shape;
 
 namespace PowerPointLabs.SyncLab.ObjectFormats

--- a/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/ReflectionTransparencyFormat.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/ReflectionTransparencyFormat.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using System.Drawing;
+
 using Microsoft.Office.Core;
+
 using PowerPointLabs.ActionFramework.Common.Log;
-using Graphics = PowerPointLabs.Utils.GraphicsUtil;
+
 using Shape = Microsoft.Office.Interop.PowerPoint.Shape;
 
 namespace PowerPointLabs.SyncLab.ObjectFormats

--- a/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/ShadowEffectFormat.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/ShadowEffectFormat.cs
@@ -1,9 +1,9 @@
-﻿using System;
-using System.Drawing;
-using System.Windows.Forms;
+﻿using System.Drawing;
+
 using Microsoft.Office.Core;
-using PowerPointLabs.TextCollection;
+
 using PowerPointLabs.Utils;
+
 using ShadowFormat = Microsoft.Office.Interop.PowerPoint.ShadowFormat;
 using Shape = Microsoft.Office.Interop.PowerPoint.Shape;
 

--- a/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/SoftEdgeEffectFormat.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/SoftEdgeEffectFormat.cs
@@ -1,11 +1,11 @@
 ﻿using System;
 using System.Drawing;
-using System.Speech.Recognition.SrgsGrammar;
+
 using Microsoft.Office.Core;
+
 using PowerPointLabs.ActionFramework.Common.Log;
-using PowerPointLabs.Utils;
+
 using Shape = Microsoft.Office.Interop.PowerPoint.Shape;
-using Shapes = Microsoft.Office.Interop.PowerPoint.Shapes;
 
 namespace PowerPointLabs.SyncLab.ObjectFormats
 {

--- a/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/ThreeDRotationEffectFormat.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/ObjectFormats/ThreeDRotationEffectFormat.cs
@@ -1,14 +1,12 @@
 ﻿using System;
-using System.CodeDom;
-using System.ComponentModel.Design;
 using System.Drawing;
-using System.Windows;
+
 using Microsoft.Office.Core;
+
 using PowerPointLabs.ActionFramework.Common.Log;
-using PowerPointLabs.EffectsLab;
 using PowerPointLabs.Utils;
+
 using Shape = Microsoft.Office.Interop.PowerPoint.Shape;
-using Shapes = Microsoft.Office.Interop.PowerPoint.Shapes;
 using ThreeDFormat = Microsoft.Office.Interop.PowerPoint.ThreeDFormat;
 
 namespace PowerPointLabs.SyncLab.ObjectFormats

--- a/PowerPointLabs/PowerPointLabs/SyncLab/SyncFormatConstants.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/SyncFormatConstants.cs
@@ -1,7 +1,10 @@
 ﻿using System.Collections.Generic;
 using System.Drawing;
+
 using Microsoft.Office.Core;
+
 using PowerPointLabs.SyncLab.Views;
+
 using Font = System.Drawing.Font;
 
 namespace PowerPointLabs.SyncLab.ObjectFormats

--- a/PowerPointLabs/PowerPointLabs/SyncLab/SyncFormatUtil.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/SyncFormatUtil.cs
@@ -1,11 +1,7 @@
 ﻿using System;
 using System.Drawing;
 using System.Drawing.Text;
-using Microsoft.Office.Core;
-using Microsoft.Office.Interop.PowerPoint;
-using PowerPointLabs.SyncLab.ObjectFormats;
-using Shape = Microsoft.Office.Interop.PowerPoint.Shape;
-using ShapeRange = Microsoft.Office.Interop.PowerPoint.ShapeRange;
+
 using Shapes = Microsoft.Office.Interop.PowerPoint.Shapes;
 
 namespace PowerPointLabs.SyncLab

--- a/PowerPointLabs/PowerPointLabs/SyncLab/SyncLabShapeStorage.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/SyncLabShapeStorage.cs
@@ -1,10 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
+
 using Microsoft.Office.Core;
+
 using PowerPointLabs.Models;
 using PowerPointLabs.SyncLab.ObjectFormats;
 using PowerPointLabs.TextCollection;
 using PowerPointLabs.Utils;
+
 using FillFormat = PowerPointLabs.SyncLab.ObjectFormats.FillFormat;
 using Shape = Microsoft.Office.Interop.PowerPoint.Shape;
 using Shapes = Microsoft.Office.Interop.PowerPoint.Shapes;

--- a/PowerPointLabs/PowerPointLabs/SyncLab/Views/FormatTreeNode.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/Views/FormatTreeNode.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+
 using PowerPointLabs.SyncLab.ObjectFormats;
 
 namespace PowerPointLabs.SyncLab.Views

--- a/PowerPointLabs/PowerPointLabs/SyncLab/Views/SyncFormatDialog.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/Views/SyncFormatDialog.xaml.cs
@@ -3,9 +3,10 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
-using Microsoft.Office.Core;
+
 using PowerPointLabs.SyncLab.ObjectFormats;
 using PowerPointLabs.TextCollection;
+
 using Shape = Microsoft.Office.Interop.PowerPoint.Shape;
 
 namespace PowerPointLabs.SyncLab.Views

--- a/PowerPointLabs/PowerPointLabs/SyncLab/Views/SyncFormatDialogItem.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/Views/SyncFormatDialogItem.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Windows;
+﻿using System.Windows;
 
 namespace PowerPointLabs.SyncLab.Views
 {

--- a/PowerPointLabs/PowerPointLabs/SyncLab/Views/SyncFormatListItem.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/Views/SyncFormatListItem.xaml.cs
@@ -1,18 +1,9 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Drawing;
-using System.Linq;
-using System.Text;
 using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
 using System.Windows.Interop;
-using System.Windows.Media;
 using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
 
 namespace PowerPointLabs.SyncLab.Views
 {

--- a/PowerPointLabs/PowerPointLabs/SyncLab/Views/SyncPaneWPF.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/Views/SyncPaneWPF.xaml.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media.Imaging;
+
 using Microsoft.Office.Core;
 using Microsoft.Office.Interop.PowerPoint;
 
@@ -10,6 +11,7 @@ using PowerPointLabs.ActionFramework.Common.Extension;
 using PowerPointLabs.SyncLab.ObjectFormats;
 using PowerPointLabs.TextCollection;
 using PowerPointLabs.Utils;
+
 using Shape = Microsoft.Office.Interop.PowerPoint.Shape;
 using ShapeRange = Microsoft.Office.Interop.PowerPoint.ShapeRange;
 

--- a/PowerPointLabs/PowerPointLabs/TagMatchers/EndSpeedTagMatcher.cs
+++ b/PowerPointLabs/PowerPointLabs/TagMatchers/EndSpeedTagMatcher.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Text.RegularExpressions;
+
 using PowerPointLabs.Tags;
 
 namespace PowerPointLabs.TagMatchers

--- a/PowerPointLabs/PowerPointLabs/TagMatchers/EndVoiceTagMatcher.cs
+++ b/PowerPointLabs/PowerPointLabs/TagMatchers/EndVoiceTagMatcher.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Text.RegularExpressions;
+
 using PowerPointLabs.Tags;
 
 namespace PowerPointLabs.TagMatchers

--- a/PowerPointLabs/PowerPointLabs/TagMatchers/ITagMatcher.cs
+++ b/PowerPointLabs/PowerPointLabs/TagMatchers/ITagMatcher.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
+
 using PowerPointLabs.Tags;
 
 namespace PowerPointLabs.TagMatchers

--- a/PowerPointLabs/PowerPointLabs/TagMatchers/NoEffectTagMatcher.cs
+++ b/PowerPointLabs/PowerPointLabs/TagMatchers/NoEffectTagMatcher.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Text.RegularExpressions;
+
 using PowerPointLabs.Tags;
 
 namespace PowerPointLabs.TagMatchers

--- a/PowerPointLabs/PowerPointLabs/TagMatchers/PauseTagMatcher.cs
+++ b/PowerPointLabs/PowerPointLabs/TagMatchers/PauseTagMatcher.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Text.RegularExpressions;
+
 using PowerPointLabs.Tags;
 
 namespace PowerPointLabs.TagMatchers

--- a/PowerPointLabs/PowerPointLabs/TagMatchers/PronounceTagMatcher.cs
+++ b/PowerPointLabs/PowerPointLabs/TagMatchers/PronounceTagMatcher.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Text.RegularExpressions;
+
 using PowerPointLabs.Tags;
 
 namespace PowerPointLabs.TagMatchers

--- a/PowerPointLabs/PowerPointLabs/TagMatchers/StartSpeedTagMatcher.cs
+++ b/PowerPointLabs/PowerPointLabs/TagMatchers/StartSpeedTagMatcher.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Text.RegularExpressions;
+
 using PowerPointLabs.Tags;
 
 namespace PowerPointLabs.TagMatchers

--- a/PowerPointLabs/PowerPointLabs/TagMatchers/StartVoiceTagMatcher.cs
+++ b/PowerPointLabs/PowerPointLabs/TagMatchers/StartVoiceTagMatcher.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
+
 using PowerPointLabs.Tags;
 
 namespace PowerPointLabs.TagMatchers

--- a/PowerPointLabs/PowerPointLabs/Tags/EndVoiceTag.cs
+++ b/PowerPointLabs/PowerPointLabs/Tags/EndVoiceTag.cs
@@ -1,4 +1,5 @@
 ﻿using System.Speech.Synthesis;
+
 using PowerPointLabs.SpeechEngine;
 
 namespace PowerPointLabs.Tags

--- a/PowerPointLabs/PowerPointLabs/Tags/NoEffectTag.cs
+++ b/PowerPointLabs/PowerPointLabs/Tags/NoEffectTag.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Speech.Synthesis;
+﻿using System.Speech.Synthesis;
 
 namespace PowerPointLabs.Tags
 {

--- a/PowerPointLabs/PowerPointLabs/ThisAddIn.Designer.cs
+++ b/PowerPointLabs/PowerPointLabs/ThisAddIn.Designer.cs
@@ -11,9 +11,10 @@
 using System;
 
 #pragma warning disable 414
-namespace PowerPointLabs {
-    
-    
+namespace PowerPointLabs
+{
+
+
     /// 
     [Microsoft.VisualStudio.Tools.Applications.Runtime.StartupObjectAttribute(0)]
     [global::System.Security.Permissions.PermissionSetAttribute(global::System.Security.Permissions.SecurityAction.Demand, Name="FullTrust")]

--- a/PowerPointLabs/PowerPointLabs/Utils/Assumption.cs
+++ b/PowerPointLabs/PowerPointLabs/Utils/Assumption.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+
 using PowerPointLabs.Utils.Exceptions;
 
 namespace PowerPointLabs.Utils

--- a/PowerPointLabs/PowerPointLabs/Utils/Comparers.cs
+++ b/PowerPointLabs/PowerPointLabs/Utils/Comparers.cs
@@ -1,8 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
-using System.Text;
 using System.Text.RegularExpressions;
 
 namespace PowerPointLabs.Utils

--- a/PowerPointLabs/PowerPointLabs/Utils/Exceptions/AssumptionFailedException.cs
+++ b/PowerPointLabs/PowerPointLabs/Utils/Exceptions/AssumptionFailedException.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+
 using PowerPointLabs.ActionFramework.Common.Log;
 using PowerPointLabs.ActionFramework.Common.Logger;
 

--- a/PowerPointLabs/PowerPointLabs/Utils/FileDir.cs
+++ b/PowerPointLabs/PowerPointLabs/Utils/FileDir.cs
@@ -1,8 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using PowerPointLabs.Views;
 
 namespace PowerPointLabs.Utils
 {

--- a/PowerPointLabs/PowerPointLabs/Utils/PPShape.Helper.cs
+++ b/PowerPointLabs/PowerPointLabs/Utils/PPShape.Helper.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Drawing;
+
 using Microsoft.Office.Core;
 
 namespace PowerPointLabs.Utils

--- a/PowerPointLabs/PowerPointLabs/Utils/ShapeUtil.cs
+++ b/PowerPointLabs/PowerPointLabs/Utils/ShapeUtil.cs
@@ -9,6 +9,7 @@ using Microsoft.Office.Interop.PowerPoint;
 
 using PowerPointLabs.Models;
 using PowerPointLabs.SyncLab.ObjectFormats;
+
 using Shape = Microsoft.Office.Interop.PowerPoint.Shape;
 using ShapeRange = Microsoft.Office.Interop.PowerPoint.ShapeRange;
 using Shapes = Microsoft.Office.Interop.PowerPoint.Shapes;

--- a/PowerPointLabs/PowerPointLabs/Utils/SlideUtil.cs
+++ b/PowerPointLabs/PowerPointLabs/Utils/SlideUtil.cs
@@ -3,6 +3,7 @@ using System.Runtime.InteropServices;
 
 using Microsoft.Office.Core;
 using Microsoft.Office.Interop.PowerPoint;
+
 using PowerPointLabs.ActionFramework.Common.Log;
 using PowerPointLabs.Models;
 

--- a/PowerPointLabs/PowerPointLabs/Utils/StringUtil.cs
+++ b/PowerPointLabs/PowerPointLabs/Utils/StringUtil.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Drawing;
+
 using Microsoft.Office.Core;
 
 namespace PowerPointLabs.Utils

--- a/PowerPointLabs/PowerPointLabs/Utils/TempPath.cs
+++ b/PowerPointLabs/PowerPointLabs/Utils/TempPath.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.IO;
+﻿using System.IO;
 
 namespace PowerPointLabs.Utils
 {

--- a/PowerPointLabs/PowerPointLabs/Views/FolderDialogLauncher.cs
+++ b/PowerPointLabs/PowerPointLabs/Views/FolderDialogLauncher.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Windows.Forms;
+
 using PPExtraEventHelper;
 
 namespace PowerPointLabs.Views

--- a/PowerPointLabs/PowerPointLabs/WPF/ImageButton.cs
+++ b/PowerPointLabs/PowerPointLabs/WPF/ImageButton.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Windows;
+﻿using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media;
 

--- a/PowerPointLabs/PowerPointLabs/XMLMisc/Data/AudioGenSpeechData.cs
+++ b/PowerPointLabs/PowerPointLabs/XMLMisc/Data/AudioGenSpeechData.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-namespace PowerPointLabs.XMLMisc.Data
+﻿namespace PowerPointLabs.XMLMisc.Data
 {
     class AudioGenSpeechData
     {

--- a/PowerPointLabs/PowerPointLabs/ZoomLab/ZoomToArea.cs
+++ b/PowerPointLabs/PowerPointLabs/ZoomLab/ZoomToArea.cs
@@ -6,6 +6,7 @@ using PowerPointLabs.ActionFramework.Common.Log;
 using PowerPointLabs.Models;
 using PowerPointLabs.Utils;
 using PowerPointLabs.Views;
+
 using Office = Microsoft.Office.Core;
 using PowerPoint = Microsoft.Office.Interop.PowerPoint;
 

--- a/PowerPointLabs/Test/Base/TestAssemblyFixture.cs
+++ b/PowerPointLabs/Test/Base/TestAssemblyFixture.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+
 using PowerPointLabs.Utils;
 
 namespace Test.Base

--- a/PowerPointLabs/Test/FunctionalTest/AgendaLabGenerateTest.cs
+++ b/PowerPointLabs/Test/FunctionalTest/AgendaLabGenerateTest.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+
 using Test.Util;
 
 namespace Test.FunctionalTest

--- a/PowerPointLabs/Test/FunctionalTest/AgendaLabTextSyncTest.cs
+++ b/PowerPointLabs/Test/FunctionalTest/AgendaLabTextSyncTest.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+
 using Test.Util;
 
 namespace Test.FunctionalTest

--- a/PowerPointLabs/Test/FunctionalTest/AgendaLabVisualSyncTest.cs
+++ b/PowerPointLabs/Test/FunctionalTest/AgendaLabVisualSyncTest.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+
 using Test.Util;
 
 namespace Test.FunctionalTest

--- a/PowerPointLabs/Test/FunctionalTest/AgendaLabWithSlideNumberGenerateTest.cs
+++ b/PowerPointLabs/Test/FunctionalTest/AgendaLabWithSlideNumberGenerateTest.cs
@@ -1,6 +1,6 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+
 using Test.Util;
-using System.Diagnostics;
 
 namespace Test.FunctionalTest
 {

--- a/PowerPointLabs/Test/FunctionalTest/AnimateInSlideTest.cs
+++ b/PowerPointLabs/Test/FunctionalTest/AnimateInSlideTest.cs
@@ -1,5 +1,7 @@
 ﻿using System.Collections.Generic;
+
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+
 using Test.Util;
 
 namespace Test.FunctionalTest

--- a/PowerPointLabs/Test/FunctionalTest/AutoAnimateTest.cs
+++ b/PowerPointLabs/Test/FunctionalTest/AutoAnimateTest.cs
@@ -1,7 +1,9 @@
 ﻿using System.Collections.Generic;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Test.Util;
+
 using Microsoft.Office.Interop.PowerPoint;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Test.Util;
 
 namespace Test.FunctionalTest
 {

--- a/PowerPointLabs/Test/FunctionalTest/AutoCropTest.cs
+++ b/PowerPointLabs/Test/FunctionalTest/AutoCropTest.cs
@@ -1,5 +1,7 @@
 ﻿using System.Collections.Generic;
+
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+
 using Test.Util;
 
 namespace Test.FunctionalTest

--- a/PowerPointLabs/Test/FunctionalTest/AutoNarrationTest.cs
+++ b/PowerPointLabs/Test/FunctionalTest/AutoNarrationTest.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+
 using Test.Util;
 
 namespace Test.FunctionalTest

--- a/PowerPointLabs/Test/FunctionalTest/AutoZoomTest.cs
+++ b/PowerPointLabs/Test/FunctionalTest/AutoZoomTest.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+
 using Test.Util;
 
 namespace Test.FunctionalTest

--- a/PowerPointLabs/Test/FunctionalTest/BaseFunctionalTest.cs
+++ b/PowerPointLabs/Test/FunctionalTest/BaseFunctionalTest.cs
@@ -2,11 +2,14 @@
 using System.Diagnostics;
 using System.IO;
 using System.Runtime.Remoting;
-using TestInterface;
+
 using Microsoft.Office.Interop.PowerPoint;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+
 using Test.Base;
 using Test.Util;
+
+using TestInterface;
 
 namespace Test.FunctionalTest
 {

--- a/PowerPointLabs/Test/FunctionalTest/ColorsLabTest.cs
+++ b/PowerPointLabs/Test/FunctionalTest/ColorsLabTest.cs
@@ -1,10 +1,14 @@
 ﻿using System;
 using System.Drawing;
 using System.Windows.Forms;
-using TestInterface;
+
 using Microsoft.Office.Interop.PowerPoint;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+
 using Test.Util;
+
+using TestInterface;
+
 using Point = System.Drawing.Point;
 
 namespace Test.FunctionalTest

--- a/PowerPointLabs/Test/FunctionalTest/ConvertToPictureTest.cs
+++ b/PowerPointLabs/Test/FunctionalTest/ConvertToPictureTest.cs
@@ -1,6 +1,8 @@
 ﻿using Microsoft.Office.Core;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+
 using Test.Util;
+
 using Shape = Microsoft.Office.Interop.PowerPoint.Shape;
 
 namespace Test.FunctionalTest

--- a/PowerPointLabs/Test/FunctionalTest/CropToSlideTest.cs
+++ b/PowerPointLabs/Test/FunctionalTest/CropToSlideTest.cs
@@ -1,5 +1,5 @@
-﻿using System.Collections.Generic;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+
 using Test.Util;
 
 namespace Test.FunctionalTest

--- a/PowerPointLabs/Test/FunctionalTest/FillSlideTest.cs
+++ b/PowerPointLabs/Test/FunctionalTest/FillSlideTest.cs
@@ -1,5 +1,5 @@
-﻿using System;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+
 using Test.Util;
 
 namespace Test.FunctionalTest

--- a/PowerPointLabs/Test/FunctionalTest/HighlightBulletsTest.cs
+++ b/PowerPointLabs/Test/FunctionalTest/HighlightBulletsTest.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+
 using Test.Util;
 
 namespace Test.FunctionalTest

--- a/PowerPointLabs/Test/FunctionalTest/NarrationsLabTest.cs
+++ b/PowerPointLabs/Test/FunctionalTest/NarrationsLabTest.cs
@@ -1,11 +1,6 @@
-﻿using System;
-using System.Drawing;
-using System.Windows.Forms;
-using TestInterface;
-using Microsoft.Office.Interop.PowerPoint;
+﻿using Microsoft.Office.Interop.PowerPoint;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Test.Util;
-using Point = System.Drawing.Point;
+
 using PowerPointLabs.AudioMisc;
 
 namespace Test.FunctionalTest

--- a/PowerPointLabs/Test/FunctionalTest/PasteLabTest.cs
+++ b/PowerPointLabs/Test/FunctionalTest/PasteLabTest.cs
@@ -1,8 +1,10 @@
-﻿using Microsoft.Office.Core;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Drawing;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
 using Test.Util;
+
 using Shape = Microsoft.Office.Interop.PowerPoint.Shape;
 
 namespace Test.FunctionalTest

--- a/PowerPointLabs/Test/FunctionalTest/PositionsLabDuplicateAndRotateTest.cs
+++ b/PowerPointLabs/Test/FunctionalTest/PositionsLabDuplicateAndRotateTest.cs
@@ -1,12 +1,14 @@
-﻿using System;
-using System.Drawing;
+﻿using System.Collections.Generic;
 using System.Windows.Forms;
-using TestInterface;
+
 using Microsoft.Office.Interop.PowerPoint;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+
 using Test.Util;
+
+using TestInterface;
+
 using Point = System.Drawing.Point;
-using System.Collections.Generic;
 
 namespace Test.FunctionalTest
 {

--- a/PowerPointLabs/Test/FunctionalTest/QuickPropertyTest.cs
+++ b/PowerPointLabs/Test/FunctionalTest/QuickPropertyTest.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+
 using Test.Util;
 
 namespace Test.FunctionalTest

--- a/PowerPointLabs/Test/FunctionalTest/SaveLabTest.cs
+++ b/PowerPointLabs/Test/FunctionalTest/SaveLabTest.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Drawing;
 
 using Microsoft.Office.Core;
 using Microsoft.Office.Interop.PowerPoint;

--- a/PowerPointLabs/Test/FunctionalTest/ShapesLabTest.cs
+++ b/PowerPointLabs/Test/FunctionalTest/ShapesLabTest.cs
@@ -1,8 +1,11 @@
 ﻿using System.Drawing;
 using System.Windows.Forms;
-using TestInterface;
+
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+
 using Test.Util;
+
+using TestInterface;
 
 namespace Test.FunctionalTest
 {

--- a/PowerPointLabs/Test/FunctionalTest/SyncLabTest.cs
+++ b/PowerPointLabs/Test/FunctionalTest/SyncLabTest.cs
@@ -1,15 +1,15 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+
 using Microsoft.Office.Interop.PowerPoint;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-using PowerPointLabs;
 using PowerPointLabs.TextCollection;
 
-using TestInterface;
-
 using Test.Util;
+
+using TestInterface;
 
 namespace Test.FunctionalTest
 {

--- a/PowerPointLabs/Test/FunctionalTest/TextFragmentsTest.cs
+++ b/PowerPointLabs/Test/FunctionalTest/TextFragmentsTest.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+
 using Test.Util;
 
 namespace Test.FunctionalTest

--- a/PowerPointLabs/Test/FunctionalTest/TimerLabTest.cs
+++ b/PowerPointLabs/Test/FunctionalTest/TimerLabTest.cs
@@ -1,12 +1,11 @@
-﻿using System;
-using System.Drawing;
-using System.Windows.Forms;
-using TestInterface;
+﻿using System.Collections.Generic;
+
 using Microsoft.Office.Interop.PowerPoint;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+
 using Test.Util;
-using Point = System.Drawing.Point;
-using System.Collections.Generic;
+
+using TestInterface;
 
 namespace Test.FunctionalTest
 {

--- a/PowerPointLabs/Test/FunctionalTest/ZoomToAreaTest.cs
+++ b/PowerPointLabs/Test/FunctionalTest/ZoomToAreaTest.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+
 using Test.Util;
 
 namespace Test.FunctionalTest

--- a/PowerPointLabs/Test/Properties/AssemblyInfo.cs
+++ b/PowerPointLabs/Test/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 

--- a/PowerPointLabs/Test/UnitTest/BaseUnitTest.cs
+++ b/PowerPointLabs/Test/UnitTest/BaseUnitTest.cs
@@ -1,13 +1,18 @@
 ﻿using System.Globalization;
 using System.IO;
 using System.Runtime.InteropServices;
-using TestInterface;
+
 using Microsoft.Office.Core;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Test.Util;
-using PowerPoint = Microsoft.Office.Interop.PowerPoint;
+
 using PowerPointLabs.Utils;
+
 using Test.Base;
+using Test.Util;
+
+using TestInterface;
+
+using PowerPoint = Microsoft.Office.Interop.PowerPoint;
 
 namespace Test.UnitTest
 {

--- a/PowerPointLabs/Test/UnitTest/CropLab/BaseCropLabTest.cs
+++ b/PowerPointLabs/Test/UnitTest/CropLab/BaseCropLabTest.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 

--- a/PowerPointLabs/Test/UnitTest/FitToSlideTest.cs
+++ b/PowerPointLabs/Test/UnitTest/FitToSlideTest.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+
 using Test.Util;
 
 namespace Test.UnitTest

--- a/PowerPointLabs/Test/UnitTest/HighlightLab/RemoveHighlightTest.cs
+++ b/PowerPointLabs/Test/UnitTest/HighlightLab/RemoveHighlightTest.cs
@@ -1,7 +1,9 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Test.Util;
+
 using PowerPointLabs.HighlightLab;
 using PowerPointLabs.Models;
+
+using Test.Util;
 
 namespace Test.UnitTest.HighlightLab
 {

--- a/PowerPointLabs/Test/UnitTest/PictureSlidesLab/Model/ImageItemTest.cs
+++ b/PowerPointLabs/Test/UnitTest/PictureSlidesLab/Model/ImageItemTest.cs
@@ -1,8 +1,10 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
+
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+
 using PowerPointLabs.PictureSlidesLab.Model;
 using PowerPointLabs.PictureSlidesLab.Util;
+
 using Test.Util;
 
 namespace Test.UnitTest.PictureSlidesLab.Model

--- a/PowerPointLabs/Test/UnitTest/PictureSlidesLab/Model/ObservableFontTest.cs
+++ b/PowerPointLabs/Test/UnitTest/PictureSlidesLab/Model/ObservableFontTest.cs
@@ -1,6 +1,7 @@
-﻿using System;
-using System.Windows.Media;
+﻿using System.Windows.Media;
+
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+
 using PowerPointLabs.PictureSlidesLab.Model;
 
 namespace Test.UnitTest.PictureSlidesLab.Model

--- a/PowerPointLabs/Test/UnitTest/PictureSlidesLab/Model/ObservableImageItemTest.cs
+++ b/PowerPointLabs/Test/UnitTest/PictureSlidesLab/Model/ObservableImageItemTest.cs
@@ -1,5 +1,5 @@
-﻿using System;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+
 using PowerPointLabs.PictureSlidesLab.Model;
 
 namespace Test.UnitTest.PictureSlidesLab.Model

--- a/PowerPointLabs/Test/UnitTest/PictureSlidesLab/Model/StyleOptionsTest.cs
+++ b/PowerPointLabs/Test/UnitTest/PictureSlidesLab/Model/StyleOptionsTest.cs
@@ -1,6 +1,8 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+
 using PowerPointLabs.PictureSlidesLab.Model;
 using PowerPointLabs.PictureSlidesLab.Service.Effect;
+
 using Test.Util;
 
 namespace Test.UnitTest.PictureSlidesLab.Model

--- a/PowerPointLabs/Test/UnitTest/PictureSlidesLab/Model/StyleVariantsTest.cs
+++ b/PowerPointLabs/Test/UnitTest/PictureSlidesLab/Model/StyleVariantsTest.cs
@@ -1,6 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
+
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+
 using PowerPointLabs.PictureSlidesLab.Model;
 
 namespace Test.UnitTest.PictureSlidesLab.Model

--- a/PowerPointLabs/Test/UnitTest/PictureSlidesLab/Service/Effect/TextBoxesTest.cs
+++ b/PowerPointLabs/Test/UnitTest/PictureSlidesLab/Service/Effect/TextBoxesTest.cs
@@ -1,5 +1,7 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+
 using PowerPointLabs.PictureSlidesLab.Service.Effect;
+
 using Test.Util;
 
 namespace Test.UnitTest.PictureSlidesLab.Service.Effect

--- a/PowerPointLabs/Test/UnitTest/PictureSlidesLab/Service/EffectsDesignerTest.cs
+++ b/PowerPointLabs/Test/UnitTest/PictureSlidesLab/Service/EffectsDesignerTest.cs
@@ -1,11 +1,14 @@
 ﻿using ImageProcessor.Imaging.Filters;
+
 using Microsoft.Office.Core;
 using Microsoft.Office.Interop.PowerPoint;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+
 using PowerPointLabs.PictureSlidesLab.Model;
 using PowerPointLabs.PictureSlidesLab.Service;
 using PowerPointLabs.PictureSlidesLab.Service.Effect;
 using PowerPointLabs.PictureSlidesLab.Util;
+
 using Test.Util;
 
 namespace Test.UnitTest.PictureSlidesLab.Service

--- a/PowerPointLabs/Test/UnitTest/PictureSlidesLab/Service/StylesDesignerTest.cs
+++ b/PowerPointLabs/Test/UnitTest/PictureSlidesLab/Service/StylesDesignerTest.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.IO;
+
 using Microsoft.Office.Interop.PowerPoint;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+
 using PowerPointLabs.PictureSlidesLab.Model;
 using PowerPointLabs.PictureSlidesLab.ModelFactory;
 using PowerPointLabs.PictureSlidesLab.Service;
 using PowerPointLabs.PictureSlidesLab.Util;
+
 using Test.Util;
 
 namespace Test.UnitTest.PictureSlidesLab.Service

--- a/PowerPointLabs/Test/UnitTest/PictureSlidesLab/Util/ImageUtilTest.cs
+++ b/PowerPointLabs/Test/UnitTest/PictureSlidesLab/Util/ImageUtilTest.cs
@@ -1,10 +1,10 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Drawing;
-using System.IO;
-using ImageProcessor;
+
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+
 using PowerPointLabs.PictureSlidesLab.Util;
+
 using Test.Util;
 
 namespace Test.UnitTest.PictureSlidesLab.Util

--- a/PowerPointLabs/Test/UnitTest/PictureSlidesLab/Util/StoragePathTest.cs
+++ b/PowerPointLabs/Test/UnitTest/PictureSlidesLab/Util/StoragePathTest.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
+
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+
 using PowerPointLabs.PictureSlidesLab.Util;
 
 namespace Test.UnitTest.PictureSlidesLab.Util

--- a/PowerPointLabs/Test/UnitTest/PictureSlidesLab/Util/TempPathTest.cs
+++ b/PowerPointLabs/Test/UnitTest/PictureSlidesLab/Util/TempPathTest.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+
 using PowerPointLabs.PictureSlidesLab.Util;
 
 namespace Test.UnitTest.PictureSlidesLab.Util

--- a/PowerPointLabs/Test/UnitTest/PictureSlidesLab/Util/UrlUtilTest.cs
+++ b/PowerPointLabs/Test/UnitTest/PictureSlidesLab/Util/UrlUtilTest.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+
 using PowerPointLabs.PictureSlidesLab.Model;
 using PowerPointLabs.PictureSlidesLab.Util;
 

--- a/PowerPointLabs/Test/UnitTest/PictureSlidesLab/ViewModel/PictureSlidesLabWindowViewModelTest.cs
+++ b/PowerPointLabs/Test/UnitTest/PictureSlidesLab/ViewModel/PictureSlidesLabWindowViewModelTest.cs
@@ -1,9 +1,11 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+
 using Moq;
+
 using PowerPointLabs.PictureSlidesLab.Model;
 using PowerPointLabs.PictureSlidesLab.Service.Interface;
-using PowerPointLabs.PictureSlidesLab.Views.Interface;
 using PowerPointLabs.PictureSlidesLab.ViewModel;
+using PowerPointLabs.PictureSlidesLab.Views.Interface;
 
 namespace Test.UnitTest.PictureSlidesLab.ViewModel
 {

--- a/PowerPointLabs/Test/UnitTest/PlaceHolderCopyTest.cs
+++ b/PowerPointLabs/Test/UnitTest/PlaceHolderCopyTest.cs
@@ -1,8 +1,9 @@
-﻿using System;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
+
 using Microsoft.Office.Interop.PowerPoint;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
 using PowerPointLabs.SyncLab.ObjectFormats;
 using PowerPointLabs.Utils;
 

--- a/PowerPointLabs/Test/UnitTest/PositionsLab/BasePositionsLabTest.cs
+++ b/PowerPointLabs/Test/UnitTest/PositionsLab/BasePositionsLabTest.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 
 using Microsoft.Office.Core;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+
 using PowerPointLabs.PositionsLab;
 using PowerPointLabs.Utils;
 

--- a/PowerPointLabs/Test/UnitTest/PositionsLab/PositionsLabAdjoinTest.cs
+++ b/PowerPointLabs/Test/UnitTest/PositionsLab/PositionsLabAdjoinTest.cs
@@ -1,9 +1,12 @@
 ﻿using System;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Collections.Generic;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
 using PowerPointLabs.PositionsLab;
-using PowerPoint = Microsoft.Office.Interop.PowerPoint;
 using PowerPointLabs.Utils;
+
+using PowerPoint = Microsoft.Office.Interop.PowerPoint;
 
 namespace Test.UnitTest.PositionsLab
 {

--- a/PowerPointLabs/Test/UnitTest/PositionsLab/PositionsLabAlignTest.cs
+++ b/PowerPointLabs/Test/UnitTest/PositionsLab/PositionsLabAlignTest.cs
@@ -1,7 +1,10 @@
 ﻿using System;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Collections.Generic;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
 using PowerPointLabs.PositionsLab;
+
 using PowerPoint = Microsoft.Office.Interop.PowerPoint;
 
 namespace Test.UnitTest.PositionsLab

--- a/PowerPointLabs/Test/UnitTest/PositionsLab/PositionsLabDistributeGridTest.cs
+++ b/PowerPointLabs/Test/UnitTest/PositionsLab/PositionsLabDistributeGridTest.cs
@@ -1,9 +1,12 @@
 ﻿using System;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Collections.Generic;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
 using PowerPointLabs.PositionsLab;
-using PowerPoint = Microsoft.Office.Interop.PowerPoint;
 using PowerPointLabs.Utils;
+
+using PowerPoint = Microsoft.Office.Interop.PowerPoint;
 
 namespace Test.UnitTest.PositionsLab
 {

--- a/PowerPointLabs/Test/UnitTest/PositionsLab/PositionsLabDistributeRadialTest.cs
+++ b/PowerPointLabs/Test/UnitTest/PositionsLab/PositionsLabDistributeRadialTest.cs
@@ -1,9 +1,11 @@
 ﻿using System;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Collections.Generic;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
 using PowerPointLabs.PositionsLab;
+
 using PowerPoint = Microsoft.Office.Interop.PowerPoint;
-using PowerPointLabs.Utils;
 
 namespace Test.UnitTest.PositionsLab
 {

--- a/PowerPointLabs/Test/UnitTest/PositionsLab/PositionsLabDistributeTest.cs
+++ b/PowerPointLabs/Test/UnitTest/PositionsLab/PositionsLabDistributeTest.cs
@@ -1,9 +1,12 @@
 ﻿using System;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Collections.Generic;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
 using PowerPointLabs.PositionsLab;
-using PowerPoint = Microsoft.Office.Interop.PowerPoint;
 using PowerPointLabs.Utils;
+
+using PowerPoint = Microsoft.Office.Interop.PowerPoint;
 
 namespace Test.UnitTest.PositionsLab
 {

--- a/PowerPointLabs/Test/UnitTest/PositionsLab/PositionsLabSnapTest.cs
+++ b/PowerPointLabs/Test/UnitTest/PositionsLab/PositionsLabSnapTest.cs
@@ -1,10 +1,12 @@
 ﻿using System;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Collections.Generic;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
 using PowerPointLabs.PositionsLab;
+
 using PowerPoint = Microsoft.Office.Interop.PowerPoint;
 using Shape = Microsoft.Office.Interop.PowerPoint.Shape;
-using PowerPointLabs.Utils;
 
 namespace Test.UnitTest.PositionsLab
 {

--- a/PowerPointLabs/Test/UnitTest/PositionsLab/PositionsLabSwapTest.cs
+++ b/PowerPointLabs/Test/UnitTest/PositionsLab/PositionsLabSwapTest.cs
@@ -4,9 +4,9 @@ using System.Collections.Generic;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using PowerPointLabs.PositionsLab;
-using PowerPoint = Microsoft.Office.Interop.PowerPoint;
 using PowerPointLabs.Utils;
 
+using PowerPoint = Microsoft.Office.Interop.PowerPoint;
 using SlideUtil = Test.Util.SlideUtil;
 
 namespace Test.UnitTest.PositionsLab

--- a/PowerPointLabs/Test/UnitTest/ResizeLab/BaseResizeLabTest.cs
+++ b/PowerPointLabs/Test/UnitTest/ResizeLab/BaseResizeLabTest.cs
@@ -1,7 +1,10 @@
 ﻿using System;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Collections.Generic;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
 using Test.Util;
+
 using PowerPoint = Microsoft.Office.Interop.PowerPoint;
 
 namespace Test.UnitTest.ResizeLab

--- a/PowerPointLabs/Test/UnitTest/ResizeLab/EqualizeTest.cs
+++ b/PowerPointLabs/Test/UnitTest/ResizeLab/EqualizeTest.cs
@@ -1,6 +1,8 @@
 ﻿using System.Collections.Generic;
+
 using Microsoft.Office.Core;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+
 using PowerPointLabs.ResizeLab;
 
 namespace Test.UnitTest.ResizeLab

--- a/PowerPointLabs/Test/UnitTest/ResizeLab/FitToSlideTest.cs
+++ b/PowerPointLabs/Test/UnitTest/ResizeLab/FitToSlideTest.cs
@@ -1,5 +1,7 @@
 ﻿using System.Collections.Generic;
+
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+
 using PowerPointLabs.ResizeLab;
 
 namespace Test.UnitTest.ResizeLab

--- a/PowerPointLabs/Test/UnitTest/ResizeLab/MainSettingsTest.cs
+++ b/PowerPointLabs/Test/UnitTest/ResizeLab/MainSettingsTest.cs
@@ -1,7 +1,10 @@
 ﻿using System.Collections.Generic;
+
 using Microsoft.Office.Core;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+
 using PowerPointLabs.ResizeLab;
+
 using PowerPoint = Microsoft.Office.Interop.PowerPoint;
 
 namespace Test.UnitTest.ResizeLab

--- a/PowerPointLabs/Test/UnitTest/ResizeLab/MatchTest.cs
+++ b/PowerPointLabs/Test/UnitTest/ResizeLab/MatchTest.cs
@@ -1,5 +1,7 @@
 ﻿using System.Collections.Generic;
+
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+
 using PowerPointLabs.ResizeLab;
 
 namespace Test.UnitTest.ResizeLab

--- a/PowerPointLabs/Test/UnitTest/ResizeLab/SlightAdjustTest.cs
+++ b/PowerPointLabs/Test/UnitTest/ResizeLab/SlightAdjustTest.cs
@@ -1,6 +1,8 @@
 ﻿using System.Collections.Generic;
+
 using Microsoft.Office.Core;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+
 using PowerPointLabs.ResizeLab;
 
 namespace Test.UnitTest.ResizeLab

--- a/PowerPointLabs/Test/UnitTest/ResizeLab/StretchShrinkTest.cs
+++ b/PowerPointLabs/Test/UnitTest/ResizeLab/StretchShrinkTest.cs
@@ -1,6 +1,8 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
+
 using Microsoft.Office.Core;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
 using PowerPointLabs.ResizeLab;
 
 namespace Test.UnitTest.ResizeLab

--- a/PowerPointLabs/Test/UnitTest/SyncLab/BaseSyncLabTest.cs
+++ b/PowerPointLabs/Test/UnitTest/SyncLab/BaseSyncLabTest.cs
@@ -1,7 +1,9 @@
-﻿using System;
+﻿using System.Collections.Generic;
+
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System.Collections.Generic;
+
 using Test.Util;
+
 using PowerPoint = Microsoft.Office.Interop.PowerPoint;
 
 namespace Test.UnitTest.SyncLab

--- a/PowerPointLabs/Test/UnitTest/SyncLab/SyncLabArtisticEffectTest.cs
+++ b/PowerPointLabs/Test/UnitTest/SyncLab/SyncLabArtisticEffectTest.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+
 using PowerPointLabs.SyncLab.ObjectFormats;
 
 namespace Test.UnitTest.SyncLab

--- a/PowerPointLabs/Test/UnitTest/SyncLab/SyncLabFillTest.cs
+++ b/PowerPointLabs/Test/UnitTest/SyncLab/SyncLabFillTest.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+
 using PowerPointLabs.SyncLab.ObjectFormats;
 
 namespace Test.UnitTest.SyncLab

--- a/PowerPointLabs/Test/UnitTest/SyncLab/SyncLabFontTest.cs
+++ b/PowerPointLabs/Test/UnitTest/SyncLab/SyncLabFontTest.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+
 using PowerPointLabs.SyncLab.ObjectFormats;
 
 namespace Test.UnitTest.SyncLab

--- a/PowerPointLabs/Test/UnitTest/SyncLab/SyncLabGlowEffectTest.cs
+++ b/PowerPointLabs/Test/UnitTest/SyncLab/SyncLabGlowEffectTest.cs
@@ -1,5 +1,5 @@
-﻿using MahApps.Metro.Controls;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+
 using PowerPointLabs.SyncLab.ObjectFormats;
 
 namespace Test.UnitTest.SyncLab

--- a/PowerPointLabs/Test/UnitTest/SyncLab/SyncLabLineTest.cs
+++ b/PowerPointLabs/Test/UnitTest/SyncLab/SyncLabLineTest.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+
 using PowerPointLabs.SyncLab.ObjectFormats;
 
 namespace Test.UnitTest.SyncLab

--- a/PowerPointLabs/Test/UnitTest/SyncLab/SyncLabPositionTest.cs
+++ b/PowerPointLabs/Test/UnitTest/SyncLab/SyncLabPositionTest.cs
@@ -1,6 +1,6 @@
 ﻿using Microsoft.Office.Interop.PowerPoint;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System.Collections.Generic;
+
 using PowerPointLabs.SyncLab.ObjectFormats;
 
 namespace Test.UnitTest.SyncLab

--- a/PowerPointLabs/Test/UnitTest/SyncLab/SyncLabReflectionEffectTest.cs
+++ b/PowerPointLabs/Test/UnitTest/SyncLab/SyncLabReflectionEffectTest.cs
@@ -1,6 +1,6 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+
 using PowerPointLabs.SyncLab.ObjectFormats;
-using Microsoft.Office.Interop.PowerPoint;
 
 namespace Test.UnitTest.SyncLab
 {

--- a/PowerPointLabs/Test/UnitTest/SyncLab/SyncLabShadowEffectTest.cs
+++ b/PowerPointLabs/Test/UnitTest/SyncLab/SyncLabShadowEffectTest.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+
 using PowerPointLabs.SyncLab.ObjectFormats;
 
 namespace Test.UnitTest.SyncLab

--- a/PowerPointLabs/Test/UnitTest/SyncLab/SyncLabSoftEdgeEffectTest.cs
+++ b/PowerPointLabs/Test/UnitTest/SyncLab/SyncLabSoftEdgeEffectTest.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+
 using PowerPointLabs.SyncLab.ObjectFormats;
 
 namespace Test.UnitTest.SyncLab

--- a/PowerPointLabs/Test/UnitTest/SyncLab/SyncLabThreeDEffectTest.cs
+++ b/PowerPointLabs/Test/UnitTest/SyncLab/SyncLabThreeDEffectTest.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Office.Interop.PowerPoint;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+
 using PowerPointLabs.SyncLab.ObjectFormats;
 
 namespace Test.UnitTest.SyncLab

--- a/PowerPointLabs/Test/UnitTest/SyncLab/SyncLabThreeDRotationEffectTest.cs
+++ b/PowerPointLabs/Test/UnitTest/SyncLab/SyncLabThreeDRotationEffectTest.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Office.Interop.PowerPoint;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+
 using PowerPointLabs.SyncLab.ObjectFormats;
 
 namespace Test.UnitTest.SyncLab

--- a/PowerPointLabs/Test/UnitTest/TagMatchers/EndSpeedTests.cs
+++ b/PowerPointLabs/Test/UnitTest/TagMatchers/EndSpeedTests.cs
@@ -1,7 +1,10 @@
 ﻿using System.Linq;
 using System.Text.RegularExpressions;
+
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+
 using PowerPointLabs.TagMatchers;
+
 using Test.Util;
 
 namespace Test.UnitTest.TagMatchers

--- a/PowerPointLabs/Test/UnitTest/TagMatchers/EndVoiceTests.cs
+++ b/PowerPointLabs/Test/UnitTest/TagMatchers/EndVoiceTests.cs
@@ -1,7 +1,10 @@
 ﻿using System.Linq;
 using System.Text.RegularExpressions;
+
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+
 using PowerPointLabs.TagMatchers;
+
 using Test.Util;
 
 namespace Test.UnitTest.TagMatchers

--- a/PowerPointLabs/Test/UnitTest/TagMatchers/PauseTest.cs
+++ b/PowerPointLabs/Test/UnitTest/TagMatchers/PauseTest.cs
@@ -1,7 +1,10 @@
 ﻿using System.Linq;
 using System.Text.RegularExpressions;
+
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+
 using PowerPointLabs.TagMatchers;
+
 using Test.Util;
 
 namespace Test.UnitTest.TagMatchers

--- a/PowerPointLabs/Test/UnitTest/TagMatchers/PronounceTests.cs
+++ b/PowerPointLabs/Test/UnitTest/TagMatchers/PronounceTests.cs
@@ -1,7 +1,10 @@
 ﻿using System.Linq;
 using System.Text.RegularExpressions;
+
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+
 using PowerPointLabs.TagMatchers;
+
 using Test.Util;
 
 namespace Test.UnitTest.TagMatchers

--- a/PowerPointLabs/Test/UnitTest/TagMatchers/StartSpeedTests.cs
+++ b/PowerPointLabs/Test/UnitTest/TagMatchers/StartSpeedTests.cs
@@ -1,7 +1,10 @@
 ﻿using System.Linq;
 using System.Text.RegularExpressions;
+
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+
 using PowerPointLabs.TagMatchers;
+
 using Test.Util;
 
 namespace Test.UnitTest.TagMatchers

--- a/PowerPointLabs/Test/UnitTest/TagMatchers/StartVoiceTests.cs
+++ b/PowerPointLabs/Test/UnitTest/TagMatchers/StartVoiceTests.cs
@@ -1,7 +1,10 @@
 ﻿using System.Linq;
 using System.Text.RegularExpressions;
+
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+
 using PowerPointLabs.TagMatchers;
+
 using Test.Util;
 
 namespace Test.UnitTest.TagMatchers

--- a/PowerPointLabs/Test/UnitTest/TagMatchers/TaggedTextTest.cs
+++ b/PowerPointLabs/Test/UnitTest/TagMatchers/TaggedTextTest.cs
@@ -1,5 +1,7 @@
 ﻿using System.Linq;
+
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+
 using PowerPointLabs.Models;
 
 namespace Test.UnitTest.TagMatchers

--- a/PowerPointLabs/Test/UnitTest/Utils/TempPathTest.cs
+++ b/PowerPointLabs/Test/UnitTest/Utils/TempPathTest.cs
@@ -1,5 +1,7 @@
 ﻿using System.IO;
+
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+
 using PowerPointLabs.Utils;
 
 namespace Test.UnitTest.Utils

--- a/PowerPointLabs/Test/Util/DialogUtil.cs
+++ b/PowerPointLabs/Test/Util/DialogUtil.cs
@@ -1,8 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
+
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Test.Util

--- a/PowerPointLabs/Test/Util/MessageBoxUtil.cs
+++ b/PowerPointLabs/Test/Util/MessageBoxUtil.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Text;
 using System.Threading.Tasks;
+
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Test.Util

--- a/PowerPointLabs/Test/Util/PathUtil.cs
+++ b/PowerPointLabs/Test/Util/PathUtil.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+
 using PowerPointLabs.Utils;
 
 namespace Test.Util

--- a/PowerPointLabs/Test/Util/PresentationUtil.cs
+++ b/PowerPointLabs/Test/Util/PresentationUtil.cs
@@ -1,6 +1,8 @@
 ﻿using System.Collections.Generic;
-using TestInterface;
+
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using TestInterface;
 
 namespace Test.Util
 {

--- a/PowerPointLabs/Test/Util/SlideUtil.cs
+++ b/PowerPointLabs/Test/Util/SlideUtil.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.IO;
-using Microsoft.Office.Interop.PowerPoint;
+
 using EyeOpen.Imaging.Processing;
+
+using Microsoft.Office.Interop.PowerPoint;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Test.Util

--- a/PowerPointLabs/Test/Util/TagUtil.cs
+++ b/PowerPointLabs/Test/Util/TagUtil.cs
@@ -1,4 +1,5 @@
 using System.Text.RegularExpressions;
+
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Test.Util

--- a/PowerPointLabs/Test/Util/UnitTestPpOperations.cs
+++ b/PowerPointLabs/Test/Util/UnitTestPpOperations.cs
@@ -2,11 +2,15 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using TestInterface;
+
 using Microsoft.Office.Core;
 using Microsoft.Office.Interop.PowerPoint;
+
 using PowerPointLabs.FunctionalTestInterface.Impl;
 using PowerPointLabs.Utils;
+
+using TestInterface;
+
 using Shape = Microsoft.Office.Interop.PowerPoint.Shape;
 using ShapeRange = Microsoft.Office.Interop.PowerPoint.ShapeRange;
 

--- a/PowerPointLabs/TestInterface/IHighlightLabController.cs
+++ b/PowerPointLabs/TestInterface/IHighlightLabController.cs
@@ -1,7 +1,4 @@
-﻿using System.Drawing;
-using System.Windows.Forms;
-
-namespace TestInterface
+﻿namespace TestInterface
 {
     public interface IHighlightLabController
     {

--- a/PowerPointLabs/TestInterface/IPowerPointLabsFT.cs
+++ b/PowerPointLabs/TestInterface/IPowerPointLabsFT.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-namespace TestInterface
+﻿namespace TestInterface
 {
     public interface IPowerPointLabsFT
     {

--- a/PowerPointLabs/TestInterface/IPowerPointOperations.cs
+++ b/PowerPointLabs/TestInterface/IPowerPointOperations.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+
 using Microsoft.Office.Interop.PowerPoint;
 
 namespace TestInterface

--- a/PowerPointLabs/TestInterface/IShapesLabController.cs
+++ b/PowerPointLabs/TestInterface/IShapesLabController.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Windows.Forms;
 
 namespace TestInterface
 {

--- a/PowerPointLabs/TestInterface/ISyncLabController.cs
+++ b/PowerPointLabs/TestInterface/ISyncLabController.cs
@@ -1,6 +1,4 @@
-﻿using Microsoft.Office.Interop.PowerPoint;
-
-namespace TestInterface
+﻿namespace TestInterface
 {
     public interface ISyncLabController
     {

--- a/PowerPointLabs/TestInterface/ITimerLabController.cs
+++ b/PowerPointLabs/TestInterface/ITimerLabController.cs
@@ -1,7 +1,4 @@
-﻿using System.Drawing;
-using System.Windows.Forms;
-
-namespace TestInterface
+﻿namespace TestInterface
 {
     public interface ITimerLabController
     {

--- a/PowerPointLabs/TestInterface/Properties/AssemblyInfo.cs
+++ b/PowerPointLabs/TestInterface/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 


### PR DESCRIPTION
Fixes #1533

Ready for review.

I thought that this can be recurring problem so I've decided to look for a macro to speed things up. To set up the macro environment, follow the instructions from the repo link below:

https://github.com/yuhongherald/VisualStudioDirectiveMacro/blob/master/README.adoc

Some other macros I found but are not used:
1. Some stackoverflow post, seemingly wrote in Visual Basic
https://stackoverflow.com/questions/283471/remove-unused-namespaces-across-a-whole-project-or-solution-at-once

Not used because: Can't find the Macros IDE plugin for Visual Basic macros

2. JetBrains ReSharper
http://www.jetbrains.com/resharper/

Not used because: 30-day trial, also not integrated into visual studio.
