### PR TITLE
#1931 Highly duplicated code for converting between media color and drawing color

### DIFF
--- a/PowerPointLabs/PowerPointLabs/ColorsLab/ColorInformationDialog.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/ColorsLab/ColorInformationDialog.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using System.Windows;
 using System.Windows.Media;
+using PowerPointLabs.Utils;
 
 namespace PowerPointLabs.ColorsLab
 {
@@ -18,7 +19,7 @@ namespace PowerPointLabs.ColorsLab
 
             InitializeComponent();
 
-            colorRectangle.Fill = new SolidColorBrush(System.Windows.Media.Color.FromArgb(color.A, color.R, color.G, color.B));
+            colorRectangle.Fill = GraphicsUtil.MediaBrushFromDrawingColor(color);
             colorHexText.Text = ((HSLColor)color).ToHexString();
             colorRgbText.Text = ((HSLColor)color).ToRGBString();
             colorHslText.Text = ((HSLColor)color).ToString();

--- a/PowerPointLabs/PowerPointLabs/ColorsLab/ColorsLabPaneWPF.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/ColorsLab/ColorsLabPaneWPF.xaml.cs
@@ -195,25 +195,25 @@ namespace PowerPointLabs.ColorsLab
         /// </summary>
         private void SetupImageSources()
         {
-            textColorIcon.Source = GraphicsUtil.CreateBitmapSource(Properties.Resources.TextColor_icon);
+            textColorIcon.Source = GraphicsUtil.BitmapToImageSource(Properties.Resources.TextColor_icon);
 
-            lineColorIcon.Source = GraphicsUtil.CreateBitmapSource(Properties.Resources.LineColor_icon);
+            lineColorIcon.Source = GraphicsUtil.BitmapToImageSource(Properties.Resources.LineColor_icon);
 
-            fillColorIcon.Source = GraphicsUtil.CreateBitmapSource(Properties.Resources.FillColor_icon);
+            fillColorIcon.Source = GraphicsUtil.BitmapToImageSource(Properties.Resources.FillColor_icon);
 
-            eyeDropperIcon.Source = GraphicsUtil.CreateBitmapSource(Properties.Resources.EyeDropper_icon);
+            eyeDropperIcon.Source = GraphicsUtil.BitmapToImageSource(Properties.Resources.EyeDropper_icon);
 
-            brightnessIcon.Source = GraphicsUtil.CreateBitmapSource(Properties.Resources.Brightness_icon_25x25);
+            brightnessIcon.Source = GraphicsUtil.BitmapToImageSource(Properties.Resources.Brightness_icon_25x25);
 
-            saturationIcon.Source = GraphicsUtil.CreateBitmapSource(Properties.Resources.Saturation_icon_18x18);
+            saturationIcon.Source = GraphicsUtil.BitmapToImageSource(Properties.Resources.Saturation_icon_18x18);
 
-            saveColorIcon.Source = GraphicsUtil.CreateBitmapSource(Properties.Resources.Save_icon);
+            saveColorIcon.Source = GraphicsUtil.BitmapToImageSource(Properties.Resources.Save_icon);
 
-            loadColorIcon.Source = GraphicsUtil.CreateBitmapSource(Properties.Resources.Load_icon);
+            loadColorIcon.Source = GraphicsUtil.BitmapToImageSource(Properties.Resources.Load_icon);
 
-            reloadColorIcon.Source = GraphicsUtil.CreateBitmapSource(Properties.Resources.Reload_icon);
+            reloadColorIcon.Source = GraphicsUtil.BitmapToImageSource(Properties.Resources.Reload_icon);
 
-            clearColorIcon.Source = GraphicsUtil.CreateBitmapSource(Properties.Resources.Clear_icon);
+            clearColorIcon.Source = GraphicsUtil.BitmapToImageSource(Properties.Resources.Clear_icon);
         }
 
         /// <summary>

--- a/PowerPointLabs/PowerPointLabs/ColorsLab/ColorsLabPaneWPF.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/ColorsLab/ColorsLabPaneWPF.xaml.cs
@@ -195,25 +195,25 @@ namespace PowerPointLabs.ColorsLab
         /// </summary>
         private void SetupImageSources()
         {
-            textColorIcon.Source = CommonUtil.CreateBitmapSource(Properties.Resources.TextColor_icon);
+            textColorIcon.Source = GraphicsUtil.CreateBitmapSource(Properties.Resources.TextColor_icon);
 
-            lineColorIcon.Source = CommonUtil.CreateBitmapSource(Properties.Resources.LineColor_icon);
+            lineColorIcon.Source = GraphicsUtil.CreateBitmapSource(Properties.Resources.LineColor_icon);
 
-            fillColorIcon.Source = CommonUtil.CreateBitmapSource(Properties.Resources.FillColor_icon);
+            fillColorIcon.Source = GraphicsUtil.CreateBitmapSource(Properties.Resources.FillColor_icon);
 
-            eyeDropperIcon.Source = CommonUtil.CreateBitmapSource(Properties.Resources.EyeDropper_icon);
+            eyeDropperIcon.Source = GraphicsUtil.CreateBitmapSource(Properties.Resources.EyeDropper_icon);
 
-            brightnessIcon.Source = CommonUtil.CreateBitmapSource(Properties.Resources.Brightness_icon_25x25);
+            brightnessIcon.Source = GraphicsUtil.CreateBitmapSource(Properties.Resources.Brightness_icon_25x25);
 
-            saturationIcon.Source = CommonUtil.CreateBitmapSource(Properties.Resources.Saturation_icon_18x18);
+            saturationIcon.Source = GraphicsUtil.CreateBitmapSource(Properties.Resources.Saturation_icon_18x18);
 
-            saveColorIcon.Source = CommonUtil.CreateBitmapSource(Properties.Resources.Save_icon);
+            saveColorIcon.Source = GraphicsUtil.CreateBitmapSource(Properties.Resources.Save_icon);
 
-            loadColorIcon.Source = CommonUtil.CreateBitmapSource(Properties.Resources.Load_icon);
+            loadColorIcon.Source = GraphicsUtil.CreateBitmapSource(Properties.Resources.Load_icon);
 
-            reloadColorIcon.Source = CommonUtil.CreateBitmapSource(Properties.Resources.Reload_icon);
+            reloadColorIcon.Source = GraphicsUtil.CreateBitmapSource(Properties.Resources.Reload_icon);
 
-            clearColorIcon.Source = CommonUtil.CreateBitmapSource(Properties.Resources.Clear_icon);
+            clearColorIcon.Source = GraphicsUtil.CreateBitmapSource(Properties.Resources.Clear_icon);
         }
 
         /// <summary>
@@ -484,7 +484,7 @@ namespace PowerPointLabs.ColorsLab
             rect.MouseUp -= ColorRectangle_MouseUp;
 
             System.Windows.Media.Color color = ((SolidColorBrush)rect.Fill).Color;
-            Color selectedColor = Color.FromArgb(color.A, color.R, color.G, color.B);
+            Color selectedColor = GraphicsUtil.DrawingColorFromMediaColor(color);
             dataSource.SelectedColor = new HSLColor(selectedColor);
         }
 
