### PR TITLE
#1432 Close background ppts on closing of main window

### DIFF
--- a/PowerPointLabs/PowerPointLabs/SyncLab/Views/SyncPaneWPF.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/Views/SyncPaneWPF.xaml.cs
@@ -52,11 +52,6 @@ namespace PowerPointLabs.SyncLab.Views
 
         public void SyncPane_Closing(Object sender, EventArgs e)
         {
-            if (this.GetAddIn().Application.Presentations.Count == 2)
-            {
-                shapeStorage.Close();
-            }
-
             if (Dialog != null)
             {
                 Dialog.Close();

--- a/PowerPointLabs/PowerPointLabs/ThisAddIn.cs
+++ b/PowerPointLabs/PowerPointLabs/ThisAddIn.cs
@@ -1054,6 +1054,11 @@ namespace PowerPointLabs
         {
             Trace.TraceInformation("Closing " + pres.Name + "...");
 
+
+            // We need to check if there is only one window AND the active window's presentation 
+            // has the same name as the one we are closing because it is possible for background 
+            // presentation (those without windows) to close and trigger this event as well.
+            // We only want to shut down PPTLabs if we are closing the main presentation.
             if (Application.Windows.Count == 1 &&
                 Application.ActiveWindow.Presentation.FullName == pres.FullName)
             {

--- a/PowerPointLabs/PowerPointLabs/ThisAddIn.cs
+++ b/PowerPointLabs/PowerPointLabs/ThisAddIn.cs
@@ -488,7 +488,7 @@ namespace PowerPointLabs
 
         private void ShutDownPictureSlidesLab()
         {
-            PictureSlidesLab.Views.PictureSlidesLabWindow pictureSlidesLabWindow = Globals.ThisAddIn.Ribbon.PictureSlidesLabWindow;
+            PictureSlidesLab.Views.PictureSlidesLabWindow pictureSlidesLabWindow = Ribbon.PictureSlidesLabWindow;
             if (pictureSlidesLabWindow != null && pictureSlidesLabWindow.IsOpen)
             {
                 pictureSlidesLabWindow.Close();

--- a/PowerPointLabs/PowerPointLabs/ThisAddIn.cs
+++ b/PowerPointLabs/PowerPointLabs/ThisAddIn.cs
@@ -1066,15 +1066,6 @@ namespace PowerPointLabs
                 _pptLabsShouldTerminate = true;
             }
 
-            if (IsApplicationVersion2010() &&
-                _deactivatedPresFullName == pres.FullName &&
-                Application.Presentations.Count == 2 &&
-                ShapePresentation != null &&
-                ShapePresentation.Opened)
-            {
-                ShapePresentation.Close();
-            }
-
             // special case: if we are closing 'ShapeGallery.pptx' or 'Sync Lab - Do not edit.pptx', no other action will be done
             if (pres.Name.Contains(ShapeGalleryPptxName) || pres.Name.Contains(SyncLabPptxName)) 
             {


### PR DESCRIPTION
Fixes #1432 

From the original issue, if user were to open at least 2 of the 3 labs with background presentations (SyncLab, ShapesLab and PictureSlidesLab), closing the main PowerPoint window does not automatically close all the background ppts, you have to manually close them from the Task Manager or by clicking "Stop" in Visual Studio (assuming you're running from VS).

Also noted in the original issue, it seems that the methods that attempt to close PictureSlidesLab and ShapesLab will check if there are only 2 opened presentations before closing them. This is why when there are 2 or more of these labs open (makes 3 including the main presentation), they don't close properly. I'm not too sure why this check was included in the first place, but removing it seemed like the best way to fix this issue for now. Please update here if the check is required, we'll have to find another solution for this problem then.

**Outline of Solution**
~~1. When user closes the main ppt window, the `PresentationClose` event will be triggered. Our handler method (`ThisAddInPresentationClose()`) attempts to close PictureSlidesLab and all the other active panes in the presentation. For some unknown reason, closing the SyncLab pane when it is the only pane opened will close the background ppt as well, but when ShapesLab and SyncLab panes are open together, closing the pane doesn't not close the background ppt.
2. The next event called is `WindowDeactivate`. Our handler method (`ThisAddInApplicationOnWindowDeactivate()`) will then attempt to close SyncLab and ShapesLab background ppts here, if they are still opened.~~
**[UPDATE]**
When user closes the main ppt window, `ThisAddInPresentationClose()` will be triggered and it will attempt to close all 3 background ppts (SyncLab, ShapesLab & PictureSlidesLab), if they are open. In the case that this handler is called but the presentation that is closing is NOT the main window, execution will simply proceed and skip the closing methods.

**[UPDATE 2]**
I have removed the logic for checking for PPT2010 when closing presentation. I have found that even without that check, all the presentations and windows close as they should on PPT 2010.






Related FTs and UTs are passing. I have tested this on both PPT2016 and PPT2013, Windows 10. 