### PR TITLE
#195 Increase resolution of images in ZoomLab

### DIFF
--- a/PowerPointLabs/PowerPointLabs/Utils/FileDir.cs
+++ b/PowerPointLabs/PowerPointLabs/Utils/FileDir.cs
@@ -139,6 +139,16 @@ namespace PowerPointLabs.Utils
             return CopyFolder(oldPath, newPath) && DeleteFolder(oldPath);
         }
 
+        public static string GetTemporaryPngFilePath()
+        {
+            string tempDirectory = Path.GetTempPath();
+            Directory.CreateDirectory(tempDirectory);
+
+            string randomFileName = "pptlabs_" + Path.GetRandomFileName();
+            string randomFilePath = Path.Combine(tempDirectory, randomFileName);
+            return Path.ChangeExtension(randomFilePath, "png");
+        }
+
         /// <summary>
         /// This function sets attribute of all files in a folder and its sub-folder 
         /// to normal.

--- a/PowerPointLabs/PowerPointLabs/ZoomLab/AutoZoom.cs
+++ b/PowerPointLabs/PowerPointLabs/ZoomLab/AutoZoom.cs
@@ -457,17 +457,28 @@ namespace PowerPointLabs.ZoomLab
 
         private static PowerPoint.Shape AddSlideAsShape(PowerPointSlide slideToAdd, PowerPointSlide targetSlide)
         {
-            // Export the slide as .png to a temporary location, then add it to shapes.
-            // This yields a higher quality image compared to copy-pasting slide as image.
-            string tempFilePath = FileDir.GetTemporaryPngFilePath();
-            GraphicsUtil.ExportSlide(slideToAdd, tempFilePath);
-            PowerPoint.Shape slideAsShape = targetSlide.Shapes.AddPicture2(tempFilePath,
-                                                                             Microsoft.Office.Core.MsoTriState.msoFalse,
-                                                                             Microsoft.Office.Core.MsoTriState.msoTrue,
-                                                                             0,
-                                                                             0);
-            FileDir.DeleteFile(tempFilePath);
-            return slideAsShape;
+            try
+            {
+                // Export the slide as .png to a temporary location, then add it to shapes.
+                // This yields a higher quality image compared to copy-pasting slide as image.
+                string tempFilePath = FileDir.GetTemporaryPngFilePath();
+                GraphicsUtil.ExportSlide(slideToAdd, tempFilePath);
+                PowerPoint.Shape slideAsShape = targetSlide.Shapes.AddPicture2(tempFilePath,
+                                                                                 Microsoft.Office.Core.MsoTriState.msoFalse,
+                                                                                 Microsoft.Office.Core.MsoTriState.msoTrue,
+                                                                                 0,
+                                                                                 0);
+                FileDir.DeleteFile(tempFilePath);
+                return slideAsShape;
+            }
+            catch (Exception)
+            {
+                // It is possible that there could permissions-related issues that cause user to be unable to create/delete files.
+                // In that case, we proceed with copy-pasting the slide as image.
+                slideToAdd.Copy();
+                PowerPoint.Shape slideAsShape = targetSlide.Shapes.PasteSpecial(PowerPoint.PpPasteDataType.ppPastePNG)[1];
+                return slideAsShape;
+            }
         }
     }
 }

--- a/PowerPointLabs/PowerPointLabs/ZoomLab/AutoZoom.cs
+++ b/PowerPointLabs/PowerPointLabs/ZoomLab/AutoZoom.cs
@@ -65,8 +65,7 @@ namespace PowerPointLabs.ZoomLab
                     shapeToZoom = addedSlide.Shapes.Paste()[1];
                     addedSlide.DeleteShapeAnimations(shapeToZoom);
 
-                    currentSlide.Copy();
-                    PowerPoint.Shape backgroundShape = addedSlide.Shapes.PasteSpecial(PowerPoint.PpPasteDataType.ppPastePNG)[1];
+                    PowerPoint.Shape backgroundShape = AddSlideAsShape(currentSlide, addedSlide);
                     backgroundShape.Apply();
                     ShapeUtil.FitShapeToSlide(ref backgroundShape);
                     backgroundShape.ZOrder(Office.MsoZOrderCmd.msoSendBackward);
@@ -89,8 +88,7 @@ namespace PowerPointLabs.ZoomLab
                     shapeToZoom = addedSlide.Shapes.Paste()[1];
                     addedSlide.DeleteShapeAnimations(shapeToZoom);
 
-                    currentSlide.Copy();
-                    PowerPoint.Shape backgroundShape = addedSlide.Shapes.PasteSpecial(PowerPoint.PpPasteDataType.ppPastePNG)[1];
+                    PowerPoint.Shape backgroundShape = AddSlideAsShape(currentSlide, addedSlide);
                     backgroundShape.Apply();
                     ShapeUtil.FitShapeToSlide(ref backgroundShape);
                     backgroundShape.ZOrder(Office.MsoZOrderCmd.msoSendBackward);
@@ -314,9 +312,7 @@ namespace PowerPointLabs.ZoomLab
             {
                 s.Delete();
             }