@@ -503,7 +503,7 @@ namespace PowerPointLabs.ColorsLab
             System.Windows.Shapes.Rectangle rect = (System.Windows.Shapes.Rectangle)sender;
 
             System.Windows.Media.Color prevMediaColor = ((SolidColorBrush)rect.Fill).Color;
-            _previousFillColor = Color.FromArgb(prevMediaColor.A, prevMediaColor.R, prevMediaColor.G, prevMediaColor.B);
+            _previousFillColor = GraphicsUtil.DrawingColorFromMediaColor(prevMediaColor);
 
             if (rect != null)
             {
@@ -518,7 +518,7 @@ namespace PowerPointLabs.ColorsLab
                     if (converter.IsValid(dataString))
                     {
                         System.Windows.Media.Color mediaColor = (System.Windows.Media.Color)ColorConverter.ConvertFromString(dataString);
-                        Color color = Color.FromArgb(mediaColor.A, mediaColor.R, mediaColor.G, mediaColor.B);
+                        Color color = GraphicsUtil.DrawingColorFromMediaColor(mediaColor);
 
                         SetFavoriteColorRectangle(Grid.GetColumn(rect), color);
                     }
@@ -599,7 +599,7 @@ namespace PowerPointLabs.ColorsLab
                     if (converter.IsValid(dataString))
                     {
                         System.Windows.Media.Color mediaColor = (System.Windows.Media.Color)ColorConverter.ConvertFromString(dataString);
-                        Color color = Color.FromArgb(mediaColor.A, mediaColor.R, mediaColor.G, mediaColor.B);
+                        Color color = GraphicsUtil.DrawingColorFromMediaColor(mediaColor);
 
                         SetFavoriteColorRectangle(Grid.GetColumn(rect), color);
                     }
@@ -772,7 +772,7 @@ namespace PowerPointLabs.ColorsLab
             }
             System.Windows.Shapes.Rectangle rect = ((ContextMenu)(menuItem.Parent)).PlacementTarget as System.Windows.Shapes.Rectangle;
             System.Windows.Media.Color color = ((SolidColorBrush)rect.Fill).Color;
-            Color selectedColor = Color.FromArgb(color.A, color.R, color.G, color.B);
+            Color selectedColor = GraphicsUtil.DrawingColorFromMediaColor(color);
             ColorInformationDialog dialog = new ColorInformationDialog(selectedColor);
             dialog.Show();
         }
@@ -786,7 +786,7 @@ namespace PowerPointLabs.ColorsLab
             }
             System.Windows.Shapes.Rectangle rect = ((ContextMenu)(menuItem.Parent)).PlacementTarget as System.Windows.Shapes.Rectangle;
             System.Windows.Media.Color color = ((SolidColorBrush)rect.Fill).Color;
-            Color selectedColor = Color.FromArgb(color.A, color.R, color.G, color.B);
+            Color selectedColor = GraphicsUtil.DrawingColorFromMediaColor(color);
             dataSource.SelectedColor = new HSLColor(selectedColor);
         }
 
@@ -799,7 +799,7 @@ namespace PowerPointLabs.ColorsLab
             }
             System.Windows.Shapes.Rectangle rect = ((ContextMenu)(menuItem.Parent)).PlacementTarget as System.Windows.Shapes.Rectangle;
             System.Windows.Media.Color color = ((SolidColorBrush)rect.Fill).Color;
-            HSLColor clickedColor = Color.FromArgb(color.A, color.R, color.G, color.B);
+            HSLColor clickedColor = GraphicsUtil.DrawingColorFromMediaColor(color);
             dataSource.AddColorToFavorites(clickedColor);
         }
 
@@ -1142,8 +1142,7 @@ namespace PowerPointLabs.ColorsLab
 
         private void ColorMainColorRect(Color color)
         {
-            eyeDropperPreviewRectangle.Fill = 
-                new SolidColorBrush(System.Windows.Media.Color.FromArgb(color.A, color.R, color.G, color.B));
+            eyeDropperPreviewRectangle.Fill = GraphicsUtil.MediaBrushFromDrawingColor(color);
         }
 
         #endregion

--- a/PowerPointLabs/PowerPointLabs/ELearningLab/Converters/ELearningWorkspaceConverters/AnimationTypeToImageSourceConverter.cs
+++ b/PowerPointLabs/PowerPointLabs/ELearningLab/Converters/ELearningWorkspaceConverters/AnimationTypeToImageSourceConverter.cs
@@ -22,14 +22,14 @@ namespace PowerPointLabs.ELearningLab.Converters
             switch ((AnimationType)value)
             {
                 case AnimationType.Emphasis:
-                    return CommonUtil.CreateBitmapSource(Properties.Resources.AnimationEmphasis);
+                    return GraphicsUtil.CreateBitmapSource(Properties.Resources.AnimationEmphasis);
                 case AnimationType.Entrance:
-                    return CommonUtil.CreateBitmapSource(Properties.Resources.AnimationEntrance);
+                    return GraphicsUtil.CreateBitmapSource(Properties.Resources.AnimationEntrance);
                 case AnimationType.Exit:
-                    return CommonUtil.CreateBitmapSource(Properties.Resources.AnimationExit);
+                    return GraphicsUtil.CreateBitmapSource(Properties.Resources.AnimationExit);
                 case AnimationType.MotionPath:
                 default:
-                    return CommonUtil.CreateBitmapSource(Properties.Resources.AnimationMotionPath);
+                    return GraphicsUtil.CreateBitmapSource(Properties.Resources.AnimationMotionPath);
             }
         }
 

