### PR TITLE
Tooltips Lab: Add exit effect for callout and change behaviour on multiple usages of create/assign tooltip

### DIFF
--- a/PowerPointLabs/PowerPointLabs/TooltipsLab/AttachTriggerAnimation.cs
+++ b/PowerPointLabs/PowerPointLabs/TooltipsLab/AttachTriggerAnimation.cs
@@ -46,24 +46,46 @@ namespace PowerPointLabs.TooltipsLab
         private static void AddTriggerAnimation(PowerPointSlide currentSlide, Shape triggerShape, List<Shape> shapesToAnimate)
         {
             TimeLine timeline = currentSlide.TimeLine;
-            MsoAnimEffect appearEffect = MsoAnimEffect.msoAnimEffectFade;
+            MsoAnimEffect fadeEffect = MsoAnimEffect.msoAnimEffectFade;
             Sequence sequence = timeline.InteractiveSequences.Add();
+            // Add Entrance Effect to Shapes
             for (int i = 0; i < shapesToAnimate.Count; i++)
             {
                 Shape animationShape = shapesToAnimate[i];
                 MsoAnimTriggerType triggerType;
-                // The first shape will be triggered by the click
+                // The first shape will be triggered by the click to appear
                 if (i == 0)
                 {
                     triggerType = MsoAnimTriggerType.msoAnimTriggerOnShapeClick;
-                    sequence.AddTriggerEffect(animationShape, appearEffect, triggerType, triggerShape);
+                    sequence.AddTriggerEffect(animationShape, fadeEffect, triggerType, triggerShape);
                 }
                 // Rest of the shapes will appear with the first shape
                 else
                 {
                     triggerType = MsoAnimTriggerType.msoAnimTriggerWithPrevious;
-                    sequence.AddEffect(shapesToAnimate[i], appearEffect, MsoAnimateByLevel.msoAnimateLevelNone, MsoAnimTriggerType.msoAnimTriggerWithPrevious);
+                    sequence.AddEffect(shapesToAnimate[i], fadeEffect, MsoAnimateByLevel.msoAnimateLevelNone, MsoAnimTriggerType.msoAnimTriggerWithPrevious);
                 }
+            }
+
+            // Add Exit Effect to Shapes
+            for (int i = 0; i < shapesToAnimate.Count; i++)
+            {
+                Shape animationShape = shapesToAnimate[i];
+                MsoAnimTriggerType triggerType;
+                Effect effect;
+                // The first shape will be triggered by the click to disappear
+                if (i == 0)
+                {
+                    triggerType = MsoAnimTriggerType.msoAnimTriggerOnShapeClick;
+                    effect = sequence.AddTriggerEffect(animationShape, fadeEffect, triggerType, triggerShape);
+                }
+                // Rest of the shapes will disappear with the first shape
+                else
+                {
+                    triggerType = MsoAnimTriggerType.msoAnimTriggerWithPrevious;
+                    effect = sequence.AddEffect(shapesToAnimate[i], fadeEffect, MsoAnimateByLevel.msoAnimateLevelNone, MsoAnimTriggerType.msoAnimTriggerWithPrevious);
+                }
+                effect.Exit = Microsoft.Office.Core.MsoTriState.msoTrue;
             }
         }
 


### PR DESCRIPTION
**Phase 2 of `Tooltips-Lab`: Changing behaviour of `Create Tooltip` and `Assign Tooltip`**
The other proposed changes can be found in #1767 

_Previously,_ 
`Create Tooltip` and ` Assign Tooltip` will add an appear effect to the callout shape. (Subsequent clicks will make the shape disappear and reappear in one click)

_Now,_
`Create Tooltip` and ` Assign Tooltip`  will add an appear and exit effect to the callout shape. (1st click makes shape appear, second click makes shape disappear)

_Previously,_
Subsequent Usage of `Create Tooltip` and ` Assign Tooltip`  on the same trigger will add animations to the next click. i.e. Callout Shape 1 appears on first click. Callout Shape 2 appears on second click. 

_Now,_ 
Subsequent Usage of `Create Tooltip` and ` Assign Tooltip`  on the same trigger will make all Callout Shapes assigned to trigger appear together and disappear together. 

![phase 2](https://user-images.githubusercontent.com/39242483/53218699-1e223d00-3698-11e9-8f79-76785938d90c.gif)
