### PR TITLE
#2017 replace with clipboard only keeps first and last animation and has undo exception

### DIFF
--- a/PowerPointLabs/PowerPointLabs/ActionFramework/PasteLab/ReplaceWithClipboard/ReplaceWithClipboardActionHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/PasteLab/ReplaceWithClipboard/ReplaceWithClipboardActionHandler.cs
@@ -2,8 +2,8 @@
 
 using Microsoft.Office.Interop.PowerPoint;
 
-using PowerPointLabs.ActionFramework.Common.Extension;
 using PowerPointLabs.ActionFramework.Common.Attribute;
+using PowerPointLabs.ActionFramework.Common.Extension;
 using PowerPointLabs.ActionFramework.Common.Log;
 using PowerPointLabs.Models;
 using PowerPointLabs.PasteLab;

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/PasteLab/ReplaceWithClipboard/ReplaceWithClipboardActionHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/PasteLab/ReplaceWithClipboard/ReplaceWithClipboardActionHandler.cs
@@ -2,6 +2,7 @@
 
 using Microsoft.Office.Interop.PowerPoint;
 
+using PowerPointLabs.ActionFramework.Common.Extension;
 using PowerPointLabs.ActionFramework.Common.Attribute;
 using PowerPointLabs.ActionFramework.Common.Log;
 using PowerPointLabs.Models;
@@ -22,6 +23,8 @@ namespace PowerPointLabs.ActionFramework.PasteLab
                 MessageBox.Show(TextCollection.PasteLabText.ReplaceWithClipboardActionHandlerReminderText, TextCollection.CommonText.ErrorTitle);
                 return null;
             }
+
+            this.StartNewUndoEntry();
 
             ShapeRange pastingShapes = ClipboardUtil.PasteShapesFromClipboard(presentation, slide);
             if (pastingShapes == null)

--- a/PowerPointLabs/PowerPointLabs/Models/PowerPointSlide.cs
+++ b/PowerPointLabs/PowerPointLabs/Models/PowerPointSlide.cs
@@ -692,7 +692,7 @@ namespace PowerPointLabs.Models
             {
                 if (effect.Shape.Equals(source))
                 {
-                    InsertAnimationAtIndex(destination, effect.Index, effect.EffectType, effect.Timing.TriggerType);
+                    InsertAnimationAtIndex(destination, effect.Index, effect.EffectType, effect.Timing.TriggerType, IsExitEffect(effect));
                 }
             }
         }
@@ -1295,11 +1295,17 @@ namespace PowerPointLabs.Models
         }
 
         private Effect InsertAnimationAtIndex(Shape shape, int index, MsoAnimEffect animationEffect,
-            MsoAnimTriggerType triggerType)
+            MsoAnimTriggerType triggerType, bool isExitEffect = false)
         {
             Sequence animationSequence = _slide.TimeLine.MainSequence;
             Effect effect = animationSequence.AddEffect(shape, animationEffect, MsoAnimateByLevel.msoAnimateLevelNone,
                 triggerType);
+
+            if (isExitEffect)
+            {
+                effect.Exit = MsoTriState.msoTrue;
+            }
+
             effect.MoveTo(index);
             return effect;
         }
@@ -1380,6 +1386,11 @@ namespace PowerPointLabs.Models
         private bool IsEntryEffect(Effect effect)
         {
             return effect.Exit == MsoTriState.msoFalse && entryEffects.Contains(effect.EffectType);
+        }
+
+        private bool IsExitEffect(Effect effect)
+        {
+            return effect.Exit == MsoTriState.msoTrue;
         }
     }
 }

