### PR TITLE
#1818 Prevent auto resizing of theme colors boxes

### DIFF
--- a/PowerPointLabs/PowerPointLabs/ColorsLab/ColorsLabPaneWPF.xaml
+++ b/PowerPointLabs/PowerPointLabs/ColorsLab/ColorsLabPaneWPF.xaml
@@ -331,18 +331,18 @@
                             <RowDefinition Height="20" />
                         </Grid.RowDefinitions>
                         <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="*" />
-                            <ColumnDefinition Width="*" />
-                            <ColumnDefinition Width="*" />
-                            <ColumnDefinition Width="*" />
-                            <ColumnDefinition Width="*" />
-                            <ColumnDefinition Width="*" />
-                            <ColumnDefinition Width="*" />
-                            <ColumnDefinition Width="*" />
-                            <ColumnDefinition Width="*" />
-                            <ColumnDefinition Width="*" />
-                            <ColumnDefinition Width="*" />
-                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="20" />
+                            <ColumnDefinition Width="20" />
+                            <ColumnDefinition Width="20" />
+                            <ColumnDefinition Width="20" />
+                            <ColumnDefinition Width="20" />
+                            <ColumnDefinition Width="20" />
+                            <ColumnDefinition Width="20" />
+                            <ColumnDefinition Width="20" />
+                            <ColumnDefinition Width="20" />
+                            <ColumnDefinition Width="20" />
+                            <ColumnDefinition Width="20" />
+                            <ColumnDefinition Width="20" />
                         </Grid.ColumnDefinitions>
                         <TextBlock Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="12" HorizontalAlignment="Left" VerticalAlignment="Center">Favorite Colors</TextBlock>
                         <Rectangle x:Name="favoriteColorRectangleOne" Grid.Row="1" Grid.Column="0" Margin="2,2,2,2" AllowDrop="True"
@@ -424,13 +424,6 @@
                                    DragEnter="FavoriteRect_DragEnter" DragOver="FavoriteRect_DragOver" DragLeave="FavoriteRect_DragLeave" Drop="FavoriteRect_Drop"/>
                         <Rectangle x:Name="favoriteColorRectangleTwelve" Grid.Row="1" Grid.Column="11" Margin="2,2,2,2" AllowDrop="True" 
                                    Fill="{Binding ThemeColorTwelve, Converter={x:Static converter:HSLColorToHex.Instance}}" 
-                                   Stroke="Black" StrokeThickness="0.5"
-                                   ToolTip="{x:Static textCollection:ColorsLabText.ThemeColorRectangleTooltip}"
-                                   ContextMenu="{DynamicResource ColorRectContextMenu}"
-                                   MouseLeftButtonDown="ColorRectangle_MouseDown"
-                                   DragEnter="FavoriteRect_DragEnter" DragOver="FavoriteRect_DragOver" DragLeave="FavoriteRect_DragLeave" Drop="FavoriteRect_Drop"/>
-                        <Rectangle x:Name="favoriteColorRectangleThirteen" Grid.Row="1" Grid.Column="12" Margin="2,2,2,2" AllowDrop="True" 
-                                   Fill="{Binding ThemeColorThirteen, Converter={x:Static converter:HSLColorToHex.Instance}}" 
                                    Stroke="Black" StrokeThickness="0.5"
                                    ToolTip="{x:Static textCollection:ColorsLabText.ThemeColorRectangleTooltip}"
                                    ContextMenu="{DynamicResource ColorRectContextMenu}"

--- a/PowerPointLabs/PowerPointLabs/ColorsLab/ColorsLabPaneWPF.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/ColorsLab/ColorsLabPaneWPF.xaml.cs
@@ -86,7 +86,6 @@ namespace PowerPointLabs.ColorsLab
             list.Add(dataSource.ThemeColorTen);
             list.Add(dataSource.ThemeColorEleven);
             list.Add(dataSource.ThemeColorTwelve);
-            list.Add(dataSource.ThemeColorThirteen);
             return list;
         }
 
@@ -1185,7 +1184,6 @@ namespace PowerPointLabs.ColorsLab
                     dataSource.ThemeColorTen = Color.White;
                     dataSource.ThemeColorEleven = Color.White;
                     dataSource.ThemeColorTwelve = Color.White;
-                    dataSource.ThemeColorThirteen = Color.White;
                 }
             }
             catch (Exception e)
@@ -1238,9 +1236,6 @@ namespace PowerPointLabs.ColorsLab
                 break;
                 case "favoriteColorRectangleTwelve":
                 dataSource.ThemeColorTwelve = color;
-                break;
-                case "favoriteColorRectangleThirteen":
-                dataSource.ThemeColorThirteen = color;
                 break;
                 default:
                 break;

--- a/PowerPointLabs/PowerPointLabs/DataSources/ColorDataSource.cs
+++ b/PowerPointLabs/PowerPointLabs/DataSources/ColorDataSource.cs
@@ -298,24 +298,6 @@ namespace PowerPointLabs.DataSources
             }
         }
 
-        private HSLColor themeColorThirteenValue;
-
-        public HSLColor ThemeColorThirteen
-        {
-            get
-            {
-                return themeColorThirteenValue;
-            }
-            set
-            {
-                if (value != this.themeColorThirteenValue)
-                {
-                    this.themeColorThirteenValue = value;
-                    OnPropertyChanged("themeColorThirteen");
-                }
-            }
-        }
-
         public bool SaveThemeColorsInFile(String filePath)
         {
             try
@@ -333,7 +315,6 @@ namespace PowerPointLabs.DataSources
                 themeColors.Add(this.ThemeColorTen);
                 themeColors.Add(this.ThemeColorEleven);
                 themeColors.Add(this.ThemeColorTwelve);
-                themeColors.Add(this.ThemeColorThirteen);
 
                 Stream fileStream = File.Create(filePath);
                 BinaryFormatter serializer = new BinaryFormatter();
@@ -368,7 +349,6 @@ namespace PowerPointLabs.DataSources
                 this.ThemeColorTen = themeColors[9];
                 this.ThemeColorEleven = themeColors[10];
                 this.ThemeColorTwelve = themeColors[11];
-                this.ThemeColorThirteen = themeColors[12];
             }
             catch (Exception)
             {
@@ -379,7 +359,6 @@ namespace PowerPointLabs.DataSources
 
         public void AddColorToFavorites(HSLColor color)
         {
-            ThemeColorThirteen = ThemeColorTwelve;
             ThemeColorTwelve = ThemeColorEleven;
             ThemeColorEleven = ThemeColorTen;
             ThemeColorTen = ThemeColorNine;


### PR DESCRIPTION
Fixes #1818 

**Outline of Solution**
The main issue was that the columns that defined the sizes of the color boxes were set to auto resize based on the width of the panel. It has been changed to a fixed width of 20px, similar to the rest of the colors boxes in ColorsLab.

Also removed an extra theme color that was mistakenly being placed in a non-existent column.

Tested and working on PPT2013.