### PR TITLE
#1374 Disable rotation mode when exception is caught

### DIFF
--- a/PowerPointLabs/PowerPointLabs/PositionsLab/PositionsPaneWPF.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/PositionsLab/PositionsPaneWPF.xaml.cs
@@ -375,7 +375,7 @@ namespace PowerPointLabs.PositionsLab
                                                                        : null;
             try
             {
-                if (button.IsMouseOver)
+                if (button == null || button.IsMouseOver)
                 {
                     DisableRotationMode();
                     return;

--- a/PowerPointLabs/PowerPointLabs/PositionsLab/PositionsPaneWPF.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/PositionsLab/PositionsPaneWPF.xaml.cs
@@ -370,12 +370,11 @@ namespace PowerPointLabs.PositionsLab
 
         void _leftMouseDownListener_Rotation(object sender, SysMouseEventInfo e)
         {
-            try
-            {
-                ToggleButton button = ((bool)rotationButton.IsChecked) ? rotationButton :
+            ToggleButton button = ((bool)rotationButton.IsChecked) ? rotationButton :
                              ((bool)duplicateRotationButton.IsChecked) ? duplicateRotationButton
                                                                        : null;
-
+            try
+            {
                 if (button.IsMouseOver)
                 {
                     DisableRotationMode();
@@ -427,6 +426,8 @@ namespace PowerPointLabs.PositionsLab
             catch (Exception ex)
             {
                 Logger.LogException(ex, "Rotation");
+                DisableRotationMode();
+                button.IsChecked = false;
             }
         }
 


### PR DESCRIPTION
Fixes #1374 partially.

**Outline of Solution**
I am unable to diagnose why grouped shapes might become unselected after releasing the mouse. 
`_selectedRange` always returns the right group of shapes upon manual checking in the [mouse up handler](https://github.com/ChesterSng/PowerPointLabs/blob/98030db1e4a08efa905f413dae23a9a6220ac143/PowerPointLabs/PowerPointLabs/PositionsLab/PositionsPaneWPF.xaml.cs#L356-L362).

However, solved the issue caused by the deletion of the reference shape. 

_Before_
An exception will be caught however, the Rotation Mode is not disabled in the caught exception block.

_After_
Disable rotation mode when exception is caught. 