### PR TITLE
#1769 Replace .Copy() and .Paste() in ZoomToArea with .Duplicate()

### DIFF
--- a/PowerPointLabs/PowerPointLabs/CropLab/CropToShape.cs
+++ b/PowerPointLabs/PowerPointLabs/CropLab/CropToShape.cs
@@ -49,8 +49,8 @@ namespace PowerPointLabs.CropLab
                 Shape shape = hasManyShapes ? shapeRange.Group() : shapeRange[1];
                 float left = shape.Left;
                 float top = shape.Top;
-                shape.Cut();
-                shapeRange = currentSlide.Shapes.Paste();
+                shapeRange = shape.Duplicate();
+                shape.Delete();
                 shapeRange.Left = left;
                 shapeRange.Top = top;
                 if (hasManyShapes)
@@ -93,8 +93,7 @@ namespace PowerPointLabs.CropLab
                 return shape;
             }
 
-            shape.Copy();
-            Shape shapeToReturn = currentSlide.Shapes.Paste()[1];
+            Shape shapeToReturn = shape.Duplicate()[1];
             shape.Delete();
             return shapeToReturn;
         }

--- a/PowerPointLabs/PowerPointLabs/Models/PowerPointDeMagnifyingSlide.cs
+++ b/PowerPointLabs/PowerPointLabs/Models/PowerPointDeMagnifyingSlide.cs
@@ -161,9 +161,7 @@ namespace PowerPointLabs.Models
 
         private PowerPoint.Shape GetReferenceShape(PowerPoint.Shape shapeToZoom)
         {
-            shapeToZoom.Copy();
-
-            PowerPoint.Shape referenceShape = _slide.Shapes.Paste()[1];
+            PowerPoint.Shape referenceShape = shapeToZoom.Duplicate()[1];
             referenceShape.LockAspectRatio = Office.MsoTriState.msoTrue;
             if (referenceShape.Width > referenceShape.Height)
             {

--- a/PowerPointLabs/PowerPointLabs/Models/PowerPointMagnifyingSlide.cs
+++ b/PowerPointLabs/PowerPointLabs/Models/PowerPointMagnifyingSlide.cs
@@ -1,9 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-
+using System.Windows;
 using PowerPointLabs.AnimationLab;
 using PowerPointLabs.CropLab;
+using PowerPointLabs.Utils;
 using PowerPointLabs.ZoomLab;
 
 using Office = Microsoft.Office.Core;
@@ -144,9 +145,33 @@ namespace PowerPointLabs.Models
             cropShape.Select();
             PowerPoint.Selection sel = Globals.ThisAddIn.Application.ActiveWindow.Selection;
             PowerPoint.Shape croppedShape = CropToShape.Crop(zoomSlideCopy, sel, magnifyRatio: magnifyRatio);
-            croppedShape.Cut();
+            try
+            {
+                string tempFilePath = FileDir.GetTemporaryPngFilePath();
+                Utils.GraphicsUtil.ExportShape(croppedShape, tempFilePath);
+                zoomSlideCroppedShapes = _slide.Shapes.AddPicture2(tempFilePath,
+                    Office.MsoTriState.msoFalse,
+                    Office.MsoTriState.msoTrue,
+                    0,
+                    0);
+                croppedShape.Delete();
+                try
+                {
+                    FileDir.DeleteFile(tempFilePath);
+                }
+                catch (Exception)
+                {
+                    // If the file cannot be deleted, we continue without deletion.
+                }
 
-            zoomSlideCroppedShapes = _slide.Shapes.PasteSpecial(PowerPoint.PpPasteDataType.ppPastePNG)[1];
+            }
+            catch (Exception)
+            {
+                // Revert to normal copy and pasting if unable to create file.
+                croppedShape.Cut();
+                zoomSlideCroppedShapes = _slide.Shapes.PasteSpecial(PowerPoint.PpPasteDataType.ppPasteMetafilePicture)[1];
+            }
+
             zoomSlideCroppedShapes.Name = "PPTLabsMagnifyAreaGroup" + DateTime.Now.ToString("yyyyMMddHHmmssffff");
             Utils.ShapeUtil.FitShapeToSlide(ref zoomSlideCroppedShapes);
             zoomSlideCopy.Delete();

--- a/PowerPointLabs/PowerPointLabs/Models/PowerPointMagnifyingSlide.cs
+++ b/PowerPointLabs/PowerPointLabs/Models/PowerPointMagnifyingSlide.cs
@@ -169,7 +169,7 @@ namespace PowerPointLabs.Models
             {
                 // Revert to normal copy and pasting if unable to create file.
                 croppedShape.Cut();
-                zoomSlideCroppedShapes = _slide.Shapes.PasteSpecial(PowerPoint.PpPasteDataType.ppPasteMetafilePicture)[1];
+                zoomSlideCroppedShapes = _slide.Shapes.PasteSpecial(PowerPoint.PpPasteDataType.ppPastePNG)[1];
             }
 
             zoomSlideCroppedShapes.Name = "PPTLabsMagnifyAreaGroup" + DateTime.Now.ToString("yyyyMMddHHmmssffff");

--- a/PowerPointLabs/PowerPointLabs/Models/PowerPointMagnifyingSlide.cs
+++ b/PowerPointLabs/PowerPointLabs/Models/PowerPointMagnifyingSlide.cs
@@ -101,9 +101,7 @@ namespace PowerPointLabs.Models
         //Return shape which helps to calculate the amount of zoom-in animation
         private PowerPoint.Shape GetReferenceShape(PowerPoint.Shape shapeToZoom)
         {
-            shapeToZoom.Copy();
-
-            PowerPoint.Shape referenceShape = _slide.Shapes.Paste()[1];
+            PowerPoint.Shape referenceShape = shapeToZoom.Duplicate()[1];
             referenceShape.LockAspectRatio = Office.MsoTriState.msoTrue;
             if (referenceShape.Width > referenceShape.Height)
             {

--- a/PowerPointLabs/PowerPointLabs/ZoomLab/ZoomToArea.cs
+++ b/PowerPointLabs/PowerPointLabs/ZoomLab/ZoomToArea.cs
@@ -160,8 +160,7 @@ namespace PowerPointLabs.ZoomLab
         //Shape dimensions should match the slide dimensions and the shape should be within the slide
         private static PowerPoint.Shape GetBestFitShape(PowerPointSlide currentSlide, PowerPoint.Shape zoomShape)
         {
-            zoomShape.Copy();
-            PowerPoint.Shape zoomShapeCopy = currentSlide.Shapes.Paste()[1];
+            PowerPoint.Shape zoomShapeCopy = zoomShape.Duplicate()[1];
             
             zoomShapeCopy.LockAspectRatio = Office.MsoTriState.msoFalse;
 


### PR DESCRIPTION
Fixes #1769 

**Outline of Solution**
<!-- Tell us how you solved the issue. -->
After researching and experimenting on the problem, it seems an exception will be thrown on some machines because `ZoomToArea` uses a lot of `.Copy()` and `.Paste()`. It might be due to concurrent access of clipboard resulting in `AccessViolationException` being thrown. 

Replaced `.Copy()` and `.Paste()` with `.Duplicate()` in functions that do not require the use of clipboard, i.e. copying a shape from one slide and pasting it to another. This seemed to solve the issue on my machine. 

Also, `.PasteSpecial()` throws exception consistently on my machine as well, fixed the problem by exporting the shape as an image first and then adding it back into the slide like in PR #1761 
<!--This also helped with the lower resolution in `ZoomToArea`. -->
<!-- Mention things you want reviewers to focus on, if any. -->
Previously, my `ZoomToArea` FT was failing due to this error, so need more people to test on this PR to make sure the fix really works. 

This PR also affects `CropLab#CropToShape` because it is used in `ZoomToArea`. Previously, `CropToShape` also threw a `AccessViolationException` and changing it to use `.Duplicate()` fixed it.
<!-- Skip this section if fix is trivial. -->
