### PR TITLE
#1272 Shows details of copied formats in tooltips

### DIFF
--- a/PowerPointLabs/PowerPointLabs/PowerPointLabs.csproj
+++ b/PowerPointLabs/PowerPointLabs/PowerPointLabs.csproj
@@ -667,6 +667,7 @@
     <Compile Include="SyncLab\ObjectFormats\GlowTransparencyFormat.cs" />
     <Compile Include="SyncLab\ObjectFormats\ShadowEffectFormat.cs" />
     <Compile Include="SyncLab\ObjectFormats\SoftEdgeEffectFormat.cs" />
+    <Compile Include="SyncLab\Views\SyncFormatPanelItemStub.cs" />
     <Compile Include="TextCollection\SaveLabText.cs" />
     <Compile Include="SyncLab\ObjectFormats\Format.cs" />
     <Compile Include="SyncLab\ObjectFormats\ArtisticEffectFormat.cs" />

--- a/PowerPointLabs/PowerPointLabs/SyncLab/SyncFormatConstants.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/SyncFormatConstants.cs
@@ -30,6 +30,8 @@ namespace PowerPointLabs.SyncLab.ObjectFormats
         public static readonly int ColorBlack = 0;
         public static readonly int DisplayLineWeight = 5;
 
+        public static readonly string FormatNameSeparator = ">";
+
         public static FormatTreeNode[] FormatCategories => CreateFormatCategories();
 
         public static List<Format> Formats

--- a/PowerPointLabs/PowerPointLabs/SyncLab/Views/SyncFormatPaneItem.xaml
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/Views/SyncFormatPaneItem.xaml
@@ -22,7 +22,7 @@
         </Grid.ColumnDefinitions>
         <Image x:Name="imageBox" Grid.Column="0" Margin="10,10,0,10" OpacityMask="{DynamicResource {x:Static SystemColors.ControlBrushKey}}" HorizontalAlignment="Left" Width="40" Height="40"/>
         <Canvas x:Name="canvas" Grid.Column="1" >
-            <TextBlock x:Name="textBlock" Margin="0,20,0,20" MaxWidth="{Binding ActualWidth, ElementName=canvas}" HorizontalAlignment="Stretch" VerticalAlignment="Center" IsHitTestVisible="False"/>
+            <TextBlock x:Name="textBlock" Margin="0,20,0,20" MaxWidth="{Binding ActualWidth, ElementName=canvas}" HorizontalAlignment="Stretch" VerticalAlignment="Center" TextTrimming="CharacterEllipsis" IsHitTestVisible="False"/>
         </Canvas>
         <Button x:Name="pasteButton" Grid.Column="2" Margin="0,10,65,10" Click="PasteButton_Click" HorizontalAlignment="Right" MinWidth="25" MaxWidth="25" MinHeight="25" MaxHeight="25">
             <Image x:Name="pasteImage" Source="pack://siteoforigin:,,,/Resources/SyncLabPasteButton.png" Stretch="Fill"/>

--- a/PowerPointLabs/PowerPointLabs/SyncLab/Views/SyncFormatPaneItem.xaml
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/Views/SyncFormatPaneItem.xaml
@@ -10,7 +10,7 @@
     <Grid x:Name="grid" ClipToBounds="True" Background="Transparent">
         <Grid.ToolTip>
             <StackPanel>
-                <TextBlock x:Name="toolTipName" FontWeight="Bold" FontSize="14" Margin="0,0,0,5"/>
+                <TextBlock x:Name="toolTipName" FontWeight="Bold" FontSize="14" Margin="0,0,0,5" MaxWidth="400" TextWrapping="Wrap"/>
                 <Border BorderBrush="Silver" BorderThickness="0,1,0,0" Margin="0,8" />
                 <TextBlock x:Name="toolTipBody"/>
             </StackPanel>

