### PR TITLE
#1963 zoom lab buttons greyed out depsite rectangle selected

### DIFF
--- a/PowerPointLabs/PowerPointLabs/PowerPointLabs.csproj
+++ b/PowerPointLabs/PowerPointLabs/PowerPointLabs.csproj
@@ -183,6 +183,9 @@
   -->
   <ItemGroup>
     <Reference Include="Accessibility" />
+    <Reference Include="EyeOpen.Imaging.Processing">
+      <HintPath>..\Test\Dependency\EyeOpen.Imaging.Processing.dll</HintPath>
+    </Reference>
     <Reference Include="ImageProcessor">
       <HintPath>..\packages\ImageProcessor.1.9.5.0\lib\ImageProcessor.dll</HintPath>
     </Reference>


### PR DESCRIPTION
Fixes #1963

To check if a shape is a rectangle, its visual appearance is compared to a rectangle with autoshape of `msoShapeRectangle`, the `IsSameLooking` method from `SlideUtil` in test project.