### PR TITLE
#2002 replace with clipboard lose image quality

### DIFF
--- a/PowerPointLabs/PowerPointLabs/PasteLab/ReplaceWithClipboard.cs
+++ b/PowerPointLabs/PowerPointLabs/PasteLab/ReplaceWithClipboard.cs
@@ -15,7 +15,14 @@ namespace PowerPointLabs.PasteLab
         {
             // ignore height & width, it doesn't always make sense to sync the height & width especially for circles, squares
             List<Format> formatsToIgnore = new List<Format> {new PositionHeightFormat(), new PositionWidthFormat()};
-            
+
+            // the following effects are not useful for pictures and cause degradation of picture quality
+            List<Format> formatsToIgnoreIfPicture = new List<Format>
+            {
+                new ContourColorFormat(), new ContourWidthFormat(), new DepthSizeFormat(), new LightingAngleFormat(),
+                new MaterialEffectFormat(), new PositionHeightFormat(), new PositionWidthFormat(), new ThreeDRotationEffectFormat()
+            };
+
             // Replacing individual shape
             if (selectedChildShapes.Count == 0)
             {
@@ -32,7 +39,16 @@ namespace PowerPointLabs.PasteLab
 
                 slide.DeleteShapeAnimations(pastingShape);
                 slide.TransferAnimation(selectedShape, pastingShape);
-                ShapeUtil.ApplyAllPossibleFormats(selectedShape, pastingShape, formatsToIgnore);
+
+                if (pastingShape.IsPicture())
+                {
+                    ShapeUtil.ApplyAllPossibleFormats(selectedShape, pastingShape, formatsToIgnoreIfPicture);
+                }
+                else
+                {
+                    ShapeUtil.ApplyAllPossibleFormats(selectedShape, pastingShape, formatsToIgnore);
+                }
+
                 selectedShape.SafeDelete();
 
                 return slide.ToShapeRange(pastingShape);
@@ -74,10 +90,17 @@ namespace PowerPointLabs.PasteLab
 
                 List<Format> positionFormats = new List<Format> {new PositionXFormat(), new PositionYFormat()};
                 formatsToIgnore.AddRange(positionFormats);
-                
+
                 for (int i = 1; i <= pastingShapes.Count; i++)
                 {
-                    ShapeUtil.ApplyAllPossibleFormats(selectedChildShape, pastingShapes[i], formatsToIgnore);
+                    if (pastingShapes[i].IsPicture())
+                    {
+                        ShapeUtil.ApplyAllPossibleFormats(selectedChildShape, pastingShapes[i], formatsToIgnoreIfPicture);
+                    }
+                    else
+                    {
+                        ShapeUtil.ApplyAllPossibleFormats(selectedChildShape, pastingShapes[i], formatsToIgnore);
+                    }
                 }
 
                 // Remove selected child since it is being replaced

--- a/PowerPointLabs/Test/FunctionalTest/PasteLabTest.cs
+++ b/PowerPointLabs/Test/FunctionalTest/PasteLabTest.cs
@@ -57,6 +57,10 @@ namespace Test.FunctionalTest
         private const int OrigIsClipboardRestoredPasteIntoGroupSlideNo = 37;
         private const int ExpIsClipboardRestoredPasteIntoGroupSlideNo = 38;
 
+        private const int OriginalReplaceWithClipboardDegradationSlideNo = 39;
+        private const int ReplacedReplaceWithClipboardDegradationSlideNo = 40;
+        private const int DegradedReplaceWithClipboardDegradationSlideNo = 41;
+
         protected override string GetTestingSlideName()
         {
             return "PasteLab\\PasteLab.pptx";
@@ -66,26 +70,29 @@ namespace Test.FunctionalTest
         [TestCategory("FT")]
         public void FT_PasteLabTest()
         {
-            PasteToFillSlide(OriginalPasteToFillSlideSlideNo, ExpectedPasteToFillSlideSlideNo);
-            PasteToFillSlide(OriginalDiagonalPasteToFillSlideSlideNo, ExpectedDiagonalPasteToFillSlideSlideNo);
-            PasteToFillSlide(OriginalMultiplePasteToFillSlideSlideNo, ExpectedMultiplePasteToFillSlideSlideNo);
-            PasteToFillSlide(OriginalGroupPasteToFillSlideSlideNo, ExpectedGroupPasteToFillSlideSlideNo);
+            //PasteToFillSlide(OriginalPasteToFillSlideSlideNo, ExpectedPasteToFillSlideSlideNo);
+            //PasteToFillSlide(OriginalDiagonalPasteToFillSlideSlideNo, ExpectedDiagonalPasteToFillSlideSlideNo);
+            //PasteToFillSlide(OriginalMultiplePasteToFillSlideSlideNo, ExpectedMultiplePasteToFillSlideSlideNo);
+            //PasteToFillSlide(OriginalGroupPasteToFillSlideSlideNo, ExpectedGroupPasteToFillSlideSlideNo);
 
-            PasteAtCursorPosition(OriginalPasteAtCursorSlideNo, ExpectedPasteAtCursorSlideNo);
-            PasteAtOriginalPosition(OriginalPasteAtOriginalSlideNo, ExpectedPasteAtOriginalSlideNo);
+            //PasteAtCursorPosition(OriginalPasteAtCursorSlideNo, ExpectedPasteAtCursorSlideNo);
+            //PasteAtOriginalPosition(OriginalPasteAtOriginalSlideNo, ExpectedPasteAtOriginalSlideNo);
 
-            ReplaceWithClipboard(OriginalReplaceWithClipboardSlideNo, ExpectedReplaceWithClipboardSlideNo);
-            ReplaceWithClipboard(OriginalGroupReplaceWithClipboardSlideNo, ExpectedGroupReplaceWithClipboardSlideNo);
+            //ReplaceWithClipboard(OriginalReplaceWithClipboardSlideNo, ExpectedReplaceWithClipboardSlideNo);
+            //ReplaceWithClipboard(OriginalGroupReplaceWithClipboardSlideNo, ExpectedGroupReplaceWithClipboardSlideNo);
 
-            PasteIntoGroup(OriginalPasteIntoGroupSlideNo, ExpectedPasteIntoGroupSlideNo);
+            //PasteIntoGroup(OriginalPasteIntoGroupSlideNo, ExpectedPasteIntoGroupSlideNo);
 
-            PasteToFitSlide(OriginalPasteToFitSlideSlideNo, ExpectedPasteToFitSlideSlideNo);
-            PasteToFitSlide(OriginalDiagonalPasteToFitSlideSlideNo, ExpectedDiagonalPasteToFitSlideSlideNo);
-            PasteToFitSlide(OriginalMultiplePasteToFitSlideSlideNo, ExpectedMultiplePasteToFitSlideSlideNo);
-            PasteToFitSlide(OriginalGroupPasteToFitSlideSlideNo, ExpectedGroupPasteToFitSlideSlideNo);
+            //PasteToFitSlide(OriginalPasteToFitSlideSlideNo, ExpectedPasteToFitSlideSlideNo);
+            //PasteToFitSlide(OriginalDiagonalPasteToFitSlideSlideNo, ExpectedDiagonalPasteToFitSlideSlideNo);
+            //PasteToFitSlide(OriginalMultiplePasteToFitSlideSlideNo, ExpectedMultiplePasteToFitSlideSlideNo);
+            //PasteToFitSlide(OriginalGroupPasteToFitSlideSlideNo, ExpectedGroupPasteToFitSlideSlideNo);
 
-            IsClipboardRestoredReplaceWithClipboard(OrigIsClipboardRestoredReplaceWithClipboardSlideNo, ExpIsClipboardRestoredReplaceWithClipboardSlideNo);
-            IsClipboardRestoredPasteIntoGroup(OrigIsClipboardRestoredPasteIntoGroupSlideNo, ExpIsClipboardRestoredPasteIntoGroupSlideNo);
+            //IsClipboardRestoredReplaceWithClipboard(OrigIsClipboardRestoredReplaceWithClipboardSlideNo, ExpIsClipboardRestoredReplaceWithClipboardSlideNo);
+            //IsClipboardRestoredPasteIntoGroup(OrigIsClipboardRestoredPasteIntoGroupSlideNo, ExpIsClipboardRestoredPasteIntoGroupSlideNo);
+
+            IsDegradedAfterReplaceWithClipboard(OriginalReplaceWithClipboardDegradationSlideNo, ReplacedReplaceWithClipboardDegradationSlideNo,
+                DegradedReplaceWithClipboardDegradationSlideNo);
         }
 
         private void PasteToFillSlide(int originalSlideNo, int expSlideNo)
@@ -180,13 +187,44 @@ namespace Test.FunctionalTest
             }, originalSlideNo, ShapeToCopyPrefix, expSlideNo, "", ShapeToCompareCopied);
         }
 
