### PR TITLE
#1900 ColorsLab Eyedropper bug

### DIFF
--- a/PowerPointLabs/PowerPointLabs/ColorsLab/ColorsLabPaneWPF.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/ColorsLab/ColorsLabPaneWPF.xaml.cs
@@ -620,6 +620,9 @@ namespace PowerPointLabs.ColorsLab
         {
             timer1Ticks++;
 
+            // Force the magnifier to update
+            magnifier.Show();
+
             System.Drawing.Point mousePos = System.Windows.Forms.Control.MousePosition;
             IntPtr deviceContext = PPExtraEventHelper.Native.GetDC(IntPtr.Zero);
 


### PR DESCRIPTION
Fixes #1900

Added a line to show the magnifier (update) every timer tick. Currently the magnifier has it's own timer that calls the update method to update itself. This PR adds the code to the timer belonging to ColorsLab.

So far in my testing I do not encounter the problem described in #1900, but let's see if this helps.