### PR TITLE
(Tooltips lab) Add Textbox adding functionality to tooltips.

### DIFF
--- a/PowerPointLabs/PowerPointLabs/ActionFramework/TooltipsLab/AddTextbox/AddTextboxActionHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/TooltipsLab/AddTextbox/AddTextboxActionHandler.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.Office.Interop.PowerPoint;
+using PowerPointLabs.ActionFramework.Common.Attribute;
+using PowerPointLabs.ActionFramework.Common.Extension;
+using PowerPointLabs.ActionFramework.Common.Interface;
+using PowerPointLabs.Models;
+using PowerPointLabs.TextCollection;
+using PowerPointLabs.TooltipsLab;
+
+namespace PowerPointLabs.ActionFramework.TooltipsLab
+{
+    [ExportActionRibbonId(TooltipsLabText.AddTextboxTag)]
+    class AddTextboxActionHandler : ActionHandler
+    {
+        protected override void ExecuteAction(string ribbonId)
+        {
+            Selection selection = this.GetCurrentSelection();
+            PowerPointSlide currentSlide = this.GetCurrentSlide();
+            this.StartNewUndoEntry();
+
+            AddTextbox.AddTextboxToCallout(currentSlide, selection);
+        }
+    }
+}

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/TooltipsLab/AddTextbox/AddTextboxImageHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/TooltipsLab/AddTextbox/AddTextboxImageHandler.cs
@@ -1,0 +1,17 @@
+﻿using System.Drawing;
+
+using PowerPointLabs.ActionFramework.Common.Attribute;
+using PowerPointLabs.ActionFramework.Common.Interface;
+using PowerPointLabs.TextCollection;
+
+namespace PowerPointLabs.ActionFramework.TooltipsLab
+{
+    [ExportImageRibbonId(TooltipsLabText.AddTextboxTag)]
+    class AddTextboxImageHandler : ImageHandler
+    {
+        protected override Bitmap GetImage(string ribbonId)
+        {
+            return new Bitmap(Properties.Resources.AddAnimation);
+        }
+    }
+}

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/TooltipsLab/AddTextbox/AddTextboxLabelHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/TooltipsLab/AddTextbox/AddTextboxLabelHandler.cs
@@ -1,0 +1,15 @@
+﻿using PowerPointLabs.ActionFramework.Common.Attribute;
+using PowerPointLabs.ActionFramework.Common.Interface;
+using PowerPointLabs.TextCollection;
+
+namespace PowerPointLabs.ActionFramework.TooltipsLab
+{
+    [ExportLabelRibbonId(TooltipsLabText.AddTextboxTag)]
+    class AddTextboxLabelHandler : LabelHandler
+    {
+        protected override string GetLabel(string ribbonId)
+        {
+            return TooltipsLabText.AddTextboxButtonLabel;
+        }
+    }
+}

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/TooltipsLab/AddTextbox/AddTextboxSupertipHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/TooltipsLab/AddTextbox/AddTextboxSupertipHandler.cs
@@ -1,0 +1,15 @@
+﻿using PowerPointLabs.ActionFramework.Common.Attribute;
+using PowerPointLabs.ActionFramework.Common.Interface;
+using PowerPointLabs.TextCollection;
+
+namespace PowerPointLabs.ActionFramework.TooltipsLab
+{
+    [ExportSupertipRibbonId(TooltipsLabText.AddTextboxTag)]
+    class AddTextboxSupertipHandler : SupertipHandler
+    {
+        protected override string GetSupertip(string ribbonId)
+        {
+            return AnimationLabText.AddAnimationButtonSupertip;
+        }
+    }
+}

--- a/PowerPointLabs/PowerPointLabs/PowerPointLabs.csproj
+++ b/PowerPointLabs/PowerPointLabs/PowerPointLabs.csproj
@@ -258,6 +258,10 @@
     can be found.
   -->
   <ItemGroup>
+    <Compile Include="ActionFramework\TooltipsLab\AddTextbox\AddTextboxActionHandler.cs" />
+    <Compile Include="ActionFramework\TooltipsLab\AddTextbox\AddTextboxImageHandler.cs" />
+    <Compile Include="ActionFramework\TooltipsLab\AddTextbox\AddTextboxLabelHandler.cs" />
+    <Compile Include="ActionFramework\TooltipsLab\AddTextbox\AddTextboxSupertipHandler.cs" />
     <Compile Include="ActionFramework\TooltipsLab\CreateTooltip\CreateTooltipActionHandler.cs" />
     <Compile Include="ActionFramework\TooltipsLab\CreateTooltip\CreateTooltipImageHandler.cs" />
     <Compile Include="ActionFramework\TooltipsLab\CreateTooltip\CreateTooltipLabelHandler.cs" />
@@ -752,6 +756,7 @@
     <Compile Include="TextCollection\SyncLabText.cs" />
     <Compile Include="TextCollection\CropLabText.cs" />
     <Compile Include="TimerLab\TimerLab.cs" />
+    <Compile Include="TooltipsLab\AddTextbox.cs" />
     <Compile Include="TooltipsLab\AttachTriggerAnimation.cs" />
     <Compile Include="Utils\ClipboardUtil.cs" />
     <Compile Include="Utils\ShapeUtil.cs" />
@@ -2109,7 +2114,7 @@
   <ProjectExtensions>
     <VisualStudio>
       <FlavorProperties GUID="{BAA0C2D2-18E2-41B9-852F-F413020CAA33}">