--- a/PowerPointLabs/PowerPointLabs/ELearningLab/Converters/ELearningWorkspaceConverters/AnimationTypeToImageSourceConverter.cs
+++ b/PowerPointLabs/PowerPointLabs/ELearningLab/Converters/ELearningWorkspaceConverters/AnimationTypeToImageSourceConverter.cs
@@ -22,14 +22,14 @@ namespace PowerPointLabs.ELearningLab.Converters
             switch ((AnimationType)value)
             {
                 case AnimationType.Emphasis:
-                    return GraphicsUtil.CreateBitmapSource(Properties.Resources.AnimationEmphasis);
+                    return GraphicsUtil.BitmapToImageSource(Properties.Resources.AnimationEmphasis);
                 case AnimationType.Entrance:
-                    return GraphicsUtil.CreateBitmapSource(Properties.Resources.AnimationEntrance);
+                    return GraphicsUtil.BitmapToImageSource(Properties.Resources.AnimationEntrance);
                 case AnimationType.Exit:
-                    return GraphicsUtil.CreateBitmapSource(Properties.Resources.AnimationExit);
+                    return GraphicsUtil.BitmapToImageSource(Properties.Resources.AnimationExit);
                 case AnimationType.MotionPath:
                 default:
-                    return GraphicsUtil.CreateBitmapSource(Properties.Resources.AnimationMotionPath);
+                    return GraphicsUtil.BitmapToImageSource(Properties.Resources.AnimationMotionPath);
             }
         }
 

--- a/PowerPointLabs/PowerPointLabs/ELearningLab/Views/ELearningWorkspaceViews/ELearningLabMainPanel.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/ELearningLab/Views/ELearningWorkspaceViews/ELearningLabMainPanel.xaml.cs
@@ -58,8 +58,8 @@ namespace PowerPointLabs.ELearningLab.Views
         public ELearningLabMainPanel()
         {
             InitializeComponent();
-            syncImage.Source = CommonUtil.CreateBitmapSource(Properties.Resources.SyncExplanationIcon);
-            createImage.Source = CommonUtil.CreateBitmapSource(Properties.Resources.AddExplanationIcon);
+            syncImage.Source = GraphicsUtil.CreateBitmapSource(Properties.Resources.SyncExplanationIcon);
+            createImage.Source = GraphicsUtil.CreateBitmapSource(Properties.Resources.AddExplanationIcon);
             isSynced = true;          
             InitializeBackgroundWorker();
             slide = this.GetCurrentSlide();

--- a/PowerPointLabs/PowerPointLabs/ELearningLab/Views/ELearningWorkspaceViews/ELearningLabMainPanel.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/ELearningLab/Views/ELearningWorkspaceViews/ELearningLabMainPanel.xaml.cs
@@ -58,8 +58,8 @@ namespace PowerPointLabs.ELearningLab.Views
         public ELearningLabMainPanel()
         {
             InitializeComponent();
-            syncImage.Source = GraphicsUtil.CreateBitmapSource(Properties.Resources.SyncExplanationIcon);
-            createImage.Source = GraphicsUtil.CreateBitmapSource(Properties.Resources.AddExplanationIcon);
+            syncImage.Source = GraphicsUtil.BitmapToImageSource(Properties.Resources.SyncExplanationIcon);
+            createImage.Source = GraphicsUtil.BitmapToImageSource(Properties.Resources.AddExplanationIcon);
             isSynced = true;          
             InitializeBackgroundWorker();
             slide = this.GetCurrentSlide();

--- a/PowerPointLabs/PowerPointLabs/ELearningLab/Views/ELearningWorkspaceViews/ExplanationItemView.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/ELearningLab/Views/ELearningWorkspaceViews/ExplanationItemView.xaml.cs
@@ -75,11 +75,11 @@ namespace PowerPointLabs.ELearningLab.Views
         public ExplanationItemView()
         {
             InitializeComponent();
-            upImage.Source = GraphicsUtil.CreateBitmapSource(Properties.Resources.Up);
-            deleteImage.Source = GraphicsUtil.CreateBitmapSource(Properties.Resources.SyncLabDeleteButton);
-            downImage.Source = GraphicsUtil.CreateBitmapSource(Properties.Resources.Down);
-            audioImage.Source = GraphicsUtil.CreateBitmapSource(Properties.Resources.SpeakTextContext);
-            cancelCalloutImage.Source = GraphicsUtil.CreateBitmapSource(Properties.Resources.CancelCalloutButton);
+            upImage.Source = GraphicsUtil.BitmapToImageSource(Properties.Resources.Up);
+            deleteImage.Source = GraphicsUtil.BitmapToImageSource(Properties.Resources.SyncLabDeleteButton);
+            downImage.Source = GraphicsUtil.BitmapToImageSource(Properties.Resources.Down);
+            audioImage.Source = GraphicsUtil.BitmapToImageSource(Properties.Resources.SpeakTextContext);
+            cancelCalloutImage.Source = GraphicsUtil.BitmapToImageSource(Properties.Resources.CancelCalloutButton);
         }
 
         #region XAML-Binded Action Handler

--- a/PowerPointLabs/PowerPointLabs/ELearningLab/Views/ELearningWorkspaceViews/ExplanationItemView.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/ELearningLab/Views/ELearningWorkspaceViews/ExplanationItemView.xaml.cs
@@ -75,11 +75,11 @@ namespace PowerPointLabs.ELearningLab.Views
         public ExplanationItemView()
         {
             InitializeComponent();
-            upImage.Source = CommonUtil.CreateBitmapSource(Properties.Resources.Up);
-            deleteImage.Source = CommonUtil.CreateBitmapSource(Properties.Resources.SyncLabDeleteButton);
-            downImage.Source = CommonUtil.CreateBitmapSource(Properties.Resources.Down);
-            audioImage.Source = CommonUtil.CreateBitmapSource(Properties.Resources.SpeakTextContext);
-            cancelCalloutImage.Source = CommonUtil.CreateBitmapSource(Properties.Resources.CancelCalloutButton);
+            upImage.Source = GraphicsUtil.CreateBitmapSource(Properties.Resources.Up);
+            deleteImage.Source = GraphicsUtil.CreateBitmapSource(Properties.Resources.SyncLabDeleteButton);
+            downImage.Source = GraphicsUtil.CreateBitmapSource(Properties.Resources.Down);
+            audioImage.Source = GraphicsUtil.CreateBitmapSource(Properties.Resources.SpeakTextContext);
+            cancelCalloutImage.Source = GraphicsUtil.CreateBitmapSource(Properties.Resources.CancelCalloutButton);
         }
 
         #region XAML-Binded Action Handler

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Util/ImageUtil.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Util/ImageUtil.cs
@@ -47,21 +47,5 @@ namespace PowerPointLabs.PictureSlidesLab.Util
             }
             return result;
         }
