### PR TITLE
Add preview for background highlight points

### DIFF
--- a/PowerPointLabs/PowerPointLabs/HighlightLab/HighlightBulletsBackground.cs
+++ b/PowerPointLabs/PowerPointLabs/HighlightLab/HighlightBulletsBackground.cs
@@ -69,6 +69,12 @@ namespace PowerPointLabs.HighlightLab
                     AnimationLabSettings.IsUseFrameAnimation = oldValue;
                     PowerPointPresentation.Current.AddAckSlide();
                 }
+
+                if (currentSlide.HasAnimationForClick(clickNumber: 1))
+                {
+                    Globals.ThisAddIn.Application.CommandBars.ExecuteMso("AnimationPreview");
+                }
+
                 Globals.ThisAddIn.Application.ActiveWindow.Selection.Unselect();
             }
             catch (Exception e)


### PR DESCRIPTION
Fixes #2009 

### Outline of Solution
Fixed the issue by checking if animation is successfully added to the slide, and then playing the animation preview.