### PR TITLE
Fix only English supported message to appear once only

### DIFF
--- a/PowerPointLabs/PowerPointLabs/ELearningLab/Views/AudioSettingsViews/AudioMainSettingsPage.xaml
+++ b/PowerPointLabs/PowerPointLabs/ELearningLab/Views/AudioSettingsViews/AudioMainSettingsPage.xaml
@@ -23,6 +23,7 @@
             <Border Margin="10" BorderBrush="LightSlateGray" BorderThickness="1" CornerRadius="2">
                 <StackPanel>
                     <Label Content="Default Voice" FontSize="12" FontWeight="SemiBold" Margin="20 10 0 0"/>
+                    <Label Content="Note that only English voice is supported for Azure and IBM voices" FontSize="9" Margin="20 -10 0 0"/>
                     <Grid>
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="*"/>

--- a/PowerPointLabs/PowerPointLabs/ELearningLab/Views/AudioSettingsViews/AudioMainSettingsPage.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/ELearningLab/Views/AudioSettingsViews/AudioMainSettingsPage.xaml.cs
@@ -73,7 +73,6 @@ namespace PowerPointLabs.ELearningLab.Views
 
         private List<IVoice> rankedAudioListCache = new List<IVoice>();
 
-        private static bool hasEnglishSupportMessageShowed = false;
         public AudioMainSettingsPage()
         {
             InitializeComponent();
@@ -123,8 +122,6 @@ namespace PowerPointLabs.ELearningLab.Views
 
         private void AudioMainSettingsPage_Loaded(object sender, RoutedEventArgs e)
         {
-            RadioAzureVoice.Checked += RadioVoice_Checked;
-            RadioWatsonVoice.Checked += RadioVoice_Checked;
             ToggleAzureFunctionVisibility();
             ToggleWatsonFunctionVisibility();
             SetupAudioPreferenceUI();
@@ -211,15 +208,6 @@ namespace PowerPointLabs.ELearningLab.Views
             RadioWatsonVoice.IsEnabled = false;
             RadioDefaultVoice.IsChecked = true;
             WatsonRuntimeService.IsWatsonAccountPresentAndValid = false;
-        }
-
-        private void RadioVoice_Checked(object sender, RoutedEventArgs e)
-        {
-            if (!hasEnglishSupportMessageShowed)
-            {
-                hasEnglishSupportMessageShowed = true;
-                MessageBox.Show(ELearningLabText.OnlyEnglishLanguageSupportedMessage);
-            }
         }
 
         private void PreviewCheckBox_Checked(object sender, RoutedEventArgs e)

--- a/PowerPointLabs/PowerPointLabs/ELearningLab/Views/AudioSettingsViews/AudioMainSettingsPage.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/ELearningLab/Views/AudioSettingsViews/AudioMainSettingsPage.xaml.cs
@@ -73,6 +73,7 @@ namespace PowerPointLabs.ELearningLab.Views
 
         private List<IVoice> rankedAudioListCache = new List<IVoice>();
 
+        private static bool hasEnglishSupportMessageShowed = false;
         public AudioMainSettingsPage()
         {
             InitializeComponent();
@@ -122,7 +123,8 @@ namespace PowerPointLabs.ELearningLab.Views
 
         private void AudioMainSettingsPage_Loaded(object sender, RoutedEventArgs e)
         {
-            RadioAzureVoice.Checked += RadioAzureVoice_Checked;          
+            RadioAzureVoice.Checked += RadioVoice_Checked;
+            RadioWatsonVoice.Checked += RadioVoice_Checked;
             ToggleAzureFunctionVisibility();
             ToggleWatsonFunctionVisibility();
             SetupAudioPreferenceUI();
@@ -211,9 +213,13 @@ namespace PowerPointLabs.ELearningLab.Views
             WatsonRuntimeService.IsWatsonAccountPresentAndValid = false;
         }
 
-        private void RadioAzureVoice_Checked(object sender, RoutedEventArgs e)
+        private void RadioVoice_Checked(object sender, RoutedEventArgs e)
         {
-            MessageBox.Show("Note that we only support English language at this stage.");
+            if (!hasEnglishSupportMessageShowed)
+            {
+                hasEnglishSupportMessageShowed = true;
+                MessageBox.Show(ELearningLabText.OnlyEnglishLanguageSupportedMessage);
+            }
         }
 
         private void PreviewCheckBox_Checked(object sender, RoutedEventArgs e)

--- a/PowerPointLabs/PowerPointLabs/TextCollection/ELearningLabText.cs
+++ b/PowerPointLabs/PowerPointLabs/TextCollection/ELearningLabText.cs
@@ -37,8 +37,7 @@ namespace PowerPointLabs.TextCollection
         public const string SelfExplanationItemIdentifier = "Item";
 
         public const string NoSlideSelectedMessage = "No slide is selected";
-        public const string OnLoadingMessage = "Now Loading...";
-        public const string OnlyEnglishLanguageSupportedMessage = "Note that we only support English language at this stage.";
+        public const string OnLoadingMessage = "Now Loading...";        
 
         public const string ExplanationItem_IsCallout = "IsCallout";
         public const string ExplanationItem_IsCaption = "IsCaption";

--- a/PowerPointLabs/PowerPointLabs/TextCollection/ELearningLabText.cs
+++ b/PowerPointLabs/PowerPointLabs/TextCollection/ELearningLabText.cs
@@ -38,6 +38,7 @@ namespace PowerPointLabs.TextCollection
 
         public const string NoSlideSelectedMessage = "No slide is selected";
         public const string OnLoadingMessage = "Now Loading...";
+        public const string OnlyEnglishLanguageSupportedMessage = "Note that we only support English language at this stage.";
 
         public const string ExplanationItem_IsCallout = "IsCallout";
         public const string ExplanationItem_IsCaption = "IsCaption";

--- a/PowerPointLabs/PowerPointLabs/TextCollection/ELearningLabText.cs
+++ b/PowerPointLabs/PowerPointLabs/TextCollection/ELearningLabText.cs
@@ -37,7 +37,7 @@ namespace PowerPointLabs.TextCollection
         public const string SelfExplanationItemIdentifier = "Item";
 
         public const string NoSlideSelectedMessage = "No slide is selected";
-        public const string OnLoadingMessage = "Now Loading...";        
+        public const string OnLoadingMessage = "Now Loading...";
 
         public const string ExplanationItem_IsCallout = "IsCallout";
         public const string ExplanationItem_IsCaption = "IsCaption";


### PR DESCRIPTION
Fixes #1881 

Previously `Note that we only support English language at this stage` message shows up every time when Azure option is checked. This PR fixes it by showing the message as text on the settings page.

Updated settings UI:
<img width="264" alt="Capture" src="https://user-images.githubusercontent.com/17466278/56139488-91c33500-5fcb-11e9-9434-9df4e984ac05.PNG">


Tested on PPT2016.