-
-        public static BitmapImage BitmapToImageSource(Bitmap bitmap)
-        {
-            using (MemoryStream memory = new MemoryStream())
-            {
-                bitmap.Save(memory, System.Drawing.Imaging.ImageFormat.Png);
-                memory.Position = 0;
-                BitmapImage bitmapimage = new BitmapImage();
-                bitmapimage.BeginInit();
-                bitmapimage.StreamSource = memory;
-                bitmapimage.CacheOption = BitmapCacheOption.OnLoad;
-                bitmapimage.EndInit();
-
-                return bitmapimage;
-            }
-        }
     }
 }

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Views/AdjustImageWindow.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Views/AdjustImageWindow.xaml.cs
@@ -9,6 +9,7 @@ using PowerPointLabs.ActionFramework.Common.Extension;
 using PowerPointLabs.CropLab;
 using PowerPointLabs.PictureSlidesLab.Util;
 using PowerPointLabs.PictureSlidesLab.Views.ImageAdjustment;
+using PowerPointLabs.Utils;
 using PowerPointLabs.WPF.Observable;
 
 using Color = System.Windows.Media.Color;
@@ -48,17 +49,17 @@ namespace PowerPointLabs.PictureSlidesLab.Views
         {
             InitializeComponent();
             ImageHolder.DataContext = thumbnailImageFile;
-            MoveLeftImage.Source = ImageUtil.BitmapToImageSource(Properties.Resources.Left);
-            MoveUpImage.Source = ImageUtil.BitmapToImageSource(Properties.Resources.Up);
-            MoveDownImage.Source = ImageUtil.BitmapToImageSource(Properties.Resources.Down);
-            MoveRightImage.Source = ImageUtil.BitmapToImageSource(Properties.Resources.Right);
-            ZoomInImage.Source = ImageUtil.BitmapToImageSource(Properties.Resources.PlusZoom);
-            ZoomOutImage.Source = ImageUtil.BitmapToImageSource(Properties.Resources.MinusZoom);
-            AutoFitImage.Source = ImageUtil.BitmapToImageSource(Properties.Resources.Fit);
-            LeftRotateImage.Source = ImageUtil.BitmapToImageSource(Properties.Resources.LeftRotate);
-            RightRotateImage.Source = ImageUtil.BitmapToImageSource(Properties.Resources.RightRotate);
-            FlipHorizontalImage.Source = ImageUtil.BitmapToImageSource(Properties.Resources.FlipHorizontal);
-            FlipVerticalImage.Source = ImageUtil.BitmapToImageSource(Properties.Resources.FlipVertical);
+            MoveLeftImage.Source = GraphicsUtil.BitmapToImageSource(Properties.Resources.Left);
+            MoveUpImage.Source = GraphicsUtil.BitmapToImageSource(Properties.Resources.Up);
+            MoveDownImage.Source = GraphicsUtil.BitmapToImageSource(Properties.Resources.Down);
+            MoveRightImage.Source = GraphicsUtil.BitmapToImageSource(Properties.Resources.Right);
+            ZoomInImage.Source = GraphicsUtil.BitmapToImageSource(Properties.Resources.PlusZoom);
+            ZoomOutImage.Source = GraphicsUtil.BitmapToImageSource(Properties.Resources.MinusZoom);
+            AutoFitImage.Source = GraphicsUtil.BitmapToImageSource(Properties.Resources.Fit);
+            LeftRotateImage.Source = GraphicsUtil.BitmapToImageSource(Properties.Resources.LeftRotate);
+            RightRotateImage.Source = GraphicsUtil.BitmapToImageSource(Properties.Resources.RightRotate);
+            FlipHorizontalImage.Source = GraphicsUtil.BitmapToImageSource(Properties.Resources.FlipHorizontal);
+            FlipVerticalImage.Source = GraphicsUtil.BitmapToImageSource(Properties.Resources.FlipVertical);
         }
 
         public void ShowAdjustPictureDimensionsDialog()
@@ -181,27 +182,32 @@ namespace PowerPointLabs.PictureSlidesLab.Views
         private void SaveCropButton_OnClick(object sender, RoutedEventArgs e)
         {
             Rect rect = _croppingAdorner.ClippingRectangle;
-            double xRatio = rect.X/ImageHolder.ActualWidth;
-            double yRatio = rect.Y/ImageHolder.ActualHeight;
-            double widthRatio = rect.Width/ImageHolder.ActualWidth;
-            double heightRatio = rect.Height/ImageHolder.ActualHeight;
+            double xRatio = rect.X / ImageHolder.ActualWidth;
+            double yRatio = rect.Y / ImageHolder.ActualHeight;
+            double widthRatio = rect.Width / ImageHolder.ActualWidth;
+            double heightRatio = rect.Height / ImageHolder.ActualHeight;
             Rect = rect;
-
-            Bitmap originalImg = (Bitmap)Bitmap.FromFile(CropResult);
-            Bitmap result = CropToShape.KiCut(originalImg, 
-                (float) xRatio*originalImg.Width,
-                (float) yRatio * originalImg.Height,
-                (float) widthRatio * originalImg.Width,
-                (float) heightRatio * originalImg.Height);
-            CropResult = StoragePath.GetPath("crop-"
-                                    + DateTime.Now.GetHashCode() + "-"
-                                    + Guid.NewGuid().ToString().Substring(0, 7));
-            result.Save(CropResult);
+            CropResult = CropAndSaveImageFromFile(CropResult, xRatio, yRatio, widthRatio, heightRatio);
 
             CropResultThumbnail = ImageUtil.GetThumbnailFromFullSizeImg(CropResult);
             IsCropped = true;
 
             Close();
+        }
+
+        private string CropAndSaveImageFromFile(string image, double xRatio, double yRatio, double widthRatio, double heightRatio)
+        {
+            Bitmap originalImg = (Bitmap)Bitmap.FromFile(image);
+            Bitmap result = CropToShape.KiCut(originalImg,
+                (float)xRatio * originalImg.Width,
+                (float)yRatio * originalImg.Height,
+                (float)widthRatio * originalImg.Width,
+                (float)heightRatio * originalImg.Height);
+            string croppedImage = StoragePath.GetPath("crop-"
+                                    + DateTime.Now.GetHashCode() + "-"
+                                    + Guid.NewGuid().ToString().Substring(0, 7));
+            result.Save(croppedImage);
+            return croppedImage;
         }
 
         private void AutoFitButton_OnClick(object sender, RoutedEventArgs e)

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Views/PictureSlidesLabWindow.xaml.VariationStageControls.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Views/PictureSlidesLabWindow.xaml.VariationStageControls.cs
@@ -8,7 +8,7 @@ using System.Windows.Media;
 using PowerPointLabs.ActionFramework.Common.Extension;
 using PowerPointLabs.PictureSlidesLab.Model;
 using PowerPointLabs.TextCollection;
