### PR TITLE
#1868 Add missing reference in test.csproj

### DIFF
--- a/PowerPointLabs/Test/Test.csproj
+++ b/PowerPointLabs/Test/Test.csproj
@@ -214,6 +214,10 @@
     <Compile Include="Util\ThreadUtil.cs" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\PowerPointLabs\PowerPointLabs.csproj">
+      <Project>{e0696df3-9906-4e0e-906e-f9d47f41ef80}</Project>
+      <Name>PowerPointLabs</Name>
+    </ProjectReference>
     <ProjectReference Include="..\TestInterface\TestInterface.csproj">
       <Project>{573cc738-5349-4a0d-bc53-9325fa9c0e6f}</Project>
       <Name>TestInterface</Name>


### PR DESCRIPTION
Fixes #1868

This PR adds back the missing reference to `PowerPointLabs` in `test.csproj`.