-        private void AssertIsSame(int actualSlideNo, int expectedSlideNo)
+        private void IsDegradedAfterReplaceWithClipboard(int originalSlideNo, int replacedSlideNo, int degradedSlideNo)
+        {
+            Microsoft.Office.Interop.PowerPoint.ShapeRange shapes = GetShapesByPrefix(replacedSlideNo, ShapeToCopyPrefix);
+            shapes.Cut();
+
+            PpOperations.SelectShapes(new List<string> { ShapeToReplace });
+            PplFeatures.ReplaceWithClipboard();
+
+            // Degradation results in subtle differences, therefore comparison threshold must be stricter
+            AssertIsSame(originalSlideNo, replacedSlideNo, 0.999999999);
+            
+            // Verify that the degradation is detectable
+            AssertNotSame(originalSlideNo, degradedSlideNo, 0.999999999);
+        }
+
+        private void AssertIsSame(int actualSlideNo, int expectedSlideNo, double similarityTolerance = 0.95)
         {
             Microsoft.Office.Interop.PowerPoint.Slide actualSlide = PpOperations.SelectSlide(actualSlideNo);
             Microsoft.Office.Interop.PowerPoint.Slide expectedSlide = PpOperations.SelectSlide(expectedSlideNo);
 
-            SlideUtil.IsSameLooking(expectedSlide, actualSlide);
+            SlideUtil.IsSameLooking(expectedSlide, actualSlide, similarityTolerance);
             SlideUtil.IsSameAnimations(expectedSlide, actualSlide);
+        }
+
+        private void AssertNotSame(int actualSlideNo, int expectedSlideNo, double similarityTolerance = 0.95)
+        {
+            try
+            {
+                AssertIsSame(actualSlideNo, expectedSlideNo, similarityTolerance);
+                throw new AssertFailedException("AssertNotSame failed. The slides look similar.");
+            }
+            catch (AssertFailedException e)
+            {
+                if (e.Message.Equals("AssertNotSame failed. The slides look similar."))
+                {
+                    throw e;
+                }
+            }
         }
 
         private Microsoft.Office.Interop.PowerPoint.ShapeRange GetShapesByPrefix(int slideNo, string shapePrefix)

