### PR TITLE
#1756 Prevent illegal adjustment of GridSplitter

### DIFF
--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Views/PictureSlidesLabWindow.xaml
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Views/PictureSlidesLabWindow.xaml
@@ -48,12 +48,12 @@
                 <converter:StyleVariationWidthConverter x:Key="StyleVariationWidthConverter"></converter:StyleVariationWidthConverter>
             </Grid.Resources>
             <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="auto"></ColumnDefinition>
-                <ColumnDefinition Width="auto"></ColumnDefinition>
-                <ColumnDefinition Width="*"></ColumnDefinition>
+                <ColumnDefinition Name="Column0" Width="*" MinWidth="300"></ColumnDefinition>
+                <ColumnDefinition Name="Column1" Width="auto"></ColumnDefinition>
+                <ColumnDefinition Name="Column2" Width="*" MinWidth="400"></ColumnDefinition>
             </Grid.ColumnDefinitions>
             <GridSplitter Name="Splitter" DragDelta="Splitter_OnDragDelta" Grid.Column="1" ResizeDirection="Columns" Width="3" Height="Auto" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" />
-            <Grid Visibility="Collapsed" Width="560" Margin="10,0,0,0" Name="StylesPreviewGrid" Grid.Column="0">
+            <Grid Visibility="Collapsed" Width="560" Margin="10,0,0,0" Name="StylesPreviewGrid" Grid.Column="0" MinWidth="300">
                 <Grid.RowDefinitions>
                     <RowDefinition Height="5" />
                     <RowDefinition Height="35" />
@@ -158,7 +158,7 @@
                     </ListBox.ItemTemplate>
                 </ListBox>
             </Grid>
-            <Grid Visibility="Collapsed" Name="StyleVariationsFlyout" Width="{Binding Path=ActualWidth, ElementName=StylesPreviewListBox, Converter={StaticResource StyleVariationWidthConverter}}" Background="#252525" Grid.Column="0">
+            <Grid Visibility="Collapsed" Name="StyleVariationsFlyout" Width="{Binding Path=ActualWidth, ElementName=StylesPreviewListBox, Converter={StaticResource StyleVariationWidthConverter}}" MinWidth="400" Background="#252525" Grid.Column="0">
                 <Grid.Resources>
                     <ResourceDictionary>
                         <ResourceDictionary.MergedDictionaries>

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Views/PictureSlidesLabWindow.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Views/PictureSlidesLabWindow.xaml.cs
@@ -532,7 +532,21 @@ namespace PowerPointLabs.PictureSlidesLab.Views
         /// <param name="e"></param>
         private void Splitter_OnDragDelta(object sender, DragDeltaEventArgs e)
         {
-            StylesPreviewGrid.Width = StylesPreviewGrid.ActualWidth + e.HorizontalChange;
+            double newWidth = StylesPreviewGrid.ActualWidth + e.HorizontalChange;
+            // Prevent StylesPreviewGrid from becoming too small
+            if (newWidth < StylesPreviewGrid.MinWidth)
+            {
+                StylesPreviewGrid.Width = StylesPreviewGrid.MinWidth;
+            }
+            // Prevent StylesPreviewGrid from overflowing grid column 0
+            else if (newWidth > Column0.Width.Value)
+            {
+                StylesPreviewGrid.Width = Column0.Width.Value;
+            }
+            else
+            {
+                StylesPreviewGrid.Width = newWidth;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #1756 

There were no minimum widths for the grid columns so the splitter was able to exit the screen. Also, splitter can resize grid columns to an unusable width.

**Outline of Solution**
<!-- Tell us how you solved the issue. -->
1. Set minimum Widths for the grid columns

2. Add checks for dragging of splitter so `StylesPreviewGrid` (the area which the slides are previewed) will be the same size as the grid column 

_The minimum widths 300 and 400 are selected because they are the minimum width where all functionalities will be on the screen_

__Minimum width of 300 for previewing styles__
![minimum preview styles](https://user-images.githubusercontent.com/39242483/53627782-53083400-3c44-11e9-9755-42ebfd0ec951.PNG)

__Minimum width of 400 for the picture selector__
![minimum flyout](https://user-images.githubusercontent.com/39242483/53627774-4d125300-3c44-11e9-9f83-f748ce1106ff.PNG)