-
+using PowerPointLabs.Utils;
 using Color = System.Drawing.Color;
 using Forms = System.Windows.Forms;
 
@@ -200,7 +200,7 @@ namespace PowerPointLabs.PictureSlidesLab.Views
 
         private Color GetColor(SolidColorBrush brush)
         {
-            return Color.FromArgb(brush.Color.A, brush.Color.R, brush.Color.G, brush.Color.B);
+            return GraphicsUtil.DrawingColorFromBrush(brush);
         }
 
         private bool IsSliderSupported(string currentCategory)

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Views/PictureSlidesLabWindow.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Views/PictureSlidesLabWindow.xaml.cs
@@ -26,6 +26,7 @@ using PowerPointLabs.PictureSlidesLab.Util;
 using PowerPointLabs.PictureSlidesLab.ViewModel;
 using PowerPointLabs.PictureSlidesLab.Views.Interface;
 using PowerPointLabs.TextCollection;
+using PowerPointLabs.Utils;
 using PowerPointLabs.WPF.Observable;
 
 using ButtonBase = System.Windows.Controls.Primitives.ButtonBase;
@@ -92,8 +93,8 @@ namespace PowerPointLabs.PictureSlidesLab.Views
             EveryDayPhrase.Text = new EveryDayPhraseService().GetEveryDayPhrase();
             PictureSlidesLabGridLoadingOverlay.Visibility = Visibility.Visible;
             IsOpen = true;
-            SettingsButtonIcon.Source = ImageUtil.BitmapToImageSource(Properties.Resources.PslSettings);
-            PictureAspectRefreshButtonIcon.Source = ImageUtil.BitmapToImageSource(Properties.Resources.PslRefresh);
+            SettingsButtonIcon.Source = GraphicsUtil.BitmapToImageSource(Properties.Resources.PslSettings);
+            PictureAspectRefreshButtonIcon.Source = GraphicsUtil.BitmapToImageSource(Properties.Resources.PslRefresh);
             InitSizePosition();
             Logger.Log("PSL begins");
 

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Views/QuickDropDialog.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Views/QuickDropDialog.xaml.cs
@@ -5,6 +5,7 @@ using System.Windows.Input;
 using MahApps.Metro.Controls;
 
 using PowerPointLabs.PictureSlidesLab.Util;
+using PowerPointLabs.Utils;
 
 namespace PowerPointLabs.PictureSlidesLab.Views
 {
@@ -43,7 +44,7 @@ namespace PowerPointLabs.PictureSlidesLab.Views
 
             InitDragAndDrop();
             IsOpen = true;
-            PictureSlidesLabLogo.Source = ImageUtil.BitmapToImageSource(Properties.Resources.PictureSlidesLab);
+            PictureSlidesLabLogo.Source = GraphicsUtil.BitmapToImageSource(Properties.Resources.PictureSlidesLab);
         }
 
         public void ShowQuickDropDialog()

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Views/SettingsFlyout.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Views/SettingsFlyout.xaml.cs
@@ -99,7 +99,7 @@ namespace PowerPointLabs.PictureSlidesLab.Views
 
         private Color GetColor(SolidColorBrush brush)
         {
-            return Color.FromArgb(brush.Color.A, brush.Color.R, brush.Color.G, brush.Color.B);
+            return GraphicsUtil.DrawingColorFromBrush(brush);
         }
 
         private void InsertCitationToggleSwitch_OnIsCheckedChanged(object sender, EventArgs e)

