### PR TITLE
#1797 Add checkbox to ribbon for user preference to compress images

### DIFF
--- a/PowerPointLabs/PowerPointLabs/Ribbon1.cs
+++ b/PowerPointLabs/PowerPointLabs/Ribbon1.cs
@@ -160,15 +160,7 @@ namespace PowerPointLabs
         {
             ShouldCompressImages = pressed;
             _ribbon.InvalidateControl("ShouldCompressImagesCheckbox");
-
-            if (ShouldCompressImages)
-            {
-                GraphicsUtil.PictureExportingRatio = 96.0f / 72.0f;
-            }
-            else
-            {
-                GraphicsUtil.PictureExportingRatio = 330.0f / 72.0f;
-            }
+            GraphicsUtil.ShouldCompressPictureExport(ShouldCompressImages);
         }
 
 

--- a/PowerPointLabs/PowerPointLabs/Ribbon1.cs
+++ b/PowerPointLabs/PowerPointLabs/Ribbon1.cs
@@ -188,6 +188,12 @@ namespace PowerPointLabs
             return DisableFormatTab;
         }
 
+        // Sets the default starting status of the checkbox (whether checked or not)
+        public bool SetImageCompression(Office.IRibbonControl control)
+        {
+            return ShouldCompressImages;
+        }
+
         public void RibbonLoad(Office.IRibbonUI ribbonUi)
         {
             ActionHandlerFactory = new ActionHandlerFactory();

--- a/PowerPointLabs/PowerPointLabs/Ribbon1.cs
+++ b/PowerPointLabs/PowerPointLabs/Ribbon1.cs
@@ -12,6 +12,7 @@ using PowerPointLabs.ActionFramework.Common.Log;
 using PowerPointLabs.ELearningLab.Service;
 using PowerPointLabs.PictureSlidesLab.Views;
 using PowerPointLabs.TextCollection;
+using PowerPointLabs.Utils;
 
 using Office = Microsoft.Office.Core;
 using PowerPoint = Microsoft.Office.Interop.PowerPoint;
@@ -125,6 +126,8 @@ namespace PowerPointLabs
         private Office.IRibbonUI _ribbon;
         // Initial bool value for whether the Drawing Tools Format Tab is disabled
         private bool DisableFormatTab { get; set; }
+        // Initial bool value for whether images should be compressed
+        private bool ShouldCompressImages { get; set; }
 
         #region IRibbonExtensibility Members
 
@@ -152,11 +155,33 @@ namespace PowerPointLabs
             _ribbon.InvalidateControl("VisibleFormatShapes");
         }
 
+        // Toggles the boolean controlling whether images should be compressed.
+        public void ToggleImageCompression(Office.IRibbonControl control, bool pressed)
+        {
+            ShouldCompressImages = pressed;
+            _ribbon.InvalidateControl("ShouldCompressImagesCheckbox");
+
+            if (ShouldCompressImages)
+            {
+                GraphicsUtil.PictureExportingRatio = 96.0f / 72.0f;
+            }
+            else
+            {
+                GraphicsUtil.PictureExportingRatio = 330.0f / 72.0f;
+            }
+        }
+
+
         public void InitialiseVisibilityCheckbox()
         {
             _ribbon.InvalidateControl("VisibleFormatShapes");
         }
         
+        public void InitialiseCompressImagesCheckbox()
+        {
+            _ribbon.InvalidateControl("ShouldCompressImagesCheckbox");
+        }
+
         // Sets the default starting status of the checkbox (whether checked or not)
         public bool SetVisibility(Office.IRibbonControl control)
         {
@@ -175,6 +200,7 @@ namespace PowerPointLabs
             CheckBoxActionHandlerFactory = new CheckBoxActionHandlerFactory();
 
             DisableFormatTab = new Boolean();
+            ShouldCompressImages = new Boolean();
 
             _ribbon = ribbonUi;
         }

--- a/PowerPointLabs/PowerPointLabs/Ribbon1.xml
+++ b/PowerPointLabs/PowerPointLabs/Ribbon1.xml
@@ -579,8 +579,9 @@
           
         </group>
         
-        <group id="Visibility" label="Tab Management">
+        <group id="Visibility" label="General">
           <checkBox id="VisibleFormatShapes" enabled="true" label="Maintain Tab Focus" supertip="Stay on PowerPointLabs tab after inserting a shape" onAction="ToggleVisibility" getPressed="SetVisibility"/>