--- a/PowerPointLabs/Test/FunctionalTest/PasteLabTest.cs
+++ b/PowerPointLabs/Test/FunctionalTest/PasteLabTest.cs
@@ -216,15 +216,12 @@ namespace Test.FunctionalTest
             try
             {
                 AssertIsSame(actualSlideNo, expectedSlideNo, similarityTolerance);
-                throw new AssertFailedException("AssertNotSame failed. The slides look similar.");
             }
-            catch (AssertFailedException e)
+            catch (AssertFailedException)
             {
-                if (e.Message.Equals("AssertNotSame failed. The slides look similar."))
-                {
-                    throw e;
-                }
+                return;
             }
+            throw new AssertFailedException("AssertNotSame failed. The slides look similar.");
         }
 
         private Microsoft.Office.Interop.PowerPoint.ShapeRange GetShapesByPrefix(int slideNo, string shapePrefix)

--- a/PowerPointLabs/Test/FunctionalTest/PasteLabTest.cs
+++ b/PowerPointLabs/Test/FunctionalTest/PasteLabTest.cs
@@ -70,26 +70,26 @@ namespace Test.FunctionalTest
         [TestCategory("FT")]
         public void FT_PasteLabTest()
         {
-            //PasteToFillSlide(OriginalPasteToFillSlideSlideNo, ExpectedPasteToFillSlideSlideNo);
-            //PasteToFillSlide(OriginalDiagonalPasteToFillSlideSlideNo, ExpectedDiagonalPasteToFillSlideSlideNo);
-            //PasteToFillSlide(OriginalMultiplePasteToFillSlideSlideNo, ExpectedMultiplePasteToFillSlideSlideNo);
-            //PasteToFillSlide(OriginalGroupPasteToFillSlideSlideNo, ExpectedGroupPasteToFillSlideSlideNo);
+            PasteToFillSlide(OriginalPasteToFillSlideSlideNo, ExpectedPasteToFillSlideSlideNo);
+            PasteToFillSlide(OriginalDiagonalPasteToFillSlideSlideNo, ExpectedDiagonalPasteToFillSlideSlideNo);
+            PasteToFillSlide(OriginalMultiplePasteToFillSlideSlideNo, ExpectedMultiplePasteToFillSlideSlideNo);
+            PasteToFillSlide(OriginalGroupPasteToFillSlideSlideNo, ExpectedGroupPasteToFillSlideSlideNo);
 
-            //PasteAtCursorPosition(OriginalPasteAtCursorSlideNo, ExpectedPasteAtCursorSlideNo);
-            //PasteAtOriginalPosition(OriginalPasteAtOriginalSlideNo, ExpectedPasteAtOriginalSlideNo);
+            PasteAtCursorPosition(OriginalPasteAtCursorSlideNo, ExpectedPasteAtCursorSlideNo);
+            PasteAtOriginalPosition(OriginalPasteAtOriginalSlideNo, ExpectedPasteAtOriginalSlideNo);
 
-            //ReplaceWithClipboard(OriginalReplaceWithClipboardSlideNo, ExpectedReplaceWithClipboardSlideNo);
-            //ReplaceWithClipboard(OriginalGroupReplaceWithClipboardSlideNo, ExpectedGroupReplaceWithClipboardSlideNo);
+            ReplaceWithClipboard(OriginalReplaceWithClipboardSlideNo, ExpectedReplaceWithClipboardSlideNo);
+            ReplaceWithClipboard(OriginalGroupReplaceWithClipboardSlideNo, ExpectedGroupReplaceWithClipboardSlideNo);
 
-            //PasteIntoGroup(OriginalPasteIntoGroupSlideNo, ExpectedPasteIntoGroupSlideNo);
+            PasteIntoGroup(OriginalPasteIntoGroupSlideNo, ExpectedPasteIntoGroupSlideNo);
 
-            //PasteToFitSlide(OriginalPasteToFitSlideSlideNo, ExpectedPasteToFitSlideSlideNo);
-            //PasteToFitSlide(OriginalDiagonalPasteToFitSlideSlideNo, ExpectedDiagonalPasteToFitSlideSlideNo);
-            //PasteToFitSlide(OriginalMultiplePasteToFitSlideSlideNo, ExpectedMultiplePasteToFitSlideSlideNo);
-            //PasteToFitSlide(OriginalGroupPasteToFitSlideSlideNo, ExpectedGroupPasteToFitSlideSlideNo);
+            PasteToFitSlide(OriginalPasteToFitSlideSlideNo, ExpectedPasteToFitSlideSlideNo);
+            PasteToFitSlide(OriginalDiagonalPasteToFitSlideSlideNo, ExpectedDiagonalPasteToFitSlideSlideNo);
+            PasteToFitSlide(OriginalMultiplePasteToFitSlideSlideNo, ExpectedMultiplePasteToFitSlideSlideNo);
+            PasteToFitSlide(OriginalGroupPasteToFitSlideSlideNo, ExpectedGroupPasteToFitSlideSlideNo);
 
-            //IsClipboardRestoredReplaceWithClipboard(OrigIsClipboardRestoredReplaceWithClipboardSlideNo, ExpIsClipboardRestoredReplaceWithClipboardSlideNo);
-            //IsClipboardRestoredPasteIntoGroup(OrigIsClipboardRestoredPasteIntoGroupSlideNo, ExpIsClipboardRestoredPasteIntoGroupSlideNo);
+            IsClipboardRestoredReplaceWithClipboard(OrigIsClipboardRestoredReplaceWithClipboardSlideNo, ExpIsClipboardRestoredReplaceWithClipboardSlideNo);
+            IsClipboardRestoredPasteIntoGroup(OrigIsClipboardRestoredPasteIntoGroupSlideNo, ExpIsClipboardRestoredPasteIntoGroupSlideNo);
 
             IsDegradedAfterReplaceWithClipboard(OriginalReplaceWithClipboardDegradationSlideNo, ReplacedReplaceWithClipboardDegradationSlideNo,
                 DegradedReplaceWithClipboardDegradationSlideNo);


### PR DESCRIPTION
Fixes issue #2002 . Source of picture degradation are the following formats being applied to pictures:
```
ContourColorFormat
ContourWidthFormat
DepthSizeFormat
LightingAngleFormat
MaterialEffectFormat
ThreeDRotationEffectFormat
```

Issue is fixed by introducing a check to prevent pictures from having such formats applied to them.

A picture degradation test has been added to PasteLabFT as well.