### PR TITLE
#1918 text overflow cannot scroll

### DIFF
--- a/PowerPointLabs/PowerPointLabs/ELearningLab/Views/ELearningWorkspaceViews/CustomItemView.xaml
+++ b/PowerPointLabs/PowerPointLabs/ELearningLab/Views/ELearningWorkspaceViews/CustomItemView.xaml
@@ -20,25 +20,28 @@
             <Label Content="{Binding ClickNo}" VerticalAlignment="Center" HorizontalAlignment="Center"
                                        FontFamily="Century Gothic" FontWeight="SemiBold" Foreground="White" FontSize="13"/>
         </Border>
-        <ListView Grid.Column="1" ItemsSource="{Binding CustomItems}" BorderThickness="0" Margin="0" IsHitTestVisible="False">
-            <ListView.ItemTemplate>
-                <DataTemplate DataType="{x:Type data:CustomSubItem}">
-                    <Grid>
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="30" MaxWidth="30"/>
-                            <ColumnDefinition Width="*" />
-                        </Grid.ColumnDefinitions>
-                        <Image Grid.Column="0" MinHeight="15" MaxHeight="15" MinWidth="15" MaxWidth="15" VerticalAlignment="Center"
-                   Source="{Binding Type, Converter={converters:AnimationTypeToImageSourceConverter}}" 
+        <DockPanel Grid.Column="1"  x:Name="panel" Margin="0">
+            <ListView MaxWidth="{Binding ActualWidth, ElementName=panel}" ItemsSource="{Binding CustomItems}"
+                      HorizontalContentAlignment="Stretch" BorderThickness="0" Margin="0" IsHitTestVisible="False">
+                <ListView.ItemTemplate>
+                    <DataTemplate DataType="{x:Type data:CustomSubItem}">
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="30" MaxWidth="30"/>
+                                <ColumnDefinition Width="*" />
+                            </Grid.ColumnDefinitions>
+                            <Image Grid.Column="0" MinHeight="15" MaxHeight="15" MinWidth="15" MaxWidth="15" VerticalAlignment="Center"
+                               Source="{Binding Type, Converter={converters:AnimationTypeToImageSourceConverter}}" 
                                Stretch="Uniform" HorizontalAlignment="Center"/>
-                        <DockPanel x:Name="canvas" Grid.Column="1" Margin="0">
-                            <TextBlock  MaxWidth="{Binding ActualWidth, ElementName=canvas}"
+                            <DockPanel x:Name="canvas" Grid.Column="1" Margin="0">
+                                <TextBlock MaxWidth="{Binding ActualWidth, ElementName=canvas}"
                                        HorizontalAlignment="Stretch" VerticalAlignment="Center" TextTrimming="CharacterEllipsis"
                                        Margin="0" Text="{Binding ShapeName}"/>
-                        </DockPanel>
-                    </Grid>
-                </DataTemplate>
-            </ListView.ItemTemplate>
-        </ListView>
+                            </DockPanel>
+                        </Grid>
+                    </DataTemplate>
+                </ListView.ItemTemplate>
+            </ListView>
+        </DockPanel>
     </Grid>
 </UserControl>

--- a/PowerPointLabs/PowerPointLabs/ELearningLab/Views/ELearningWorkspaceViews/CustomItemView.xaml
+++ b/PowerPointLabs/PowerPointLabs/ELearningLab/Views/ELearningWorkspaceViews/CustomItemView.xaml
@@ -25,13 +25,17 @@
                 <DataTemplate DataType="{x:Type data:CustomSubItem}">
                     <Grid>
                         <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="30"/>
+                            <ColumnDefinition Width="30" MaxWidth="30"/>
                             <ColumnDefinition Width="*" />
                         </Grid.ColumnDefinitions>
                         <Image Grid.Column="0" MinHeight="15" MaxHeight="15" MinWidth="15" MaxWidth="15" VerticalAlignment="Center"
                    Source="{Binding Type, Converter={converters:AnimationTypeToImageSourceConverter}}" 
                                Stretch="Uniform" HorizontalAlignment="Center"/>
-                        <TextBlock Grid.Column="1" Text="{Binding ShapeName}"/>
+                        <DockPanel x:Name="canvas" Grid.Column="1" Margin="0">
+                            <TextBlock  MaxWidth="{Binding ActualWidth, ElementName=canvas}"
+                                       HorizontalAlignment="Stretch" VerticalAlignment="Center" TextTrimming="CharacterEllipsis"
+                                       Margin="0" Text="{Binding ShapeName}"/>
+                        </DockPanel>
                     </Grid>
                 </DataTemplate>
             </ListView.ItemTemplate>


### PR DESCRIPTION
Fixes #1918

My proposed implementation to solve the problem is to truncate the name of the item if it overflows, so that the item sizes can be kept the same.

The implementation is similar to #1384, but the size of the parent element is also variable (the ListView), so wrapping the ListView with a DockPanel similarly seem to work

![image](https://user-images.githubusercontent.com/28508438/60944868-a68a3d00-a31c-11e9-9f86-c2b77f527a53.png)
