### PR TITLE
#1765 Use of != null in This Addin

### DIFF
--- a/PowerPointLabs/PowerPointLabs/ThisAddIn.cs
+++ b/PowerPointLabs/PowerPointLabs/ThisAddIn.cs
@@ -166,7 +166,7 @@ namespace PowerPointLabs
         public void InitializeShapeGallery()
         {
             // achieves singleton ShapePresentation
-            if (ShapePresentation != null && ShapePresentation.Opened)
+            if (ShapePresentation?.Opened ?? false)
             {
                 return;
             }
@@ -330,8 +330,7 @@ namespace PowerPointLabs
 
                 CustomShapePane shapePaneControl = GetControlFromWindow(typeof(CustomShapePane), window) as CustomShapePane;
 
-                if (shapePaneControl != null &&
-                    shapePaneControl.CurrentCategory == category)
+                if (shapePaneControl?.CurrentCategory == category)
                 {
                     shapePaneControl.AddCustomShape(shapeName, shapeFullName, false);
                 }
@@ -349,8 +348,7 @@ namespace PowerPointLabs
 
                 CustomShapePane shapePaneControl = GetControlFromWindow(typeof(CustomShapePane), window) as CustomShapePane;
 
-                if (shapePaneControl != null &&
-                    shapePaneControl.CurrentCategory == category)
+                if (shapePaneControl?.CurrentCategory == category)
                 {
                     shapePaneControl.RemoveCustomShape(shapeName);
                 }
@@ -368,8 +366,7 @@ namespace PowerPointLabs
 
                 CustomShapePane shapePaneControl = GetControlFromWindow(typeof(CustomShapePane), window) as CustomShapePane;
 
-                if (shapePaneControl != null &&
-                    shapePaneControl.CurrentCategory == category)
+                if (shapePaneControl?.CurrentCategory == category)
                 {
                     shapePaneControl.RenameCustomShape(shapeOldName, shapeNewName);
                 }
@@ -463,8 +460,7 @@ namespace PowerPointLabs
         {
             RecorderTaskPane recorder = GetActiveControl(typeof(RecorderTaskPane)) as RecorderTaskPane;
 
-            if (recorder != null &&
-                recorder.HasEvent())
+            if (recorder?.HasEvent() ?? false)
             {
                 recorder.ForceStopEvent();
             }
@@ -473,7 +469,7 @@ namespace PowerPointLabs
         private void ShutDownPictureSlidesLab()
         {
             PictureSlidesLab.Views.PictureSlidesLabWindow pictureSlidesLabWindow = Ribbon.PictureSlidesLabWindow;
-            if (pictureSlidesLabWindow != null && pictureSlidesLabWindow.IsOpen)
+            if (pictureSlidesLabWindow?.IsOpen ?? false)
             {
                 pictureSlidesLabWindow.Close();
             }
@@ -551,7 +547,7 @@ namespace PowerPointLabs
             RecorderTaskPane recorder = recorderPane.Control as RecorderTaskPane;
 
             // trigger close form event when closing hide the pane
-            if (recorder != null && !recorderPane.Visible)
+            if (!recorder?.Visible ?? false)
             {
                 recorder.RecorderPaneClosing();
                 // remove recorder pane and force it to reload when next time open
@@ -802,8 +798,7 @@ namespace PowerPointLabs
         {
             RecorderTaskPane recorder = GetActiveControl(typeof(RecorderTaskPane)) as RecorderTaskPane;
 
-            if (recorder != null &&
-                recorder.HasEvent())
+            if (recorder?.HasEvent() ?? false)
             {
                 recorder.ForceStopEvent();
             }
@@ -834,8 +829,7 @@ namespace PowerPointLabs
 
         private void ShutDownShapesLab()
         {
-            if (ShapePresentation != null &&
-                ShapePresentation.Opened)
+            if (ShapePresentation?.Opened ?? false)
             {
                 if (string.IsNullOrEmpty(ShapesLabConfig.DefaultCategory))
                 {
@@ -901,22 +895,23 @@ namespace PowerPointLabs
 
         private void ThisAddInApplicationOnWindowActivate(PowerPoint.Presentation pres, PowerPoint.DocumentWindow wn)
         {
-            if (pres != null)
+            if (pres == null)
             {
-                Trace.TraceInformation(pres.Name + " (Presentation) and " + wn.Caption + " (Window) activated.");
-
-                CustomShapePane customShape = GetActiveControl(typeof(CustomShapePane)) as CustomShapePane;
-
-                // make sure ShapeGallery's default category is consistent with current presentation
-                if (customShape != null)
-                {
-                    string currentCategory = customShape.CurrentCategory;
-                    ShapePresentation.DefaultCategory = currentCategory;
-                }
-
-                // If a window was activated in any way, PptLabs should not terminate.
-                _pptLabsShouldTerminate = false;
+                return;
             }
+            Trace.TraceInformation(pres.Name + " (Presentation) and " + wn.Caption + " (Window) activated.");
+
+            CustomShapePane customShape = GetActiveControl(typeof(CustomShapePane)) as CustomShapePane;
+
+            // make sure ShapeGallery's default category is consistent with current presentation
+            if (customShape != null)
+            {
+                string currentCategory = customShape.CurrentCategory;
+                ShapePresentation.DefaultCategory = currentCategory;
+            }
+
+            // If a window was activated in any way, PptLabs should not terminate.
+            _pptLabsShouldTerminate = false;
         }
 
         private void ThisAddInSlideSelectionChanged(PowerPoint.SlideRange sldRange)
@@ -1025,17 +1020,11 @@ namespace PowerPointLabs
 
             // When there is no selection on the slide, disable the add/copy buttons on
             // customshapepane and syncpane respectively
-            if (GetActivePane(typeof(SyncPane)) != null)
-            {
-                SyncPane syncPane = GetActivePane(typeof(SyncPane)).Control as SyncPane;
-                syncPane.UpdateOnSelectionChange(sel);
-            }
+            SyncPane syncPane = GetActivePane(typeof(SyncPane))?.Control as SyncPane;
+            syncPane?.UpdateOnSelectionChange(sel);
 
-            if (GetActivePane(typeof(CustomShapePane)) != null)
-            {
-                CustomShapePane customShapePane = GetActivePane(typeof(CustomShapePane)).Control as CustomShapePane;
-                customShapePane.UpdateOnSelectionChange(sel);
-            }
+            CustomShapePane customShapePane = GetActivePane(typeof(CustomShapePane))?.Control as CustomShapePane;
+            customShapePane?.UpdateOnSelectionChange(sel);
 
             Ribbon.RefreshRibbonControl("AnimateInSlideButton");
             Ribbon.RefreshRibbonControl("DrillDownButton");
@@ -1216,8 +1205,7 @@ namespace PowerPointLabs
                 string pptName = Application.ActivePresentation.Name;
 
                 if (selection.Type == PowerPoint.PpSelectionType.ppSelectionShapes
-                    && currentSlide != null
-                    && currentSlide.SlideID != _previousSlideForCopyEvent.SlideID
+                    && currentSlide?.SlideID != _previousSlideForCopyEvent.SlideID
                     && pptName == _previousPptName)
                 {
                     PowerPoint.ShapeRange pastedShapes = selection.ShapeRange;
@@ -1570,8 +1558,7 @@ namespace PowerPointLabs
                     overlappingShapeZIndex = shape.ZOrderPosition;
                 }
             }
-            if (overlappingShape != null &&
-                overlappingShape.Visible == Office.MsoTriState.msoTrue)
+            if (overlappingShape?.Visible == Office.MsoTriState.msoTrue)
             {
                 overlappingShape.Select();
             }


### PR DESCRIPTION
Fixes #1765. Tested and working on PPT2016.

@leeyh20 According to https://msdn.microsoft.com/en-us/magazine/dn802602.aspx, optional chaining `?` and colaescing `??` are supported in C# 6. We are using [ .NET Framework 4.6 for dev release ](https://github.com/PowerPointLabs/PowerPointLabs/blob/master/doc/ProjectSetUp.md), which supports C# 6.