### PR TITLE
#1827 Add to common traps doc: Grouping shapes with ShapeRange

### DIFF
--- a/doc/CommonTraps.md
+++ b/doc/CommonTraps.md
@@ -49,7 +49,7 @@ This document details the common pitfalls when developing for PowerPointLabs, so
 	
 	Step 4. Select Single startup project and choose PowerPointLabs from the drop down list.
 
-1. To group multiple `Shape` objects together when you only have the references to the objects, an easy way is to extract a `ShapeRange` object from the slide based on the names of the shapes, and then call the `Group()` method on that `ShapeRange`
+1. When grouping multiple `Shape` objects together, it is not straightforward to do so with only references to the `Shape` objects. An easy way is to extract a `ShapeRange` object from the slide based on the names of the `Shapes`, and then calling the `Group()` method on that `ShapeRange`.
 ```c#
 string[] names = new string[] { shape1.Name, shape2.Name };
 Shape group = this.GetCurrentSlide().Shapes.Range(names).Group();

--- a/doc/CommonTraps.md
+++ b/doc/CommonTraps.md
@@ -48,3 +48,9 @@ This document details the common pitfalls when developing for PowerPointLabs, so
 	Step 3. Navigate to Common Properties > Startup Project.
 	
 	Step 4. Select Single startup project and choose PowerPointLabs from the drop down list.
+
+1. To group multiple `Shape` objects together when you only have the references to the objects, an easy way is to extract a `ShapeRange` object from the slide based on the names of the shapes, and then call the `Group()` method on that `ShapeRange`
+```c#
+string[] names = new string[] { shape1.Name, shape2.Name };
+Shape group = this.GetCurrentSlide().Shapes.Range(names).Group();
+```


### PR DESCRIPTION
Fixes #1827 

Just a small addition to our `Common Development Traps` document for grouping of `Shapes` with only a reference to them.