+          <checkBox id="ShouldCompressImagesCheckbox" enabled="true" label="Compress Images" supertip="Compress images during image-related functions" onAction="ToggleImageCompression"/>
         </group>
         
       </tab>

--- a/PowerPointLabs/PowerPointLabs/Ribbon1.xml
+++ b/PowerPointLabs/PowerPointLabs/Ribbon1.xml
@@ -581,7 +581,7 @@
         
         <group id="Visibility" label="General">
           <checkBox id="VisibleFormatShapes" enabled="true" label="Maintain Tab Focus" supertip="Stay on PowerPointLabs tab after inserting a shape" onAction="ToggleVisibility" getPressed="SetVisibility"/>
-          <checkBox id="ShouldCompressImagesCheckbox" enabled="true" label="Compress Images" supertip="Compress images during image-related functions" onAction="ToggleImageCompression"/>
+          <checkBox id="ShouldCompressImagesCheckbox" enabled="true" label="Compress Images" supertip="Compress images during image-related functions" onAction="ToggleImageCompression" getPressed="SetImageCompression"/>
         </group>
         
       </tab>

--- a/PowerPointLabs/PowerPointLabs/Ribbon1.xml
+++ b/PowerPointLabs/PowerPointLabs/Ribbon1.xml
@@ -581,7 +581,9 @@
         
         <group id="Visibility" label="General">
           <checkBox id="VisibleFormatShapes" enabled="true" label="Maintain Tab Focus" supertip="Stay on PowerPointLabs tab after inserting a shape" onAction="ToggleVisibility" getPressed="SetVisibility"/>
-          <checkBox id="ShouldCompressImagesCheckbox" enabled="true" label="Compress Images" supertip="Compress images during image-related functions" onAction="ToggleImageCompression" getPressed="SetImageCompression"/>
+          <checkBox id="ShouldCompressImagesCheckbox" enabled="true" label="Compress Images" 
+                    supertip="Compress images during image-related functions. These functions are:&#xD;- Effects Lab functions&#xD;- Zoom Lab functions&#xD;- Crop To Shape (Crop Lab)" 
+                    onAction="ToggleImageCompression" getPressed="SetImageCompression"/>
         </group>
         
       </tab>

--- a/PowerPointLabs/PowerPointLabs/ThisAddIn.cs
+++ b/PowerPointLabs/PowerPointLabs/ThisAddIn.cs
@@ -1055,8 +1055,9 @@ namespace PowerPointLabs
 
             // Refresh ribbon to enable the menu buttons
             RefreshRibbonMenuButtons();
-            // Initialise the "Maintain Tab Focus" checkbox
+            // Initialise the "Maintain Tab Focus" and "Compress Images" checkbox
             Ribbon.InitialiseVisibilityCheckbox();
+            Ribbon.InitialiseCompressImagesCheckbox();
         }
 
         // solve new un-modified unsave problem
@@ -1083,8 +1084,9 @@ namespace PowerPointLabs
 
                 // Refresh ribbon to enable the menu buttons if there are now at least one window
                 RefreshRibbonMenuButtons();
-                // Initialise the "Maintain Tab Focus" checkbox
+                // Initialise the "Maintain Tab Focus" and "Compress Images" checkbox
                 Ribbon.InitialiseVisibilityCheckbox();
+                Ribbon.InitialiseCompressImagesCheckbox();
             }
             // load audio setting preference for elearning lab
             AudioSettingStorageService.LoadAudioSettingPreference();

--- a/PowerPointLabs/PowerPointLabs/Utils/GraphicsUtil.cs
+++ b/PowerPointLabs/PowerPointLabs/Utils/GraphicsUtil.cs
@@ -29,12 +29,12 @@ namespace PowerPointLabs.Utils
         #region Constants
         private static readonly Object FileLock = new object();
         public static float PictureExportingRatio = 330.0f / 72.0f;
-        private const float TargetDpi = 96.0f;
+        private const float targetDpi = 96.0f;
         private static float dpiScale = 1.0f;
 
         // Picture exporting ratios
-        private const float PictureExportingRatioHigh = 330.0f / 72.0f;
-        private const float PictureExportingRatioCompressed = 96.0f / 72.0f;
+        private const float pictureExportingRatioHigh = 330.0f / 72.0f;
+        private const float pictureExportingRatioCompressed = 96.0f / 72.0f;
 
         // Heuristics for image compression obtained through testing
         private const long targetCompression = 75L;
@@ -45,7 +45,7 @@ namespace PowerPointLabs.Utils
         {
             using (Graphics g = Graphics.FromHwnd(IntPtr.Zero))
             {
-                dpiScale = g.DpiX / TargetDpi;
+                dpiScale = g.DpiX / targetDpi;
             }
         }
         #endregion