--- a/PowerPointLabs/PowerPointLabs/SaveLab/Views/SaveLabSettingsDialogBox.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/SaveLab/Views/SaveLabSettingsDialogBox.xaml.cs
@@ -25,7 +25,7 @@ namespace PowerPointLabs.SaveLab.Views
         public SaveLabSettingsDialogBox(string savePath)
             : this()
         {
-            savePathBrowserIconImage.Source = GraphicsUtil.CreateBitmapSource(Properties.Resources.Load_icon);
+            savePathBrowserIconImage.Source = GraphicsUtil.BitmapToImageSource(Properties.Resources.Load_icon);
             
             savePathInput.IsReadOnly = true;
             savePathInput.Text = savePath;

--- a/PowerPointLabs/PowerPointLabs/SaveLab/Views/SaveLabSettingsDialogBox.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/SaveLab/Views/SaveLabSettingsDialogBox.xaml.cs
@@ -25,7 +25,7 @@ namespace PowerPointLabs.SaveLab.Views
         public SaveLabSettingsDialogBox(string savePath)
             : this()
         {
-            savePathBrowserIconImage.Source = CommonUtil.CreateBitmapSource(Properties.Resources.Load_icon);
+            savePathBrowserIconImage.Source = GraphicsUtil.CreateBitmapSource(Properties.Resources.Load_icon);
             
             savePathInput.IsReadOnly = true;
             savePathInput.Text = savePath;

--- a/PowerPointLabs/PowerPointLabs/ShapesLab/Views/CustomShapePaneItem.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/ShapesLab/Views/CustomShapePaneItem.xaml.cs
@@ -294,7 +294,7 @@ namespace PowerPointLabs.ShapesLab.Views
             }
             else
             {
-                BitmapSource source = GraphicsUtil.CreateBitmapSource(image);
+                BitmapSource source = GraphicsUtil.BitmapToImageSource(image);
                 imageBox.Source = source;
                 imageBox.Visibility = Visibility.Visible;
                 col1.Width = new GridLength(60);

--- a/PowerPointLabs/PowerPointLabs/ShapesLab/Views/CustomShapePaneItem.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/ShapesLab/Views/CustomShapePaneItem.xaml.cs
@@ -294,7 +294,7 @@ namespace PowerPointLabs.ShapesLab.Views
             }
             else
             {
-                BitmapSource source = CommonUtil.CreateBitmapSource(image);
+                BitmapSource source = GraphicsUtil.CreateBitmapSource(image);
                 imageBox.Source = source;
                 imageBox.Visibility = Visibility.Visible;
                 col1.Width = new GridLength(60);

--- a/PowerPointLabs/PowerPointLabs/ShapesLab/Views/CustomShapePaneWPF.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/ShapesLab/Views/CustomShapePaneWPF.xaml.cs
@@ -73,7 +73,7 @@ namespace PowerPointLabs.ShapesLab.Views
             InitializeComponent();
             DataContext = this;
 
-            addShapeImage.Source = GraphicsUtil.CreateBitmapSource(Properties.Resources.AddToCustomShapes);
+            addShapeImage.Source = GraphicsUtil.BitmapToImageSource(Properties.Resources.AddToCustomShapes);
 
             singleShapeDownloadLink.NavigateUri = new Uri(CommonText.SingleShapeDownloadUrl);
         }
@@ -628,13 +628,13 @@ namespace PowerPointLabs.ShapesLab.Views
         private void DisableAddShapesButton()
         {
             addShapeButton.IsEnabled = false;
-            addShapeImage.Source = GraphicsUtil.CreateBitmapSource(Properties.Resources.AddToCustomShapesDisabled);
+            addShapeImage.Source = GraphicsUtil.BitmapToImageSource(Properties.Resources.AddToCustomShapesDisabled);
         }
 
         private void EnableAddShapesButton()
         {
             addShapeButton.IsEnabled = true;
-            addShapeImage.Source = GraphicsUtil.CreateBitmapSource(Properties.Resources.AddToCustomShapes);
+            addShapeImage.Source = GraphicsUtil.BitmapToImageSource(Properties.Resources.AddToCustomShapes);
         }
 
 

--- a/PowerPointLabs/PowerPointLabs/ShapesLab/Views/CustomShapePaneWPF.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/ShapesLab/Views/CustomShapePaneWPF.xaml.cs
@@ -73,7 +73,7 @@ namespace PowerPointLabs.ShapesLab.Views
             InitializeComponent();
             DataContext = this;
 
-            addShapeImage.Source = CommonUtil.CreateBitmapSource(Properties.Resources.AddToCustomShapes);
+            addShapeImage.Source = GraphicsUtil.CreateBitmapSource(Properties.Resources.AddToCustomShapes);
 
             singleShapeDownloadLink.NavigateUri = new Uri(CommonText.SingleShapeDownloadUrl);
         }
@@ -628,13 +628,13 @@ namespace PowerPointLabs.ShapesLab.Views
         private void DisableAddShapesButton()
         {
             addShapeButton.IsEnabled = false;
-            addShapeImage.Source = CommonUtil.CreateBitmapSource(Properties.Resources.AddToCustomShapesDisabled);
+            addShapeImage.Source = GraphicsUtil.CreateBitmapSource(Properties.Resources.AddToCustomShapesDisabled);
         }
 
         private void EnableAddShapesButton()
         {
             addShapeButton.IsEnabled = true;
-            addShapeImage.Source = CommonUtil.CreateBitmapSource(Properties.Resources.AddToCustomShapes);
+            addShapeImage.Source = GraphicsUtil.CreateBitmapSource(Properties.Resources.AddToCustomShapes);
         }
 
 

