### PR TITLE
#1735 Visual Studio modifies files in .vs folder not in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,4 +33,4 @@ cov-report.xml
 
 # StyleCop
 PowerPointLabs/PowerPointLabs/StyleCop.Cache
-PowerPointLabs/.vs/PowerPointLabs/v15/sqlite3/storage.ide
+PowerPointLabs/.vs/


### PR DESCRIPTION
Fixes #1735

Ready for review.

**Outline of Solution**
In gitignore, changed line `PowerPointLabs/.vs/PowerPointLabs/v15/sqlite3/storage.ide` to `PowerPointLabs/.vs/`. This ignores the entire `.vs` folder which gets modified frequently by Visual Studio 2017.