-
-            nextSlideCopy.Copy();
-            PowerPoint.Shape slidePicture = currentSlide.Shapes.PasteSpecial(PowerPoint.PpPasteDataType.ppPastePNG)[1];
+            PowerPoint.Shape slidePicture = AddSlideAsShape(nextSlideCopy, currentSlide);
             nextSlideCopy.Delete();
             return slidePicture;
         }
@@ -331,9 +327,7 @@ namespace PowerPointLabs.ZoomLab
             {
                 s.Delete();
             }
-
-            previousSlideCopy.Copy();
-            PowerPoint.Shape slidePicture = currentSlide.Shapes.PasteSpecial(PowerPoint.PpPasteDataType.ppPastePNG)[1];
+            PowerPoint.Shape slidePicture = AddSlideAsShape(previousSlideCopy, currentSlide);
             previousSlideCopy.Delete();
             return slidePicture;
         }
@@ -388,8 +382,8 @@ namespace PowerPointLabs.ZoomLab
 
         private static PowerPoint.Shape GetStepBackWithBackgroundShapeToZoom(PowerPointSlide currentSlide, PowerPointSlide addedSlide, PowerPoint.Shape previousSlidePicture, out PowerPoint.Shape backgroundShape)
         {
-            currentSlide.Copy();
-            PowerPoint.Shape currentSlideCopy = addedSlide.Shapes.PasteSpecial(PowerPoint.PpPasteDataType.ppPastePNG)[1];
+            PowerPoint.Shape currentSlideCopy = AddSlideAsShape(currentSlide, addedSlide);
+
             ShapeUtil.FitShapeToSlide(ref currentSlideCopy);
             currentSlideCopy.Name = "PPTZoomOutShape" + DateTime.Now.ToString("yyyyMMddHHmmssffff");
 
@@ -459,6 +453,21 @@ namespace PowerPointLabs.ZoomLab
             {
                 shapeCopy.Select(Office.MsoTriState.msoFalse);
             }
+        }
+
+        private static PowerPoint.Shape AddSlideAsShape(PowerPointSlide slideToAdd, PowerPointSlide targetSlide)
+        {
+            // Export the slide as .png to a temporary location, then add it to shapes.
+            // This yields a higher quality image compared to copy-pasting slide as image.
+            string tempFilePath = FileDir.GetTemporaryPngFilePath();
+            GraphicsUtil.ExportSlide(slideToAdd, tempFilePath);
+            PowerPoint.Shape slideAsShape = targetSlide.Shapes.AddPicture2(tempFilePath,
+                                                                             Microsoft.Office.Core.MsoTriState.msoFalse,
+                                                                             Microsoft.Office.Core.MsoTriState.msoTrue,
+                                                                             0,
+                                                                             0);
+            FileDir.DeleteFile(tempFilePath);
+            return slideAsShape;
         }
     }
 }

--- a/PowerPointLabs/PowerPointLabs/ZoomLab/AutoZoom.cs
+++ b/PowerPointLabs/PowerPointLabs/ZoomLab/AutoZoom.cs
@@ -468,7 +468,14 @@ namespace PowerPointLabs.ZoomLab
                                                                                  Microsoft.Office.Core.MsoTriState.msoTrue,
                                                                                  0,
                                                                                  0);
-                FileDir.DeleteFile(tempFilePath);
+                try
+                {
+                    FileDir.DeleteFile(tempFilePath);
+                }
+                catch (Exception)
+                {
+                    return slideAsShape;
+                }
                 return slideAsShape;
             }
             catch (Exception)


### PR DESCRIPTION
Fixes #195 

Issue was regarding resolution of images in `ZoomLab`, particularly 'Drill Down' and 'Step Back'. During the animation, it can be seen quite obviously that the quality of the images during the animation has been reduced greatly. This was due to the fact that some of the images during the animation were generated by copying and pasting the slides as images.
 
### **Outline of Solution**
This PR changes the copying and pasting to export and insert, as suggested in the issue. We already have an existing export slide as `.png` image method in `GraphicsUtil`, so that is what I used. The slide is exported as an image to a temporary destination, then immediately added back into the target slide as an image. This results in a greater quality image as opposed to just copying and pasting. Greater quality image in turn gives a smoother-looking animation. This is more evident in higher resolution images.

Screenshots of result below. 'Original' refers to the picture before the resolution drop. 'Before fix' refers to the picture as a result of copy and paste. 'After fix' refers to the picture as a result of exporting and inserting. 

**Original vs. Before fix:**
<img src="https://user-images.githubusercontent.com/39292809/52076755-56b78500-25ca-11e9-8d8b-808b8b298d0a.png" alt="original" width="330" />  <img src="https://user-images.githubusercontent.com/39292809/52076756-56b78500-25ca-11e9-9241-117fc2bc4e94.png" alt="before" width="330" />

**Original vs. After fix:**
<img src="https://user-images.githubusercontent.com/39292809/52076755-56b78500-25ca-11e9-8d8b-808b8b298d0a.png" alt="original" width="330" />  <img src="https://user-images.githubusercontent.com/39292809/52076757-57501b80-25ca-11e9-91c9-9ab720ae6ed2.png" alt="after" width="330" />

Tested and working on PPT2013.