--- a/PowerPointLabs/PowerPointLabs/SyncLab/Views/SyncFormatPaneItem.xaml
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/Views/SyncFormatPaneItem.xaml
@@ -7,7 +7,16 @@
              mc:Ignorable="d" 
              d:DesignHeight="60" d:DesignWidth="300"
              MouseDoubleClick="OnMouseDoubleClick">
-    <Grid x:Name="grid" ClipToBounds="True">
+    <Grid x:Name="grid" ClipToBounds="True" Background="Transparent">
+        <Grid.ToolTip>
+            <StackPanel>
+                <TextBlock FontWeight="Bold" FontSize="14" Margin="0,0,0,5" Text="BindNameHere"/>
+                <Border BorderBrush="Silver" BorderThickness="0,1,0,0" Margin="0,8" />
+                <TextBlock>
+                    Bind description here
+                </TextBlock>
+            </StackPanel>
+        </Grid.ToolTip>
         <Grid.ColumnDefinitions>
             <ColumnDefinition x:Name="col1" Width="60" MaxWidth="60"/>
             <ColumnDefinition x:Name="col2" Width="*"/>
@@ -15,7 +24,7 @@
         </Grid.ColumnDefinitions>
         <Image x:Name="imageBox" Grid.Column="0" Margin="10,10,0,10" OpacityMask="{DynamicResource {x:Static SystemColors.ControlBrushKey}}" HorizontalAlignment="Left" Width="40" Height="40"/>
         <Canvas x:Name="canvas" Grid.Column="1" >
-            <TextBlock x:Name="textBlock" Margin="0,20,0,20" MaxWidth="{Binding ActualWidth, ElementName=canvas}" HorizontalAlignment="Stretch" VerticalAlignment="Center" TextTrimming="CharacterEllipsis"/>
+            <TextBlock x:Name="textBlock" Margin="0,20,0,20" MaxWidth="{Binding ActualWidth, ElementName=canvas}" HorizontalAlignment="Stretch" VerticalAlignment="Center" IsHitTestVisible="False"/>
         </Canvas>
         <Button x:Name="pasteButton" Grid.Column="2" Margin="0,10,65,10" Click="PasteButton_Click" HorizontalAlignment="Right" MinWidth="25" MaxWidth="25" MinHeight="25" MaxHeight="25">
             <Image x:Name="pasteImage" Source="pack://siteoforigin:,,,/Resources/SyncLabPasteButton.png" Stretch="Fill"/>

--- a/PowerPointLabs/PowerPointLabs/SyncLab/Views/SyncFormatPaneItem.xaml
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/Views/SyncFormatPaneItem.xaml
@@ -10,11 +10,9 @@
     <Grid x:Name="grid" ClipToBounds="True" Background="Transparent">
         <Grid.ToolTip>
             <StackPanel>
-                <TextBlock FontWeight="Bold" FontSize="14" Margin="0,0,0,5" Text="BindNameHere"/>
+                <TextBlock x:Name="toolTipName" FontWeight="Bold" FontSize="14" Margin="0,0,0,5"/>
                 <Border BorderBrush="Silver" BorderThickness="0,1,0,0" Margin="0,8" />
-                <TextBlock>
-                    Bind description here
-                </TextBlock>
+                <TextBlock x:Name="toolTipBody"/>
             </StackPanel>
         </Grid.ToolTip>
         <Grid.ColumnDefinitions>

--- a/PowerPointLabs/PowerPointLabs/SyncLab/Views/SyncFormatPaneItem.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/Views/SyncFormatPaneItem.xaml.cs
@@ -26,6 +26,8 @@ namespace PowerPointLabs.SyncLab.Views
         private SyncLabShapeStorage shapeStorage;
         private FormatTreeNode[] formats = null;
 
+        #region Constructors
+
         public SyncFormatPaneItem(SyncPaneWPF parent, string shapeKey,
                     SyncLabShapeStorage shapeStorage, FormatTreeNode[] formats)
         {
@@ -57,6 +59,10 @@ namespace PowerPointLabs.SyncLab.Views
             }
             toolTipBody.Text = toolTipBodyText;
         }
