### PR TITLE
Move constants to TooltipsLabConstants + refactor

### DIFF
--- a/PowerPointLabs/PowerPointLabs/ActionFramework/TooltipsLab/AssignTooltip/AssignTooltipActionHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/TooltipsLab/AssignTooltip/AssignTooltipActionHandler.cs
@@ -20,6 +20,11 @@ namespace PowerPointLabs.ActionFramework.TooltipsLab
             Selection selection = this.GetCurrentSelection();
             PowerPointSlide currentSlide = this.GetCurrentSlide();
 
+            if (currentSlide == null)
+            {
+                return;
+            }
+
             if (!ShapeUtil.IsSelectionShape(selection))
             {
                 return;

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/TooltipsLab/AssignTooltip/AssignTooltipActionHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/TooltipsLab/AssignTooltip/AssignTooltipActionHandler.cs
@@ -34,9 +34,9 @@ namespace PowerPointLabs.ActionFramework.TooltipsLab
             {
                 AssignTooltip.AddTriggerAnimation(currentSlide, selection);
                 // Open the animation custom pane if it is not opened
-                if (!this.GetApplication().CommandBars.GetPressedMso("AnimationCustom"))
+                if (!this.GetApplication().CommandBars.GetPressedMso(TooltipsLabConstants.AnimationPaneName))
                 {
-                    this.GetApplication().CommandBars.ExecuteMso("AnimationCustom");
+                    this.GetApplication().CommandBars.ExecuteMso(TooltipsLabConstants.AnimationPaneName);
                 }
             }
             catch (Exception)

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/TooltipsLab/Create/CreateCallout/CreateCalloutActionHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/TooltipsLab/Create/CreateCallout/CreateCalloutActionHandler.cs
@@ -29,7 +29,7 @@ namespace PowerPointLabs.ActionFramework.TooltipsLab
 
             if (selection.Type != PowerPoint.PpSelectionType.ppSelectionShapes)
             {
-                MessageBox.Show("Please select 1 or more shapes as your trigger shape.");
+                MessageBox.Show(TooltipsLabText.ErrorNoTriggerShapeSelected);
                 return;
             }
 
@@ -40,9 +40,9 @@ namespace PowerPointLabs.ActionFramework.TooltipsLab
                 AssignTooltip.AddTriggerAnimation(currentSlide, selectedShape, calloutGroup);
             }
             
-            if (!this.GetApplication().CommandBars.GetPressedMso("AnimationCustom"))
+            if (!this.GetApplication().CommandBars.GetPressedMso(TooltipsLabConstants.AnimationPaneName))
             {
-                this.GetApplication().CommandBars.ExecuteMso("AnimationCustom");
+                this.GetApplication().CommandBars.ExecuteMso(TooltipsLabConstants.AnimationPaneName);
             }
         }
     }

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/TooltipsLab/Create/CreateCallout/CreateCalloutActionHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/TooltipsLab/Create/CreateCallout/CreateCalloutActionHandler.cs
@@ -20,6 +20,11 @@ namespace PowerPointLabs.ActionFramework.TooltipsLab
 
             PowerPointSlide currentSlide = this.GetCurrentSlide();
 
+            if (currentSlide == null)
+            {
+                return;
+            }
+
             PowerPoint.Selection selection = this.GetCurrentSelection();
 
             if (selection.Type != PowerPoint.PpSelectionType.ppSelectionShapes)

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/TooltipsLab/Create/CreateTooltip/CreateTooltipActionHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/TooltipsLab/Create/CreateTooltip/CreateTooltipActionHandler.cs
@@ -29,9 +29,9 @@ namespace PowerPointLabs.ActionFramework.TooltipsLab
             PowerPoint.Shape calloutGroup = AddTextbox.AddTextboxToCallout(currentSlide, callout);
             AssignTooltip.AddTriggerAnimation(currentSlide, triggerShape, calloutGroup);
 
-            if (!this.GetApplication().CommandBars.GetPressedMso("AnimationCustom"))
+            if (!this.GetApplication().CommandBars.GetPressedMso(TooltipsLabConstants.AnimationPaneName))
             {
-                this.GetApplication().CommandBars.ExecuteMso("AnimationCustom");
+                this.GetApplication().CommandBars.ExecuteMso(TooltipsLabConstants.AnimationPaneName);
             }
         }
     }

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/TooltipsLab/Create/CreateTooltip/CreateTooltipActionHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/TooltipsLab/Create/CreateTooltip/CreateTooltipActionHandler.cs
@@ -18,6 +18,11 @@ namespace PowerPointLabs.ActionFramework.TooltipsLab
             this.StartNewUndoEntry();
 
             PowerPointSlide currentSlide = this.GetCurrentSlide();
