### PR TITLE
#1947 HighlightLab bug: Background & Point highlight overwrite each other

### DIFF
--- a/PowerPointLabs/PowerPointLabs/HighlightLab/HighlightBulletsBackground.cs
+++ b/PowerPointLabs/PowerPointLabs/HighlightLab/HighlightBulletsBackground.cs
@@ -43,7 +43,6 @@ namespace PowerPointLabs.HighlightLab
                         break;
                     case HighlightBackgroundSelection.kNoneSelected:
                         currentSlide.DeleteIndicator();
-                        currentSlide.DeleteShapesWithPrefix("PPTLabsHighlightBackgroundShape");
                         shapesToUse = GetAllUsableShapesInSlide(currentSlide);
                         break;
                     default:
@@ -183,11 +182,6 @@ namespace PowerPointLabs.HighlightLab
                         sh.Select(Office.MsoTriState.msoFalse);
                     }
                 }
-                //Remove existing animations for highlight text as well
-                if (sh.Name.Contains("HighlightTextShape"))
-                {
-                    currentSlide.DeleteShapeAnimations(sh);
-                }
             }
 
             if (shapesToDelete.Count > 0)
@@ -211,7 +205,6 @@ namespace PowerPointLabs.HighlightLab
                                     .Where(sh => !sh.Name.Contains("PPTLabsHighlightBackgroundShape")
                                                     && HasText(sh))
                                     .ToList();
-            shapesToUse.ForEach(currentSlide.DeleteShapeAnimations);
             return shapesToUse;
         }
 
@@ -237,12 +230,10 @@ namespace PowerPointLabs.HighlightLab
 
             if (usableShapesWithBullets.Count == 0)
             {
-                allUsableShapes.ForEach(currentSlide.DeleteShapeAnimations);
                 return allUsableShapes;
             }
             else
             {
-                usableShapesWithBullets.ForEach(currentSlide.DeleteShapeAnimations);
                 return usableShapesWithBullets;
             }
         }

--- a/PowerPointLabs/PowerPointLabs/HighlightLab/HighlightBulletsText.cs
+++ b/PowerPointLabs/PowerPointLabs/HighlightLab/HighlightBulletsText.cs
@@ -41,13 +41,12 @@ namespace PowerPointLabs.HighlightLab
                         break;
                     case HighlightTextSelection.kNoneSelected:
                         currentSlide.DeleteIndicator();
-                        currentSlide.DeleteShapesWithPrefix("PPTLabsHighlightBackgroundShape");
                         shapesToUse = GetAllUsableShapesInSlide(currentSlide);
                         break;
                     default:
                         break;
                 }
-                
+
                 if (currentSlide.Name.Contains("PPTLabsHighlightBulletsSlide"))
                 {
                     ProcessExistingHighlightSlide(currentSlide, shapesToUse);
@@ -135,7 +134,6 @@ namespace PowerPointLabs.HighlightLab
         private static void ProcessExistingHighlightSlide(PowerPointSlide currentSlide, List<PowerPoint.Shape> shapesToUse)
         {
             currentSlide.DeleteIndicator();
-            currentSlide.DeleteShapesWithPrefix("PPTLabsHighlightBackgroundShape");
 
             foreach (PowerPoint.Shape tmp in currentSlide.Shapes)
             {


### PR DESCRIPTION
Fixes #1947 

**Outline of Solution**
Removed lines which implemented deletion of other currently existing highlight animations.

Now it looks like this if background highlight is used after point highlight and vice versa:
![ppt](https://user-images.githubusercontent.com/32454748/74081541-229f5b80-4a8b-11ea-9a74-bc3d581b706f.gif)
