### PR TITLE
#1918 UI bug in E-Learning Lab: Text overflow cannot scroll

### DIFF
--- a/PowerPointLabs/PowerPointLabs/ELearningLab/Converters/ShapeNameWidthConverter.cs
+++ b/PowerPointLabs/PowerPointLabs/ELearningLab/Converters/ShapeNameWidthConverter.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Text.RegularExpressions;
+using System.Windows;
+using System.Windows.Data;
+
+namespace PowerPointLabs.ELearningLab.Converters
+{
+    public class ShapeNameWidthConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        {
+            if (value is double)
+            {
+                return (double)value - 45;
+            }
+            return null;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        {
+            if (value is double)
+            {
+                return (double)value + 45;
+            }
+            return null;
+        }
+    }
+}

--- a/PowerPointLabs/PowerPointLabs/ELearningLab/Converters/ShapeNameWidthConverter.cs
+++ b/PowerPointLabs/PowerPointLabs/ELearningLab/Converters/ShapeNameWidthConverter.cs
@@ -7,11 +7,12 @@ namespace PowerPointLabs.ELearningLab.Converters
 {
     public class ShapeNameWidthConverter : IValueConverter
     {
+        private const int leftIconWidth = 45;
         public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
         {
             if (value is double)
             {
-                return (double)value - 45;
+                return (double)value - leftIconWidth;
             }
             return null;
         }
@@ -20,7 +21,7 @@ namespace PowerPointLabs.ELearningLab.Converters
         {
             if (value is double)
             {
-                return (double)value + 45;
+                return (double)value + leftIconWidth;
             }
             return null;
         }

--- a/PowerPointLabs/PowerPointLabs/ELearningLab/Converters/ShapeNameWidthConverter.cs
+++ b/PowerPointLabs/PowerPointLabs/ELearningLab/Converters/ShapeNameWidthConverter.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Text.RegularExpressions;
 using System.Windows;
 using System.Windows.Data;
 

--- a/PowerPointLabs/PowerPointLabs/ELearningLab/Views/ELearningWorkspaceViews/CustomItemView.xaml
+++ b/PowerPointLabs/PowerPointLabs/ELearningLab/Views/ELearningWorkspaceViews/CustomItemView.xaml
@@ -30,7 +30,7 @@
                             <ColumnDefinition Name="test" Width="*" />
                         </Grid.ColumnDefinitions>
                         <Image Grid.Column="0" MinHeight="15" MaxHeight="15" MinWidth="15" MaxWidth="15" VerticalAlignment="Center"
-                   Source="{Binding Type, Converter={converters:AnimationTypeToImageSourceConverter}}" 
+                               Source="{Binding Type, Converter={converters:AnimationTypeToImageSourceConverter}}" 
                                Stretch="Uniform" HorizontalAlignment="Center"/>
                         <TextBlock Grid.Column="1" 
                                    Width="{Binding ActualWidth, ElementName=list, Converter={StaticResource ShapeNameConverter}}"

--- a/PowerPointLabs/PowerPointLabs/ELearningLab/Views/ELearningWorkspaceViews/CustomItemView.xaml
+++ b/PowerPointLabs/PowerPointLabs/ELearningLab/Views/ELearningWorkspaceViews/CustomItemView.xaml
@@ -9,6 +9,7 @@
              mc:Ignorable="d">
     <Control.Resources>
         <BooleanToVisibilityConverter x:Key="BoolToVisibility" />
+        <converters:ShapeNameWidthConverter x:Key="ShapeNameConverter" />
     </Control.Resources>
     <Grid>
         <Grid.ColumnDefinitions>
@@ -16,22 +17,24 @@
             <ColumnDefinition Width="*"/>
         </Grid.ColumnDefinitions>
         <Border Grid.Column="0" Width="30" Height="30" CornerRadius="15"
-                    VerticalAlignment="Top" Background="Black">
+                    VerticalAlignment="Center" Background="Black">
             <Label Content="{Binding ClickNo}" VerticalAlignment="Center" HorizontalAlignment="Center"
                                        FontFamily="Century Gothic" FontWeight="SemiBold" Foreground="White" FontSize="13"/>
         </Border>
-        <ListView Grid.Column="1" ItemsSource="{Binding CustomItems}" BorderThickness="0" Margin="0" IsHitTestVisible="False">
+        <ListView x:Name="list" Grid.Column="1" ItemsSource="{Binding CustomItems}" BorderThickness="0" Margin="0" IsHitTestVisible="False">
             <ListView.ItemTemplate>
                 <DataTemplate DataType="{x:Type data:CustomSubItem}">
                     <Grid>
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="30"/>
-                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Name="test" Width="*" />
                         </Grid.ColumnDefinitions>
                         <Image Grid.Column="0" MinHeight="15" MaxHeight="15" MinWidth="15" MaxWidth="15" VerticalAlignment="Center"
                    Source="{Binding Type, Converter={converters:AnimationTypeToImageSourceConverter}}" 
                                Stretch="Uniform" HorizontalAlignment="Center"/>
-                        <TextBlock Grid.Column="1" Text="{Binding ShapeName}"/>
+                        <TextBlock Grid.Column="1" 
+                                   Width="{Binding ActualWidth, ElementName=list, Converter={StaticResource ShapeNameConverter}}"
+                                   TextWrapping="Wrap"  HorizontalAlignment="Stretch" Text="{Binding ShapeName}"/>
                     </Grid>
                 </DataTemplate>
             </ListView.ItemTemplate>

--- a/PowerPointLabs/PowerPointLabs/ELearningLab/Views/ELearningWorkspaceViews/CustomItemView.xaml
+++ b/PowerPointLabs/PowerPointLabs/ELearningLab/Views/ELearningWorkspaceViews/CustomItemView.xaml
@@ -27,7 +27,7 @@
                     <Grid>
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="30"/>
-                            <ColumnDefinition Name="test" Width="*" />
+                            <ColumnDefinition Width="*" />
                         </Grid.ColumnDefinitions>
                         <Image Grid.Column="0" MinHeight="15" MaxHeight="15" MinWidth="15" MaxWidth="15" VerticalAlignment="Center"
                                Source="{Binding Type, Converter={converters:AnimationTypeToImageSourceConverter}}" 

--- a/PowerPointLabs/PowerPointLabs/PowerPointLabs.csproj
+++ b/PowerPointLabs/PowerPointLabs/PowerPointLabs.csproj
@@ -720,6 +720,7 @@
       <DependentUpon>ColorInformationDialog.xaml</DependentUpon>
     </Compile>
     <Compile Include="ColorTheme\ActionCommand.cs" />
+    <Compile Include="ELearningLab\Converters\ShapeNameWidthConverter.cs" />
     <Compile Include="Converters\ColorPane\HSLColorToHex.cs" />
     <Compile Include="Converters\ColorPane\SelectedColorShiftByAngle.cs" />
     <Compile Include="Converters\ColorPane\SelectedColorShiftSaturationByFactor.cs" />


### PR DESCRIPTION
Fixes #1918 

**Outline of Solution**
Fixed the issue by making the name wrap if it overflows, as suggested in the issue tracker.
One problem faced while implementing this solution was that in order for the TextBlock to wrap, its width cannot be set to automatic. To circumvent this, I made the grid's column inherit the width of the ListView, and created a simple converter that subtracts 45 pixels from the value given. (45 pixels is the size of the icon on the left)