--- a/PowerPointLabs/PowerPointLabs/ShapesLab/Views/ShapesLabSettingsDialogBox.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/ShapesLab/Views/ShapesLabSettingsDialogBox.xaml.cs
@@ -27,7 +27,7 @@ namespace PowerPointLabs.ShapesLab.Views
         
         public ShapesLabSettingsDialogBox(string savePath) : this()
         {
-            savePathBrowserIconImage.Source = CommonUtil.CreateBitmapSource(Properties.Resources.Load_icon);
+            savePathBrowserIconImage.Source = GraphicsUtil.CreateBitmapSource(Properties.Resources.Load_icon);
             
             savePathInput.IsReadOnly = true;
             savePathInput.Text = savePath;

--- a/PowerPointLabs/PowerPointLabs/ShapesLab/Views/ShapesLabSettingsDialogBox.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/ShapesLab/Views/ShapesLabSettingsDialogBox.xaml.cs
@@ -27,7 +27,7 @@ namespace PowerPointLabs.ShapesLab.Views
         
         public ShapesLabSettingsDialogBox(string savePath) : this()
         {
-            savePathBrowserIconImage.Source = GraphicsUtil.CreateBitmapSource(Properties.Resources.Load_icon);
+            savePathBrowserIconImage.Source = GraphicsUtil.BitmapToImageSource(Properties.Resources.Load_icon);
             
             savePathInput.IsReadOnly = true;
             savePathInput.Text = savePath;

--- a/PowerPointLabs/PowerPointLabs/SyncLab/Views/SyncFormatListItem.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/Views/SyncFormatListItem.xaml.cs
@@ -60,7 +60,7 @@ namespace PowerPointLabs.SyncLab.Views
             }
             else
             {
-                BitmapSource source = GraphicsUtil.CreateBitmapSource(image);
+                BitmapSource source = GraphicsUtil.BitmapToImageSource(image);
                 imageBox.Source = source;
                 imageBox.Visibility = Visibility.Visible;
                 label.Margin = new Thickness(65, label.Margin.Top,

--- a/PowerPointLabs/PowerPointLabs/SyncLab/Views/SyncFormatListItem.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/Views/SyncFormatListItem.xaml.cs
@@ -60,7 +60,7 @@ namespace PowerPointLabs.SyncLab.Views
             }
             else
             {
-                BitmapSource source = CommonUtil.CreateBitmapSource(image);
+                BitmapSource source = GraphicsUtil.CreateBitmapSource(image);
                 imageBox.Source = source;
                 imageBox.Visibility = Visibility.Visible;
                 label.Margin = new Thickness(65, label.Margin.Top,

--- a/PowerPointLabs/PowerPointLabs/SyncLab/Views/SyncFormatPaneItem.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/Views/SyncFormatPaneItem.xaml.cs
@@ -39,9 +39,9 @@ namespace PowerPointLabs.SyncLab.Views
             this.shapeKey = shapeKey;
             this.shapeStorage = shapeStorage;
             this.formats = formats;
-            editImage.Source = CommonUtil.CreateBitmapSource(Properties.Resources.SyncLabEditButton);
-            pasteImage.Source = CommonUtil.CreateBitmapSource(Properties.Resources.SyncLabPasteButton);
-            deleteImage.Source = CommonUtil.CreateBitmapSource(Properties.Resources.SyncLabDeleteButton);
+            editImage.Source = GraphicsUtil.CreateBitmapSource(Properties.Resources.SyncLabEditButton);
+            pasteImage.Source = GraphicsUtil.CreateBitmapSource(Properties.Resources.SyncLabPasteButton);
+            deleteImage.Source = GraphicsUtil.CreateBitmapSource(Properties.Resources.SyncLabDeleteButton);
 
             UpdateToolTipBody();
         }
@@ -102,7 +102,7 @@ namespace PowerPointLabs.SyncLab.Views
             }
             else
             {
-                BitmapSource source = CommonUtil.CreateBitmapSource(image);
+                BitmapSource source = GraphicsUtil.CreateBitmapSource(image);
                 imageBox.Source = source;
                 imageBox.Visibility = Visibility.Visible;
                 col1.Width = new GridLength(60);

--- a/PowerPointLabs/PowerPointLabs/SyncLab/Views/SyncFormatPaneItem.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/Views/SyncFormatPaneItem.xaml.cs
@@ -39,9 +39,9 @@ namespace PowerPointLabs.SyncLab.Views
             this.shapeKey = shapeKey;
             this.shapeStorage = shapeStorage;
             this.formats = formats;
-            editImage.Source = GraphicsUtil.CreateBitmapSource(Properties.Resources.SyncLabEditButton);
-            pasteImage.Source = GraphicsUtil.CreateBitmapSource(Properties.Resources.SyncLabPasteButton);
-            deleteImage.Source = GraphicsUtil.CreateBitmapSource(Properties.Resources.SyncLabDeleteButton);
+            editImage.Source = GraphicsUtil.BitmapToImageSource(Properties.Resources.SyncLabEditButton);
+            pasteImage.Source = GraphicsUtil.BitmapToImageSource(Properties.Resources.SyncLabPasteButton);
+            deleteImage.Source = GraphicsUtil.BitmapToImageSource(Properties.Resources.SyncLabDeleteButton);
 
             UpdateToolTipBody();
         }
@@ -102,7 +102,7 @@ namespace PowerPointLabs.SyncLab.Views
             }
             else
             {
-                BitmapSource source = GraphicsUtil.CreateBitmapSource(image);
+                BitmapSource source = GraphicsUtil.BitmapToImageSource(image);
                 imageBox.Source = source;
                 imageBox.Visibility = Visibility.Visible;
                 col1.Width = new GridLength(60);

--- a/PowerPointLabs/PowerPointLabs/SyncLab/Views/SyncPaneWPF.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/Views/SyncPaneWPF.xaml.cs
@@ -30,7 +30,7 @@ namespace PowerPointLabs.SyncLab.Views
             InitializeComponent();
             shapeStorage = SyncLabShapeStorage.Instance;
 
-            copyImage.Source = CommonUtil.CreateBitmapSource(Properties.Resources.SyncLabCopyButton);
+            copyImage.Source = GraphicsUtil.CreateBitmapSource(Properties.Resources.SyncLabCopyButton);
         }
 
         public void SyncPaneWPF_Loaded(object sender, RoutedEventArgs e)

--- a/PowerPointLabs/PowerPointLabs/SyncLab/Views/SyncPaneWPF.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/Views/SyncPaneWPF.xaml.cs
@@ -30,7 +30,7 @@ namespace PowerPointLabs.SyncLab.Views
             InitializeComponent();
             shapeStorage = SyncLabShapeStorage.Instance;
 
-            copyImage.Source = GraphicsUtil.CreateBitmapSource(Properties.Resources.SyncLabCopyButton);
+            copyImage.Source = GraphicsUtil.BitmapToImageSource(Properties.Resources.SyncLabCopyButton);
         }
 
         public void SyncPaneWPF_Loaded(object sender, RoutedEventArgs e)

--- a/PowerPointLabs/PowerPointLabs/TooltipsLab/Views/TooltipsLabSettingsAnimationEntry.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/TooltipsLab/Views/TooltipsLabSettingsAnimationEntry.xaml.cs
@@ -22,7 +22,7 @@ namespace PowerPointLabs.TooltipsLab.Views
         {
             InitializeComponent();
             Type = defaultEffectType;
-            imageBox.Source = GraphicsUtil.CreateBitmapSource(image);
+            imageBox.Source = GraphicsUtil.BitmapToImageSource(image);
         }
 
         #endregion

--- a/PowerPointLabs/PowerPointLabs/TooltipsLab/Views/TooltipsLabSettingsAnimationEntry.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/TooltipsLab/Views/TooltipsLabSettingsAnimationEntry.xaml.cs
@@ -22,7 +22,7 @@ namespace PowerPointLabs.TooltipsLab.Views
         {
             InitializeComponent();
             Type = defaultEffectType;
-            imageBox.Source = CommonUtil.CreateBitmapSource(image);
+            imageBox.Source = GraphicsUtil.CreateBitmapSource(image);
         }
 
         #endregion

--- a/PowerPointLabs/PowerPointLabs/TooltipsLab/Views/TooltipsLabSettingsShapeEntry.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/TooltipsLab/Views/TooltipsLabSettingsShapeEntry.xaml.cs
@@ -20,7 +20,7 @@ namespace PowerPointLabs.TooltipsLab.Views
         {
             InitializeComponent();
             Type = type;
-            imageBox.Source = CommonUtil.CreateBitmapSource(image);
+            imageBox.Source = GraphicsUtil.CreateBitmapSource(image);
         }
 
         #endregion