@@ -297,7 +297,7 @@ namespace PowerPointLabs.Utils
 
         public static void ShouldCompressPictureExport(bool shouldCompress)
         {
-            PictureExportingRatio = shouldCompress ? PictureExportingRatioCompressed : PictureExportingRatioHigh;
+            PictureExportingRatio = shouldCompress ? pictureExportingRatioCompressed : pictureExportingRatioHigh;
         }
 
         #endregion

--- a/PowerPointLabs/PowerPointLabs/Utils/GraphicsUtil.cs
+++ b/PowerPointLabs/PowerPointLabs/Utils/GraphicsUtil.cs
@@ -28,7 +28,7 @@ namespace PowerPointLabs.Utils
 
         #region Constants
         private static readonly Object FileLock = new object();
-        public const float PictureExportingRatio = 96.0f / 72.0f;
+        public static float PictureExportingRatio = 330.0f / 72.0f;
         private const float TargetDpi = 96.0f;
         private static float dpiScale = 1.0f;
         // Heuristics for image compression obtained through testing
@@ -309,14 +309,14 @@ namespace PowerPointLabs.Utils
 
         private static double GetDesiredExportWidth()
         {
-            // Powerpoint displays at 72 dpi, while the picture stores in 96 dpi.
-            return PowerPointPresentation.Current.SlideWidth / 72.0 * 96.0;
+            // Powerpoint displays at 72 dpi, while the picture stores in 96 dpi or 330 dpi, depending on user option.
+            return PowerPointPresentation.Current.SlideWidth * PictureExportingRatio;
         }
 
         private static double GetDesiredExportHeight()
         {
-            // Powerpoint displays at 72 dpi, while the picture stores in 96 dpi.
-            return PowerPointPresentation.Current.SlideHeight / 72.0 * 96.0;
+            // Powerpoint displays at 72 dpi, while the picture stores in 96 dpi or 330 dpi, depending on user option.
+            return PowerPointPresentation.Current.SlideHeight * PictureExportingRatio;
         }
 
         /// <summary>

--- a/PowerPointLabs/PowerPointLabs/Utils/GraphicsUtil.cs
+++ b/PowerPointLabs/PowerPointLabs/Utils/GraphicsUtil.cs
@@ -31,6 +31,11 @@ namespace PowerPointLabs.Utils
         public static float PictureExportingRatio = 330.0f / 72.0f;
         private const float TargetDpi = 96.0f;
         private static float dpiScale = 1.0f;
+
+        // Picture exporting ratios
+        private const float PictureExportingRatioHigh = 330.0f / 72.0f;
+        private const float PictureExportingRatioCompressed = 96.0f / 72.0f;
+
         // Heuristics for image compression obtained through testing
         private const long targetCompression = 75L;
         private const long fileSizeLimit = 40000L;
@@ -286,6 +291,15 @@ namespace PowerPointLabs.Utils
         {
             return new SolidColorBrush(MediaColorFromDrawingColor(color));
         }
+        #endregion
+
+        #region Settings
+
+        public static void ShouldCompressPictureExport(bool shouldCompress)
+        {
+            PictureExportingRatio = shouldCompress ? PictureExportingRatioCompressed : PictureExportingRatioHigh;
+        }
+
         #endregion
 
         #endregion


### PR DESCRIPTION
Fixes #1797 

**Outline of Solution**
Previously, when using `Crop to Shape`, high resolution images will be compressed after the crop. This is because we were exporting the images at 96ppi. This PR bumps this up to 330ppi to maintain a certain amount of quality on the pictures.

Before:
![croptoshape-before](https://user-images.githubusercontent.com/39292809/53678707-b86c2b80-3cfd-11e9-8248-3fe6c32b36f0.png)
After:
![croptoshape-after](https://user-images.githubusercontent.com/39292809/53678709-ba35ef00-3cfd-11e9-8b47-80aff67b42f7.png)

There is also a checkbox added to the main ribbon to allow users to decide if they would like images to be compressed. If this is checked, the image exporting resolution will be set back down to the original 96ppi.

Checkbox:
![compress-images-checkbox](https://user-images.githubusercontent.com/39292809/53678731-0719c580-3cfe-11e9-8e68-9be31f252475.PNG)

Note: this PR also affects other labs that use the same exporting and import method, including `EffectsLab`, thus the FT slides for `EffectsLab` had to be updated.