-        <ProjectProperties HostName="PowerPoint" HostPackage="{29A7B9D7-A7F1-4328-8EF0-6B2D1A56B2C1}" OfficeVersion="15.0" VstxVersion="4.0" ApplicationType="PowerPoint" Language="cs" TemplatesPath="VSTOTemplates" DebugInfoExeName="#Software\Microsoft\Office\15.0\PowerPoint\InstallRoot\Path#powerpnt.exe" AddItemTemplatesGuid="{51063C3A-E220-4D12-8922-BDA915ACD783}" />
+        <ProjectProperties HostName="PowerPoint" HostPackage="{29A7B9D7-A7F1-4328-8EF0-6B2D1A56B2C1}" OfficeVersion="15.0" VstxVersion="4.0" ApplicationType="PowerPoint" Language="cs" TemplatesPath="VSTOTemplates" DebugInfoExeName="#Software\Microsoft\Office\16.0\PowerPoint\InstallRoot\Path#powerpnt.exe" AddItemTemplatesGuid="{51063C3A-E220-4D12-8922-BDA915ACD783}" />
         <Host Name="PowerPoint" GeneratedCodeNamespace="PowerPointLabs" PublishedHash="69C324AB27932AA2FBF2B7EA72250886FF164DE6" IconIndex="0">
           <HostItem Name="ThisAddIn" Code="ThisAddIn.cs" CanonicalName="AddIn" PublishedHash="55214155BE32CF10E93E0815C7758604B8DF3CF2" CanActivate="false" IconIndex="1" Blueprint="ThisAddIn.Designer.xml" GeneratedCode="ThisAddIn.Designer.cs" />
         </Host>

--- a/PowerPointLabs/PowerPointLabs/Ribbon1.xml
+++ b/PowerPointLabs/PowerPointLabs/Ribbon1.xml
@@ -73,6 +73,12 @@
                     getImage="GetImage"
                     getSupertip="GetSupertip"
                     onAction="OnAction"/>
+            <button id="AddTextboxButton"
+                    tag="AddTextbox"
+                    getLabel="GetLabel"
+                    getImage="GetImage"
+                    getSupertip="GetSupertip"
+                    onAction="OnAction"/>
             <menuSeparator id="TooltipsLabSettingsSeparator"/>
             <button id="TooltipsLabSettingsButton"
                     tag="TooltipsLabSettings"

--- a/PowerPointLabs/PowerPointLabs/TextCollection/TooltipsLabText.cs
+++ b/PowerPointLabs/PowerPointLabs/TextCollection/TooltipsLabText.cs
@@ -6,6 +6,7 @@
         public const string RibbonMenuId = "TooltipsLabMenu";
         public const string CreateTooltipTag = "CreateTooltip";
         public const string AssignTooltipTag = "AssignTooltip";
+        public const string AddTextboxTag = "AddTextbox";
         public const string SettingsTag = "TooltipsLabSettings";
         #endregion
 
@@ -13,6 +14,7 @@
         public const string RibbonMenuLabel = "Tooltips";
         public const string CreateTooltipButtonLabel = "Create Tooltip";
         public const string AssignTooltipButtonLabel = "Assign Tooltip";
+        public const string AddTextboxButtonLabel = "Add Textbox";
         public const string SettingsButtonLabel = "Settings";
 
         public const string RibbonMenuSupertip = "Use Animation Lab to add animations your slides easily.";

--- a/PowerPointLabs/PowerPointLabs/TooltipsLab/AddTextbox.cs
+++ b/PowerPointLabs/PowerPointLabs/TooltipsLab/AddTextbox.cs
@@ -1,0 +1,35 @@
+﻿using Microsoft.Office.Core;
+using Microsoft.Office.Interop.PowerPoint;
+using PowerPointLabs.Models;
+using PowerPointLabs.Utils;
+
+using Shape = Microsoft.Office.Interop.PowerPoint.Shape;
+
+namespace PowerPointLabs.TooltipsLab
+{
+    internal static class AddTextbox
+    {
+        public static void AddTextboxToCallout(PowerPointSlide currentSlide, Selection selection)
+        {
+            if (!ShapeUtil.IsSelectionSingleShape(selection))
+            {
+                return;
+            }
+            Shape callout = selection.ShapeRange[1];
+            Shape textbox = AddTextboxToSlide(currentSlide, callout.Left, callout.Top, callout.Width, callout.Height);
+            Shape group = selection.ShapeRange.Group();
+            group.ZOrder(MsoZOrderCmd.msoSendBackward);
+            textbox.Select(MsoTriState.msoTrue);
+        }
+
+        private static Shape AddTextboxToSlide(PowerPointSlide slide, float left, float top, float width, float height)
+        {
+            Shape textbox = slide.GetNativeSlide().Shapes.AddTextbox(MsoTextOrientation.msoTextOrientationHorizontal, left, top, width, height);
+            textbox.TextFrame2.AutoSize = MsoAutoSize.msoAutoSizeTextToFitShape;
+            textbox.ZOrder(MsoZOrderCmd.msoBringForward);
+            textbox.Select(MsoTriState.msoFalse);
+            return textbox;
+        }
+
+    }
+}


### PR DESCRIPTION
Adds textbox (with autosize) to callout. The textbox will be grouped with the callout, ending with the state where the textbox is selected. Fails if number of selected shapes != 1.