--- a/PowerPointLabs/PowerPointLabs/Models/PowerPointSlide.cs
+++ b/PowerPointLabs/PowerPointLabs/Models/PowerPointSlide.cs
@@ -685,20 +685,14 @@ namespace PowerPointLabs.Models
 
         public void TransferAnimation(Shape source, Shape destination)
         {
-            Sequence sequence = _slide.TimeLine.MainSequence;
-            List<Effect> enumerableSequence = sequence.Cast<Effect>().ToList();
+            List<Effect> effectList = sequence.Cast<Effect>().ToList();
 
-            Effect entryDetails = enumerableSequence.FirstOrDefault(effect => effect.Shape.Equals(source));
-            if (entryDetails != null)
+            foreach (Effect effect in effectList)
             {
-                InsertAnimationAtIndex(destination, entryDetails.Index, entryDetails.EffectType, entryDetails.Timing.TriggerType);
-            }
-
-            Effect exitDetails = enumerableSequence.LastOrDefault(effect => effect.Shape.Equals(source));
-            if (exitDetails != null && !exitDetails.Equals(entryDetails))
-            {
-                InsertAnimationAtIndex(destination, exitDetails.Index, exitDetails.EffectType,
-                    exitDetails.Timing.TriggerType);
+                if (effect.Shape.Equals(source))
+                {
+                    InsertAnimationAtIndex(destination, effect.Index, effect.EffectType, effect.Timing.TriggerType);
+                }
             }
         }
 

--- a/PowerPointLabs/PowerPointLabs/Models/PowerPointSlide.cs
+++ b/PowerPointLabs/PowerPointLabs/Models/PowerPointSlide.cs
@@ -685,6 +685,7 @@ namespace PowerPointLabs.Models
 
         public void TransferAnimation(Shape source, Shape destination)
         {
+            Sequence sequence = _slide.TimeLine.MainSequence;
             List<Effect> effectList = sequence.Cast<Effect>().ToList();
 
             foreach (Effect effect in effectList)

--- a/PowerPointLabs/PowerPointLabs/PasteLab/ReplaceWithClipboard.cs
+++ b/PowerPointLabs/PowerPointLabs/PasteLab/ReplaceWithClipboard.cs
@@ -39,6 +39,8 @@ namespace PowerPointLabs.PasteLab
 
                 slide.DeleteShapeAnimations(pastingShape);
                 slide.TransferAnimation(selectedShape, pastingShape);
+                // Must remove animations from source shape or else undo will fail
+                slide.RemoveAnimationsForShape(selectedShape);
 
                 if (pastingShape.IsPicture())
                 {
@@ -48,8 +50,6 @@ namespace PowerPointLabs.PasteLab
                 {
                     ShapeUtil.ApplyAllPossibleFormats(selectedShape, pastingShape, formatsToIgnore);
                 }
-                // Must remove animations from source shape or else undo will fail
-                slide.RemoveAnimationsForShape(selectedShape);
 
                 selectedShape.SafeDelete();
 

--- a/PowerPointLabs/PowerPointLabs/PasteLab/ReplaceWithClipboard.cs
+++ b/PowerPointLabs/PowerPointLabs/PasteLab/ReplaceWithClipboard.cs
@@ -33,6 +33,8 @@ namespace PowerPointLabs.PasteLab
                 slide.DeleteShapeAnimations(pastingShape);
                 slide.TransferAnimation(selectedShape, pastingShape);
                 ShapeUtil.ApplyAllPossibleFormats(selectedShape, pastingShape, formatsToIgnore);
+                // Must remove animations from source shape or else undo will fail
+                slide.RemoveAnimationsForShape(selectedShape);
                 selectedShape.SafeDelete();
 
                 return slide.ToShapeRange(pastingShape);


### PR DESCRIPTION
Fixes #2017 

Solution Outline:
- Modified `PowerPointSlide#TransferAnimation` to copy all animations instead just first and last
- Add undo entry for `ReplaceWithClipboardActionHandler` and remove animations from source shape (shape being replaced) before deleting it.

Steps to reproduce issue on dev-release:
   - Create any shape, apply > 2 animations
   - Copy any other shape
   - Use ReplaceWithClipboard on first shape. Successful, however only first and last added animation remain
  - Ctrl-Z to undo. Successful, however duplicate animations have been added to shape 1. Some animations are also added to "Unnamed" shape.
   - Use ReplaceWithClipboard on first shape again. Exception thrown.