+
+            if (currentSlide == null)
+            {
+                return;
+            }
             
             PowerPoint.Shape triggerShape = CreateTooltip.GenerateTriggerShape(currentSlide);
             PowerPoint.Shape callout = CreateTooltip.GenerateCalloutWithReferenceTriggerShape(currentSlide, triggerShape);

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/TooltipsLab/Create/CreateTrigger/CreateTriggerActionHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/TooltipsLab/Create/CreateTrigger/CreateTriggerActionHandler.cs
@@ -28,7 +28,7 @@ namespace PowerPointLabs.ActionFramework.TooltipsLab
 
             if (selection.Type != PowerPoint.PpSelectionType.ppSelectionShapes)
             {
-                MessageBox.Show("Please select 1 or more shapes as your callout shape.");
+                MessageBox.Show(TooltipsLabText.ErrorNoCalloutShapeSelected);
                 return;
             }
 
@@ -38,9 +38,9 @@ namespace PowerPointLabs.ActionFramework.TooltipsLab
                 AssignTooltip.AddTriggerAnimation(currentSlide, triggerShape, selectedShape);
             }
 
-            if (!this.GetApplication().CommandBars.GetPressedMso("AnimationCustom"))
+            if (!this.GetApplication().CommandBars.GetPressedMso(TooltipsLabConstants.AnimationPaneName))
             {
-                this.GetApplication().CommandBars.ExecuteMso("AnimationCustom");
+                this.GetApplication().CommandBars.ExecuteMso(TooltipsLabConstants.AnimationPaneName);
             }
         }
     }

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/TooltipsLab/Create/CreateTrigger/CreateTriggerActionHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/TooltipsLab/Create/CreateTrigger/CreateTriggerActionHandler.cs
@@ -19,6 +19,11 @@ namespace PowerPointLabs.ActionFramework.TooltipsLab
 
             PowerPointSlide currentSlide = this.GetCurrentSlide();
 
+            if (currentSlide == null)
+            {
+                return;
+            }
+
             PowerPoint.Selection selection = this.GetCurrentSelection();
 
             if (selection.Type != PowerPoint.PpSelectionType.ppSelectionShapes)
@@ -29,11 +34,6 @@ namespace PowerPointLabs.ActionFramework.TooltipsLab
 
             foreach (PowerPoint.Shape selectedShape in selection.ShapeRange)
             {
-                // TODO: Adding a trigger to an existing shape that is already part of a trigger animation as the "callout" (whether created by user or by TooltipsLab)
-                //       can possible cause some weird behaviour. For e.g. if user clicked once to show the callout on Trigger A, clicking Trigger B will not hide the callout,
-                //       but instead re-show the callout again. Might be a good idea to see if we can detect if the selectedShape is already part of a trigger animation
-                //       as a callout, then popup a MessageBox asking if the user is sure he/she wants to continue.
-
                 PowerPoint.Shape triggerShape = CreateTooltip.GenerateTriggerShapeWithReferenceCallout(currentSlide, selectedShape);
                 AssignTooltip.AddTriggerAnimation(currentSlide, triggerShape, selectedShape);
             }

--- a/PowerPointLabs/PowerPointLabs/PowerPointLabs.csproj
+++ b/PowerPointLabs/PowerPointLabs/PowerPointLabs.csproj
@@ -850,6 +850,7 @@
     <Compile Include="TooltipsLab\CreateTooltip.cs" />
     <Compile Include="TooltipsLab\AddTextbox.cs" />
     <Compile Include="TooltipsLab\AttachTriggerAnimation.cs" />
+    <Compile Include="TooltipsLab\TooltipsLabConstants.cs" />
     <Compile Include="Utils\ClipboardUtil.cs" />
     <Compile Include="Utils\ShapeUtil.cs" />
     <Compile Include="Utils\SlideUtil.cs" />

--- a/PowerPointLabs/PowerPointLabs/TextCollection/TooltipsLabText.cs
+++ b/PowerPointLabs/PowerPointLabs/TextCollection/TooltipsLabText.cs
@@ -39,6 +39,8 @@
 
         public const string ErrorTooltipsDialogTitle = "Unable to execute action";
         public const string ErrorLessThanTwoShapesSelected = "Please select at least two shapes. The first shape will be the trigger shape.";
+        public const string ErrorNoTriggerShapeSelected = "Please select 1 or more shapes as your trigger shape.";
+        public const string ErrorNoCalloutShapeSelected = "Please select 1 or more shapes as your callout shape.";
         #endregion
     }
 }

--- a/PowerPointLabs/PowerPointLabs/TooltipsLab/CreateTooltip.cs
+++ b/PowerPointLabs/PowerPointLabs/TooltipsLab/CreateTooltip.cs
@@ -17,17 +17,15 @@ namespace PowerPointLabs.TooltipsLab
         // Generate a trigger shape directly in the center bottom position of the specified callout shape.
         public static PowerPoint.Shape GenerateTriggerShapeWithReferenceCallout(PowerPointSlide currentSlide, PowerPoint.Shape callout)
         {
-            float height = 25;
-            float width = 25;
-            float left = ShapeUtil.GetCenterPoint(callout).X - width / 2;
-            float top = ShapeUtil.GetBottom(callout) + 10;
+            float left = ShapeUtil.GetCenterPoint(callout).X - TooltipsLabConstants.TriggerShapeDefaultWidth / 2;
+            float top = ShapeUtil.GetBottom(callout) + TooltipsLabConstants.TriggerShapeAndCalloutSpacing;
 
             PowerPoint.Shape triggerShape = currentSlide.Shapes.AddShape(
                 Microsoft.Office.Core.MsoAutoShapeType.msoShapeOval, 
                 left, 
                 top, 
-                width, 
-                height);
+                TooltipsLabConstants.TriggerShapeDefaultWidth, 
+                TooltipsLabConstants.TriggerShapeDefaultHeight);
 
             return triggerShape;
         }
