### PR TITLE
#26 Open SelectionPane after editting name

### DIFF
--- a/PowerPointLabs/PowerPointLabs/ActionFramework/ShortcutsLab/EditName/EditNameActionHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/ShortcutsLab/EditName/EditNameActionHandler.cs
@@ -23,7 +23,10 @@ namespace PowerPointLabs.ActionFramework.ShortcutsLab
             EditNameDialogBox editForm = new EditNameDialogBox(selectedShape);
             editForm.ShowDialog();
 
-            this.GetApplication().CommandBars.ExecuteMso("SelectionPane");
+            if (!this.GetApplication().CommandBars.GetPressedMso("SelectionPane"))
+            {
+                this.GetApplication().CommandBars.ExecuteMso("SelectionPane");
+            }
         }
     }
 }

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/ShortcutsLab/EditName/EditNameActionHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/ShortcutsLab/EditName/EditNameActionHandler.cs
@@ -22,6 +22,8 @@ namespace PowerPointLabs.ActionFramework.ShortcutsLab
             
             EditNameDialogBox editForm = new EditNameDialogBox(selectedShape);
             editForm.ShowDialog();
+
+            this.GetApplication().CommandBars.ExecuteMso("SelectionPane");
         }
     }
 }


### PR DESCRIPTION
Fixes #26

**Outline of Solution**
<!-- Tell us how you solved the issue. -->
Open selection pane after user edits the name of a shape
<!-- Mention things you want reviewers to focus on, if any. -->
<!-- Skip this section if fix is trivial. -->
