### PR TITLE
#1741 Picture Slides Lab: Account for scale factor of windows

### DIFF
--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Views/PictureSlidesLabWindow.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Views/PictureSlidesLabWindow.xaml.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.ComponentModel;
+using System.Drawing;
 using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
@@ -78,6 +79,7 @@ namespace PowerPointLabs.PictureSlidesLab.Views
         private const double StandardWindowWidth = 1200.0;
         private const double StandardWindowHeight = 700.0;
         private const double StandardPrewienGridWidth = 560.0;
+        private const float StandardDpi = 96f;
 
         # endregion
 
@@ -122,10 +124,13 @@ namespace PowerPointLabs.PictureSlidesLab.Views
         private void InitSizePosition()
         {
             System.Drawing.Size mSize = SystemInformation.WorkingArea.Size;
-            double systemHeight = mSize.Height * 1.0;
-            double systemWidth = mSize.Width * 1.0;
+            //Devices might have scale factors > 100%
+            float scaleFactor = GetScalingFactor();
+            double systemHeight = mSize.Height / scaleFactor;
+            double systemWidth = mSize.Width / scaleFactor;
             double windowWidth = systemWidth / StandardSystemWidth;
             double windowHeight = systemHeight / StandardSystemHeight;
+
 
             this.Window.Width = StandardWindowWidth * windowWidth;
             this.Window.Height = StandardWindowHeight * windowHeight;
@@ -133,6 +138,12 @@ namespace PowerPointLabs.PictureSlidesLab.Views
             this.Window.Left = (systemWidth - this.Window.Width) / 2;
             this.Window.Top = (systemHeight - this.Window.Height) / 2;
             this.Window.WindowStartupLocation = WindowStartupLocation.Manual;
+        }
+        
+        private float GetScalingFactor()
+        {
+            Graphics graphics = Graphics.FromHwnd(IntPtr.Zero);
+            return graphics.DpiX / StandardDpi;
         }
 
         private void InitUiExceptionHandling()


### PR DESCRIPTION
Fixes #1741

**Outline of Solution**
<!-- Tell us how you solved the issue. -->
The issue is likely to happen when opening picture slides on a small-medium size screen (13" screen). 
The lines that caused this issue are:
![image](https://user-images.githubusercontent.com/39242483/51464706-289f9d00-1da1-11e9-944d-e9dfa7b90355.png)

They retrieve the windows resolution (1920x1080). However, smaller devices tend to have their scaling factors to be >100%, causing the actual resolution for the PowerPoint window to be less than 1920 and 1080.
![image](https://user-images.githubusercontent.com/39242483/51465299-9b5d4800-1da2-11e9-895d-afa8ccbe47d9.png)


My solution was to add a function to calculate the scaling factor of the device and then account for it in the `systemHeight` and `systemWidth` calculation.

After fix, on a laptop with 150% scaling, picture slides lab now open, centered and does not overflow screen. 
![image](https://user-images.githubusercontent.com/39242483/51465352-b8921680-1da2-11e9-8394-e560fa2d4b5c.png)

<!-- Mention things you want reviewers to focus on, if any. -->
I couldn't find a simpler way to get the scale factor, if anyone has a simpler way, please let me know!
<!-- Skip this section if fix is trivial. -->