--- a/PowerPointLabs/PowerPointLabs/TooltipsLab/Views/TooltipsLabSettingsShapeEntry.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/TooltipsLab/Views/TooltipsLabSettingsShapeEntry.xaml.cs
@@ -20,7 +20,7 @@ namespace PowerPointLabs.TooltipsLab.Views
         {
             InitializeComponent();
             Type = type;
-            imageBox.Source = GraphicsUtil.CreateBitmapSource(image);
+            imageBox.Source = GraphicsUtil.BitmapToImageSource(image);
         }
 
         #endregion

--- a/PowerPointLabs/PowerPointLabs/Utils/CommonUtil.cs
+++ b/PowerPointLabs/PowerPointLabs/Utils/CommonUtil.cs
@@ -3,9 +3,6 @@ using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
 using System.Text.RegularExpressions;
-using System.Windows;
-using System.Windows.Interop;
-using System.Windows.Media.Imaging;
 
 namespace PowerPointLabs.Utils
 {
@@ -157,24 +154,6 @@ namespace PowerPointLabs.Utils
         public static double DegreeToRadian(float angle)
         {
             return angle / 180.0 * Math.PI;
-        }
-
-        #endregion
-
-        #region bitmap
-        /// <summary>
-        /// Used to create a <seealso cref="BitmapSource"/> using a <seealso cref="Bitmap"/>,
-        /// which can be used to specify an <seealso cref="System.Windows.Controls.Image"/>'s source.
-        /// As the Bitmap image is used as-is, there is no need to specify a palette, rectangle or sizing options.
-        /// As such, the palette pointer is IntPtr.Zero.
-        /// </summary>
-        public static BitmapSource CreateBitmapSource(Bitmap image)
-        {
-            return Imaging.CreateBitmapSourceFromHBitmap(
-                image.GetHbitmap(),
-                IntPtr.Zero,
-                Int32Rect.Empty,
-                BitmapSizeOptions.FromEmptyOptions());
         }
 
         #endregion

--- a/PowerPointLabs/PowerPointLabs/Utils/GraphicsUtil.cs
+++ b/PowerPointLabs/PowerPointLabs/Utils/GraphicsUtil.cs
@@ -281,19 +281,20 @@ namespace PowerPointLabs.Utils
             return thumbnail;
         }
 
-        /// <summary>
-        /// Used to create a <seealso cref="BitmapSource"/> using a <seealso cref="Bitmap"/>,
-        /// which can be used to specify an <seealso cref="System.Windows.Controls.Image"/>'s source.
-        /// As the Bitmap image is used as-is, there is no need to specify a palette, rectangle or sizing options.
-        /// As such, the palette pointer is IntPtr.Zero.
-        /// </summary>
-        public static BitmapSource CreateBitmapSource(Bitmap image)
+        public static BitmapImage BitmapToImageSource(Bitmap bitmap)
         {
-            return Imaging.CreateBitmapSourceFromHBitmap(
-                image.GetHbitmap(),
-                IntPtr.Zero,
-                System.Windows.Int32Rect.Empty,
-                BitmapSizeOptions.FromEmptyOptions());
+            using (MemoryStream memory = new MemoryStream())
+            {
+                bitmap.Save(memory, System.Drawing.Imaging.ImageFormat.Png);
+                memory.Position = 0;
+                BitmapImage bitmapimage = new BitmapImage();
+                bitmapimage.BeginInit();
+                bitmapimage.StreamSource = memory;
+                bitmapimage.CacheOption = BitmapCacheOption.OnLoad;
+                bitmapimage.EndInit();
+
+                return bitmapimage;
+            }
         }
 
         #endregion

--- a/PowerPointLabs/PowerPointLabs/Utils/GraphicsUtil.cs
+++ b/PowerPointLabs/PowerPointLabs/Utils/GraphicsUtil.cs
@@ -6,6 +6,7 @@ using System.Drawing.Drawing2D;
 using System.Drawing.Imaging;
 using System.IO;
 using System.Windows.Forms;
+using System.Windows.Interop;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
 
@@ -279,6 +280,22 @@ namespace PowerPointLabs.Utils
 
             return thumbnail;
         }
+
+        /// <summary>
+        /// Used to create a <seealso cref="BitmapSource"/> using a <seealso cref="Bitmap"/>,
+        /// which can be used to specify an <seealso cref="System.Windows.Controls.Image"/>'s source.
+        /// As the Bitmap image is used as-is, there is no need to specify a palette, rectangle or sizing options.
+        /// As such, the palette pointer is IntPtr.Zero.
+        /// </summary>
+        public static BitmapSource CreateBitmapSource(Bitmap image)
+        {
+            return Imaging.CreateBitmapSourceFromHBitmap(
+                image.GetHbitmap(),
+                IntPtr.Zero,
+                System.Windows.Int32Rect.Empty,
+                BitmapSizeOptions.FromEmptyOptions());
+        }
+
         #endregion
 
         #region GDI+
@@ -317,9 +334,10 @@ namespace PowerPointLabs.Utils
             b = (byte)((rgb >> 16) & 255);
         }
 
-        public static Drawing.Color DrawingColorFromMediaColor(System.Windows.Media.Color mediaColor)
+        public static Drawing.Color DrawingColorFromMediaColor(System.Windows.Media.Color mediaColor, bool opaque = false)
         {
-            return Drawing.Color.FromArgb(mediaColor.A, mediaColor.R, mediaColor.G, mediaColor.B);
+            return Drawing.Color.FromArgb(opaque ? 255 : mediaColor.A,
+                mediaColor.R, mediaColor.G, mediaColor.B);
         }
 
         public static System.Windows.Media.Color MediaColorFromDrawingColor(Drawing.Color drawingColor)


### PR DESCRIPTION
Fixes #1931

**PR Checklist**
- [x] Reorganize Util APIs
- [x] Use Util APIs whenever appropriate
- [x] Extract any duplicated code found

Summary of changes:
- Move `ImageUtil.BitmapToImageSource` to `GraphicsUtil`
- Remove `CommonUtil.CreateBitmapSource` and switch to `ImageUtil.BitmapToImageSource`.

- Switch to `GraphicsUtil` Colors API.