### PR TITLE
#1900 cannot pick color colorslab

### DIFF
--- a/PowerPointLabs/PowerPointLabs/ColorsLab/ColorsLabPaneWPF.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/ColorsLab/ColorsLabPaneWPF.xaml.cs
@@ -658,10 +658,9 @@ namespace PowerPointLabs.ColorsLab
             timer1Ticks++;
             
             System.Drawing.Point mousePos = System.Windows.Forms.Control.MousePosition;
-            System.Windows.Point mp = PointToScreen(Mouse.GetPosition(this));
             IntPtr deviceContext = PPExtraEventHelper.Native.GetDC(IntPtr.Zero);
 
-            Color pickedColor = System.Drawing.ColorTranslator.FromWin32(PPExtraEventHelper.Native.GetPixel(deviceContext, (int)mousePos.X, (int)mousePos.Y));
+            Color pickedColor = System.Drawing.ColorTranslator.FromWin32(PPExtraEventHelper.Native.GetPixel(deviceContext, mousePos.X, mousePos.Y));
 
             // If button has not been held long enough to register as a drag, then don't pick a color.
             if (timer1Ticks < CLICK_THRESHOLD)

--- a/PowerPointLabs/PowerPointLabs/ColorsLab/ColorsLabPaneWPF.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/ColorsLab/ColorsLabPaneWPF.xaml.cs
@@ -148,7 +148,7 @@ namespace PowerPointLabs.ColorsLab
         private const float MAGNIFICATION_FACTOR = 2.5f;
         private Cursor eyeDropperCursor = new Cursor(new MemoryStream(Properties.Resources.EyeDropper));
         private Magnifier magnifier = new Magnifier(MAGNIFICATION_FACTOR);
-        private System.Windows.Forms.Timer eyeDropperTimer = new System.Windows.Forms.Timer(new System.ComponentModel.Container());
+        private System.Windows.Threading.DispatcherTimer eyeDropperTimer = new System.Windows.Threading.DispatcherTimer(); //new System.Windows.Forms.Timer(new System.ComponentModel.Container());
         private const int CLICK_THRESHOLD = 2;
         private int timer1Ticks;
 
@@ -656,11 +656,12 @@ namespace PowerPointLabs.ColorsLab
         private void Timer1_Tick(object sender, EventArgs e)
         {
             timer1Ticks++;
-
+            
             System.Drawing.Point mousePos = System.Windows.Forms.Control.MousePosition;
+            System.Windows.Point mp = PointToScreen(Mouse.GetPosition(this));
             IntPtr deviceContext = PPExtraEventHelper.Native.GetDC(IntPtr.Zero);
 
-            Color pickedColor = System.Drawing.ColorTranslator.FromWin32(PPExtraEventHelper.Native.GetPixel(deviceContext, mousePos.X, mousePos.Y));
+            Color pickedColor = System.Drawing.ColorTranslator.FromWin32(PPExtraEventHelper.Native.GetPixel(deviceContext, (int)mousePos.X, (int)mousePos.Y));
 
             // If button has not been held long enough to register as a drag, then don't pick a color.
             if (timer1Ticks < CLICK_THRESHOLD)
@@ -693,7 +694,7 @@ namespace PowerPointLabs.ColorsLab
             if (_eyedropperMode == MODE.MAIN)
             {
                 selectedColorRectangle.Opacity = 1;
-                if (timer1Ticks > CLICK_THRESHOLD)
+                if (timer1Ticks >= CLICK_THRESHOLD)
                 {
                     dataSource.SelectedColor = _currentEyedroppedColor;
                 }
@@ -702,7 +703,7 @@ namespace PowerPointLabs.ColorsLab
             // Update recent colors if color has been used
             if (_eyedropperMode == MODE.FILL || _eyedropperMode == MODE.FONT || _eyedropperMode == MODE.LINE)
             {
-                if (timer1Ticks > CLICK_THRESHOLD)
+                if (timer1Ticks >= CLICK_THRESHOLD)
                 {
                     dataSource.AddColorToRecentColors(_currentSelectedColor);
                 }

--- a/PowerPointLabs/PowerPointLabs/ColorsLab/ColorsLabPaneWPF.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/ColorsLab/ColorsLabPaneWPF.xaml.cs
@@ -148,7 +148,7 @@ namespace PowerPointLabs.ColorsLab
         private const float MAGNIFICATION_FACTOR = 2.5f;
         private Cursor eyeDropperCursor = new Cursor(new MemoryStream(Properties.Resources.EyeDropper));
         private Magnifier magnifier = new Magnifier(MAGNIFICATION_FACTOR);
-        private System.Windows.Threading.DispatcherTimer eyeDropperTimer = new System.Windows.Threading.DispatcherTimer(); //new System.Windows.Forms.Timer(new System.ComponentModel.Container());
+        private System.Windows.Threading.DispatcherTimer eyeDropperTimer = new System.Windows.Threading.DispatcherTimer();
         private const int CLICK_THRESHOLD = 2;
         private int timer1Ticks;
 

--- a/PowerPointLabs/PowerPointLabs/ColorsLab/ColorsLabPaneWPF.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/ColorsLab/ColorsLabPaneWPF.xaml.cs
@@ -656,7 +656,7 @@ namespace PowerPointLabs.ColorsLab
         private void Timer1_Tick(object sender, EventArgs e)
         {
             timer1Ticks++;
-            
+
             System.Drawing.Point mousePos = System.Windows.Forms.Control.MousePosition;
             IntPtr deviceContext = PPExtraEventHelper.Native.GetDC(IntPtr.Zero);
 

--- a/PowerPointLabs/PowerPointLabs/ColorsLab/Magnifier.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/ColorsLab/Magnifier.xaml.cs
@@ -17,7 +17,7 @@ namespace PowerPointLabs.ColorsLab
     {
         private MagnifierOverlay magnifierOverlay;
         private MagnificationControlHost magnificationControl;
-        private System.Windows.Forms.Timer timer;
+        private System.Windows.Threading.DispatcherTimer timer;
 
         private IntPtr hwndMag;
         private bool isMagInitialized;
@@ -32,8 +32,8 @@ namespace PowerPointLabs.ColorsLab
         {
             InitializeComponent();
 
-            timer = new System.Windows.Forms.Timer();
-            timer.Interval = 100;
+            timer = new System.Windows.Threading.DispatcherTimer();
+            timer.Interval = new TimeSpan(0, 0, 0, 0, 100);
             timer.Tick += new EventHandler(Timer_Tick);
             
             magnifierOverlay = new MagnifierOverlay();


### PR DESCRIPTION
Fixes #1900

I changed the timer to `DispatchTimer`, which is WPF's version of a timer, instead of using Winform's Timer.
My dev-release is failing some unit tests before the changes so I'm not sure if I broke anything.