### PR TITLE
#1828 MessageBox not called on UI thread

### DIFF
--- a/PowerPointLabs/PowerPointLabs/ColorsLab/ColorsLabPaneWPF.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/ColorsLab/ColorsLabPaneWPF.xaml.cs
@@ -6,6 +6,7 @@ using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
+using System.Windows.Threading;
 using Microsoft.Office.Core;
 using PowerPointLabs.ActionFramework.Common.Extension;
 using PowerPointLabs.ColorsLab;
@@ -667,7 +668,10 @@ namespace PowerPointLabs.ColorsLab
 
             if (timer1Ticks < CLICK_THRESHOLD)
             {
-                MessageBox.Show("To use this button, click and drag to desired color.", ColorsLabText.ErrorDialogTitle);
+                Dispatcher.CurrentDispatcher.BeginInvoke(DispatcherPriority.Loaded, new Action(delegate
+                {
+                    MessageBox.Show("To use this button, click and drag to desired color.", ColorsLabText.ErrorDialogTitle);
+                }));
             }
         }
 


### PR DESCRIPTION
Fixes #1828 

Just need to call it on the main thread to fix the problem. User should only be shown the messageBox once no matter how many times he clicks in succession.

**Current behaviour, after fix:**
![message-box-fix](https://user-images.githubusercontent.com/39292809/54839546-0a550f80-4d06-11e9-8cca-50fc1c63bdb1.gif)