+
+        #endregion
+
+        #region Getters and Setters
 
         public string FormatShapeKey
         {
@@ -133,6 +139,8 @@ namespace PowerPointLabs.SyncLab.Views
                 toolTipName.Text = value;
             }
         }
+
+        #endregion
 
         #region Helper Functions
 

--- a/PowerPointLabs/PowerPointLabs/SyncLab/Views/SyncFormatPaneItem.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/Views/SyncFormatPaneItem.xaml.cs
@@ -57,7 +57,7 @@ namespace PowerPointLabs.SyncLab.Views
             {
                 toolTipBodyText += GetNamesOfCheckNodes(format);
             }
-            toolTipBody.Text = toolTipBodyText;
+            toolTipBody.Text = toolTipBodyText.Trim("\n".ToCharArray());
         }
 
         #endregion
@@ -192,6 +192,13 @@ namespace PowerPointLabs.SyncLab.Views
             this.formats = parent.Dialog.Formats;
             this.Text = parent.Dialog.ObjectName;
             parent.Dialog = null;
+
+            String toolTipBodyText = "";
+            foreach (FormatTreeNode format in formats)
+            {
+                toolTipBodyText += GetNamesOfCheckNodes(format);
+            }
+            toolTipBody.Text = toolTipBodyText.Trim("\n".ToCharArray());
         }
 
         private void DeleteButton_Click(object sender, RoutedEventArgs e)

--- a/PowerPointLabs/PowerPointLabs/SyncLab/Views/SyncFormatPaneItem.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/Views/SyncFormatPaneItem.xaml.cs
@@ -52,12 +52,7 @@ namespace PowerPointLabs.SyncLab.Views
                 Int32Rect.Empty,
                 BitmapSizeOptions.FromEmptyOptions());
 
-            String toolTipBodyText = "";
-            foreach (FormatTreeNode format in formats)
-            {
-                toolTipBodyText += GetNamesOfCheckNodes(format);
-            }
-            toolTipBody.Text = toolTipBodyText.Trim("\n".ToCharArray());
+            UpdateToolTipBody();
         }
 
         #endregion
@@ -144,16 +139,26 @@ namespace PowerPointLabs.SyncLab.Views
 
         #region Helper Functions
 
-        private String GetNamesOfCheckNodes(FormatTreeNode node)
+        private void UpdateToolTipBody()
+        {
+            String toolTipBodyText = "";
+            foreach (FormatTreeNode format in formats)
+            {
+                toolTipBodyText += GetNamesOfCheckNodes(format.Name, format);
+            }
+            toolTipBody.Text = toolTipBodyText.Trim("\n".ToCharArray());
+        }
+
+        private String GetNamesOfCheckNodes(String rootName, FormatTreeNode node)
         {
             if (node.IsChecked ?? false)
             {
-                return node.Name + "\n";
+                return (node.Name.Equals(rootName) ? "" : rootName + ">" ) + node.Name + "\n";
             }
             String result = "";
             foreach (FormatTreeNode child in node.ChildrenNodes ?? new FormatTreeNode[] { })
             {
-                result += GetNamesOfCheckNodes(child);
+                result += GetNamesOfCheckNodes(rootName, child);
             }
             return result;
         }
@@ -192,13 +197,7 @@ namespace PowerPointLabs.SyncLab.Views
             this.formats = parent.Dialog.Formats;
             this.Text = parent.Dialog.ObjectName;
             parent.Dialog = null;
-
-            String toolTipBodyText = "";
-            foreach (FormatTreeNode format in formats)
-            {
-                toolTipBodyText += GetNamesOfCheckNodes(format);
-            }
-            toolTipBody.Text = toolTipBodyText.Trim("\n".ToCharArray());
+            UpdateToolTipBody();
         }
 
         private void DeleteButton_Click(object sender, RoutedEventArgs e)

--- a/PowerPointLabs/PowerPointLabs/SyncLab/Views/SyncFormatPaneItem.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/Views/SyncFormatPaneItem.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Drawing;
+using System.Text;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
@@ -9,6 +10,7 @@ using System.Windows.Media.Imaging;
 using Microsoft.Office.Interop.PowerPoint;
 
 using PowerPointLabs.ActionFramework.Common.Extension;