@@ -36,32 +34,25 @@ namespace PowerPointLabs.TooltipsLab
         {
             float midpointX = ShapeUtil.GetMidpointX(triggerShape);
 
-            // TODO: To be moved to TooltipsLabConstants in the future.
-            int height = 100;
-            int width = 150;
-
-            // TODO: 0.20833 and 1.125 and 10 should be moved to TooltipsLabConstants in the future.
-            // Explanation for the choice of constants:
-            // - 0.20833 is the horizontal percentage adjustment of the arrowhead of the callout.
-            //   We position the callout with middle alignment to the trigger shape, then shift it
-            //   back to the right by 20.833% of the callout's width to align the arrowhead with the trigger shape.
-            // - 1.125 is the vertical percentage adjustment of the arrowhead of the callout.
-            //   Same explanation as the horizontal adjustment, just that this is for the height.
-            // - 10 is for extra padding between the arrowhead of the callout and the trigger shape.
+           
             PowerPoint.Shape callout = currentSlide.Shapes.AddShape(
                 Microsoft.Office.Core.MsoAutoShapeType.msoShapeRoundedRectangularCallout,
-                midpointX - width/2 + (float)(0.20833 * width),
-                triggerShape.Top - (float)(1.125 * height) - 10,
-                width,
-                height);
+                midpointX - TooltipsLabConstants.CalloutShapeDefaultWidth/2 + (float)(TooltipsLabConstants.CalloutArrowheadHorizontalAdjustment * TooltipsLabConstants.CalloutShapeDefaultWidth),
+                triggerShape.Top - (float)(TooltipsLabConstants.CalloutArrowheadVerticalAdjustment * TooltipsLabConstants.CalloutShapeDefaultHeight) - TooltipsLabConstants.TriggerShapeAndCalloutSpacing,
+                TooltipsLabConstants.CalloutShapeDefaultWidth,
+                TooltipsLabConstants.CalloutShapeDefaultHeight);
 
             return callout;
         }
 
         public static PowerPoint.Shape GenerateTriggerShape(PowerPointSlide currentSlide)
         {
-            // TODO: These are all hardcoded values for now. They should be replaced in the future.
-            PowerPoint.Shape triggerShape = currentSlide.Shapes.AddShape(Microsoft.Office.Core.MsoAutoShapeType.msoShapeOval, 200, 200, 25, 25);
+            PowerPoint.Shape triggerShape = currentSlide.Shapes.AddShape(
+                Microsoft.Office.Core.MsoAutoShapeType.msoShapeOval, 
+                TooltipsLabConstants.TriggerShapeDefaultLeft, 
+                TooltipsLabConstants.TriggerShapeDefaultTop, 
+                TooltipsLabConstants.TriggerShapeDefaultWidth, 
+                TooltipsLabConstants.TriggerShapeDefaultHeight);
             return triggerShape;
         }
 

--- a/PowerPointLabs/PowerPointLabs/TooltipsLab/TooltipsLabConstants.cs
+++ b/PowerPointLabs/PowerPointLabs/TooltipsLab/TooltipsLabConstants.cs
@@ -1,0 +1,28 @@
+﻿
+namespace PowerPointLabs.TooltipsLab
+{
+    static class TooltipsLabConstants
+    {
+        public const float TriggerShapeDefaultLeft = 200;
+        public const float TriggerShapeDefaultTop = 200;
+        public const float TriggerShapeDefaultHeight = 25;
+        public const float TriggerShapeDefaultWidth = 25;
+        public const float TriggerShapeAndCalloutSpacing = 10;
+
+        public const float CalloutShapeDefaultHeight = 100;
+        public const float CalloutShapeDefaultWidth = 150;
+
+        // Explanation for the choice of constants:
+        // - 0.20833 is the horizontal percentage adjustment of the arrowhead of the callout.
+        //   We position the callout with middle alignment to the trigger shape, then shift it
+        //   back to the right by 20.833% of the callout's width to align the arrowhead with the trigger shape.
+        // - 1.125 is the vertical percentage adjustment of the arrowhead of the callout.
+        //   Same explanation as the horizontal adjustment, just that this is for the height.
+        public const double CalloutArrowheadHorizontalAdjustment = 0.20833;
+        public const double CalloutArrowheadVerticalAdjustment = 1.125;
+
+        public const string AnimationPaneName = "AnimationCustom";
+
+
+    }
+}


### PR DESCRIPTION
- Added guard clauses for checking of active slide selection
- Remove expired comments
- Move all constants and strings to `TooltipsLabConstants` and `TooltipsLabText`