### PR TITLE
Add preview for background highlight points 

### DIFF
--- a/PowerPointLabs/PowerPointLabs/HighlightLab/HighlightBulletsBackground.cs
+++ b/PowerPointLabs/PowerPointLabs/HighlightLab/HighlightBulletsBackground.cs
@@ -68,6 +68,12 @@ namespace PowerPointLabs.HighlightLab
                     AnimationLabSettings.IsUseFrameAnimation = oldValue;
                     PowerPointPresentation.Current.AddAckSlide();
                 }
+
+                if (currentSlide.HasAnimationForClick(clickNumber: 1))
+                {
+                    Globals.ThisAddIn.Application.CommandBars.ExecuteMso("AnimationPreview");
+                }
+
                 Globals.ThisAddIn.Application.ActiveWindow.Selection.Unselect();
             }
             catch (Exception e)


### PR DESCRIPTION
Fixes #2009 
Created new branch due to branch naming issue. Previous reviews [here](https://github.com/PowerPointLabs/PowerPointLabs/pull/2010)

### Outline of Solution
Fixed the issue by checking if animation is successfully added to the slide, and then playing the animation preview.