+using PowerPointLabs.SyncLab.ObjectFormats;
 using PowerPointLabs.TextCollection;
 
 namespace PowerPointLabs.SyncLab.Views
@@ -122,7 +124,7 @@ namespace PowerPointLabs.SyncLab.Views
             }
         }
 
-        public String Text
+        public string Text
         {
             get
             {
@@ -141,26 +143,27 @@ namespace PowerPointLabs.SyncLab.Views
 
         private void UpdateToolTipBody()
         {
-            String toolTipBodyText = "";
+            StringBuilder toolTipBodyText = new StringBuilder();
             foreach (FormatTreeNode format in formats)
             {
-                toolTipBodyText += GetNamesOfCheckNodes(format.Name, format);
+                toolTipBodyText.Append(GetNamesOfCheckedNodes(format.Name, format));
             }
-            toolTipBody.Text = toolTipBodyText.Trim("\n".ToCharArray());
+            toolTipBody.Text = toolTipBodyText.ToString().Trim("\n".ToCharArray());
         }
 
-        private String GetNamesOfCheckNodes(String rootName, FormatTreeNode node)
+        private string GetNamesOfCheckedNodes(string rootName, FormatTreeNode node)
         {
             if (node.IsChecked ?? false)
             {
-                return (node.Name.Equals(rootName) ? "" : rootName + ">" ) + node.Name + "\n";
+                return (node.Name.Equals(rootName) ? "" : rootName +
+                    SyncFormatConstants.FormatNameSeparator) + node.Name + "\n";
             }
-            String result = "";
+            StringBuilder result = new StringBuilder();
             foreach (FormatTreeNode child in node.ChildrenNodes ?? new FormatTreeNode[] { })
             {
-                result += GetNamesOfCheckNodes(rootName, child);
+                result.Append(GetNamesOfCheckedNodes(rootName, child));
             }
-            return result;
+            return result.ToString();
         }
 
         private void ApplyFormatToSelected()

--- a/PowerPointLabs/PowerPointLabs/SyncLab/Views/SyncFormatPaneItem.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/Views/SyncFormatPaneItem.xaml.cs
@@ -49,6 +49,13 @@ namespace PowerPointLabs.SyncLab.Views
                 IntPtr.Zero,
                 Int32Rect.Empty,
                 BitmapSizeOptions.FromEmptyOptions());
+
+            String toolTipBodyText = "";
+            foreach (FormatTreeNode format in formats)
+            {
+                toolTipBodyText += GetNamesOfCheckNodes(format);
+            }
+            toolTipBody.Text = toolTipBodyText;
         }
 
         public string FormatShapeKey
@@ -123,9 +130,41 @@ namespace PowerPointLabs.SyncLab.Views
             set
             {
                 textBlock.Text = value;
-                textBlock.ToolTip = value;
+                toolTipName.Text = value;
             }
         }
+
+        #region Helper Functions
+
+        private String GetNamesOfCheckNodes(FormatTreeNode node)
+        {
+            if (node.IsChecked ?? false)
+            {
+                return node.Name + "\n";
+            }
+            String result = "";
+            foreach (FormatTreeNode child in node.ChildrenNodes ?? new FormatTreeNode[] { })
+            {
+                result += GetNamesOfCheckNodes(child);
+            }
+            return result;
+        }
+
+        private void ApplyFormatToSelected()
+        {
+            Shape formatShape = shapeStorage.GetShape(shapeKey);
+            if (formatShape == null)
+            {
+                MessageBox.Show(SyncLabText.ErrorShapeDeleted, SyncLabText.ErrorDialogTitle);
+                parent.ClearInvalidFormats();
+            }
+            this.StartNewUndoEntry();
+            parent.ApplyFormats(formats, formatShape);
+        }
+
+        #endregion
+
+        #region Event Handlers
 
         private void PasteButton_Click(object sender, RoutedEventArgs e)
         {
@@ -157,16 +196,7 @@ namespace PowerPointLabs.SyncLab.Views
             ApplyFormatToSelected();
         }
 
-        private void ApplyFormatToSelected()
-        {
-            Shape formatShape = shapeStorage.GetShape(shapeKey);
-            if (formatShape == null)
-            {
-                MessageBox.Show(SyncLabText.ErrorShapeDeleted, SyncLabText.ErrorDialogTitle);
-                parent.ClearInvalidFormats();
-            }
-            this.StartNewUndoEntry();
-            parent.ApplyFormats(formats, formatShape);
-        }
+        #endregion
+
     }
 }

--- a/PowerPointLabs/PowerPointLabs/SyncLab/Views/SyncFormatPanelItemStub.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/Views/SyncFormatPanelItemStub.cs
@@ -1,0 +1,18 @@
+﻿using System.Drawing;
+
+namespace PowerPointLabs.SyncLab.Views
+{
+    class SyncFormatPaneItemStub : SyncFormatPaneItem
+    {
+        public SyncFormatPaneItemStub(FormatTreeNode[] formats) :
+            base(null, null, null, formats)
+        {
+            
+        }
+
+        new public string FormatShapeKey = null;
+        new public Bitmap Image = null;
+        new public bool FormatShapeExists = false;
+
+    }
+}

--- a/PowerPointLabs/Test/Test.csproj
+++ b/PowerPointLabs/Test/Test.csproj
@@ -163,6 +163,7 @@
     <Compile Include="UnitTest\ResizeLab\SlightAdjustTest.cs" />
     <Compile Include="UnitTest\ResizeLab\StretchShrinkTest.cs" />
     <Compile Include="UnitTest\SyncLab\BaseSyncLabTest.cs" />
+    <Compile Include="UnitTest\SyncLab\SyncLabFormatPaneItemTest.cs" />
     <Compile Include="UnitTest\SyncLab\SyncLabReflectionEffectTest.cs" />
     <Compile Include="UnitTest\SyncLab\SyncLabThreeDRotationEffectTest.cs" />
     <Compile Include="UnitTest\SyncLab\SyncLabGlowEffectTest.cs" />

--- a/PowerPointLabs/Test/UnitTest/SyncLab/SyncLabFormatPaneItemTest.cs
+++ b/PowerPointLabs/Test/UnitTest/SyncLab/SyncLabFormatPaneItemTest.cs
@@ -39,11 +39,15 @@ namespace Test.UnitTest.SyncLab
             string[] nodes2 = { _testNodesNames[4], _testNodesNames[6], _testNodesNames[8] };
             string[] nodes3 = { _testNodesNames[7], _testNodesNames[11], _testNodesNames[18] };
 
-            testFollowingNodes(nodes1);
-            testFollowingNodes(nodes2);
-            testFollowingNodes(nodes3);
+            TestFollowingNodes(nodes1);
+            TestFollowingNodes(nodes2);
+            TestFollowingNodes(nodes3);
         }
 
+        /// <summary>
+        /// Get the node names of all format nodes.
+        /// </summary>
+        /// <returns></returns>
         private string[] GetAllFormatNames()
         {
             Queue<FormatTreeNode> queue = new Queue<FormatTreeNode>(SyncFormatConstants.FormatCategories);
@@ -77,12 +81,16 @@ namespace Test.UnitTest.SyncLab
         {
             foreach (string name in formatNames)
             {
-                getEndNode(formats, name).IsChecked = true;
+                GetEndNode(formats, name).IsChecked = true;
             }
             return formats;
         }
 
-        private FormatTreeNode getEndNode(FormatTreeNode[] formats, string name)
+        /// <summary>
+        /// Gets the node at the end of the format tree, as specified by the string name
+        /// Returns early with the last matching node if the next node cannot be found
+        /// </summary>
+        private FormatTreeNode GetEndNode(FormatTreeNode[] formats, string name)
         {
             string[] path = name.Split(SyncFormatConstants.FormatNameSeparator.ToCharArray());
             FormatTreeNode currentRoot = new FormatTreeNode("root", formats);
@@ -112,7 +120,10 @@ namespace Test.UnitTest.SyncLab
             return index;
         }
 
-        private void testFollowingNodes(string[] nodeNames)
+        /// <summary>
+        /// Test the node names displayed by the tooltip against the expected node names.
+        /// </summary>
+        private void TestFollowingNodes(string[] nodeNames)
         {
             FormatTreeNode[] nodes = SyncFormatConstants.FormatCategories;
             nodes = SelectFormats(SyncFormatConstants.FormatCategories, nodeNames);

--- a/PowerPointLabs/Test/UnitTest/SyncLab/SyncLabFormatPaneItemTest.cs
+++ b/PowerPointLabs/Test/UnitTest/SyncLab/SyncLabFormatPaneItemTest.cs
@@ -2,35 +2,128 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using PowerPointLabs.SyncLab.ObjectFormats;
 using PowerPointLabs.SyncLab.Views;
+using System;
+using System.Collections.Generic;
 
 namespace Test.UnitTest.SyncLab
 {
     [TestClass]
     public class SyncLabFormatPaneItemTest : BaseSyncLabTest
     {
-        private const int OriginalShapesSlideNo = 4;
-        private const string CopyFromShape = "CopyFrom";
-        private const string TestName = "TestingNameeeeeeeeeeeeeeeeee";
+        private const string TestName = "TestingN@meeeeeeeeeeeeeeeeee";
 
-        private Shape _formatShape;
+        private string[] _testNodesNames;
 
         [TestInitialize]
         public void TestInitialize()
         {
-            _formatShape = GetShape(OriginalShapesSlideNo, CopyFromShape);
+            _testNodesNames = GetAllFormatNames();
         }
 
         [TestMethod]
         [TestCategory("UT")]
-        public void TestSyncPaneTooltip()
+        public void TestSyncPaneTooltipName()
         {
             FormatTreeNode[] nodes = SyncFormatConstants.FormatCategories;
             SyncFormatPaneItem item = new SyncFormatPaneItemStub(nodes);
             item.Text = TestName;
 
             Assert.AreEqual(TestName, item.toolTipName.Text);
-            Assert.AreEqual("", item.toolTipBody.Text);
         }
 
+        [TestMethod]
+        [TestCategory("UT")]
+        public void TestSyncPaneTooltipBody()
+        {
+            string[] nodes1 = { _testNodesNames[0], _testNodesNames[13], _testNodesNames[16] };
+            string[] nodes2 = { _testNodesNames[4], _testNodesNames[6], _testNodesNames[8] };
+            string[] nodes3 = { _testNodesNames[7], _testNodesNames[11], _testNodesNames[18] };
+
+            testFollowingNodes(nodes1);
+            testFollowingNodes(nodes2);
+            testFollowingNodes(nodes3);
+        }
+
+        private string[] GetAllFormatNames()
+        {
+            Queue<FormatTreeNode> queue = new Queue<FormatTreeNode>(SyncFormatConstants.FormatCategories);
+            List<string> allNames = new List<string>();
+            while (queue.Count > 0)
+            {
+                FormatTreeNode node = queue.Dequeue();
+                string fullName = node.Name;
+                FormatTreeNode parentNode = node.ParentNode;
+                while (parentNode != null)
+                {
+                    fullName = parentNode.Name + SyncFormatConstants.FormatNameSeparator + fullName;
+                    parentNode = parentNode.ParentNode;
+                }
+                allNames.Add(fullName);
+
+                if (node.ChildrenNodes == null)
+                {
+                    continue;
+                }
+                foreach (FormatTreeNode child in node.ChildrenNodes)
+                {
+                    queue.Enqueue(child);
+                }
+            }
+
+            return allNames.ToArray();
+        }
+
+        private FormatTreeNode[] SelectFormats(FormatTreeNode[] formats, string[] formatNames)
+        {
+            foreach (string name in formatNames)
+            {
+                getEndNode(formats, name).IsChecked = true;
+            }
+            return formats;
+        }
+
+        private FormatTreeNode getEndNode(FormatTreeNode[] formats, string name)
+        {
+            string[] path = name.Split(SyncFormatConstants.FormatNameSeparator.ToCharArray());
+            FormatTreeNode currentRoot = new FormatTreeNode("root", formats);
+            foreach (string nodeName in path)
+            {
+                int nextIndex = LastIndexOf(currentRoot.ChildrenNodes, nodeName);
+                if (nextIndex < 0)
+                {
+                    break;
+                }
+                currentRoot = currentRoot.ChildrenNodes[nextIndex];
+            }
+            return currentRoot;
+        }
+
+        private int LastIndexOf(FormatTreeNode[] nodes, string name)
+        {
+            int index = nodes.Length - 1;
+            while (index >= 0)
+            {
+                if (nodes[index].Name.Equals(name))
+                {
+                    return index;
+                }
+                index--;
+            }
+            return index;
+        }
+
+        private void testFollowingNodes(string[] nodeNames)
+        {
+            FormatTreeNode[] nodes = SyncFormatConstants.FormatCategories;
+            nodes = SelectFormats(SyncFormatConstants.FormatCategories, nodeNames);
+            SyncFormatPaneItem item = new SyncFormatPaneItemStub(nodes);
+
+            string[] expected = nodeNames;
+            string[] actual = item.toolTipBody.Text.Split("\n".ToCharArray());
+            Array.Sort(expected);
+            Array.Sort(actual);
+
+            Assert.AreEqual(String.Join("\n", expected), String.Join("\n", actual));
+        }
     }
 }

--- a/PowerPointLabs/Test/UnitTest/SyncLab/SyncLabFormatPaneItemTest.cs
+++ b/PowerPointLabs/Test/UnitTest/SyncLab/SyncLabFormatPaneItemTest.cs
@@ -1,0 +1,36 @@
+﻿using Microsoft.Office.Interop.PowerPoint;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using PowerPointLabs.SyncLab.ObjectFormats;
+using PowerPointLabs.SyncLab.Views;
+
+namespace Test.UnitTest.SyncLab
+{
+    [TestClass]
+    public class SyncLabFormatPaneItemTest : BaseSyncLabTest
+    {
+        private const int OriginalShapesSlideNo = 4;
+        private const string CopyFromShape = "CopyFrom";
+        private const string TestName = "TestingNameeeeeeeeeeeeeeeeee";
+
+        private Shape _formatShape;
+
+        [TestInitialize]
+        public void TestInitialize()
+        {
+            _formatShape = GetShape(OriginalShapesSlideNo, CopyFromShape);
+        }
+
+        [TestMethod]
+        [TestCategory("UT")]
+        public void TestSyncPaneTooltip()
+        {
+            FormatTreeNode[] nodes = SyncFormatConstants.FormatCategories;
+            SyncFormatPaneItem item = new SyncFormatPaneItemStub(nodes);
+            item.Text = TestName;
+
+            Assert.AreEqual(TestName, item.toolTipName.Text);
+            Assert.AreEqual("", item.toolTipBody.Text);
+        }
+
+    }
+}


### PR DESCRIPTION
Fixes #1272

Ready for review (no tests were added). Tested and working on PPT 2016.

**Outline of Solution**
A tooltip was added to the shape grid in the list. The tooltip's values are changed whenever the name or properties are edited. The property names are compiled recursively, so that if a child property's parent is checked, the child property's name will not be included. This reduces clutter as well.

Screenshot:
![image](https://user-images.githubusercontent.com/40821389/51803409-e9d18180-228f-11e9-8698-c88f61b45fb4.png)

Example of how property names are picked:
EG.
[x] A
[x] -  A1
[x] -  A2
[ ] B
[ ] -  B1
[x] -  B2
[ ] C
[x] -  C3

Outputs: A, B2, C3
