### PR TITLE
#1681 Optimize sync selection pane ui

### DIFF
--- a/PowerPointLabs/PowerPointLabs/SyncLab/SyncFormatConstants.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/SyncFormatConstants.cs
@@ -12,7 +12,7 @@ namespace PowerPointLabs.SyncLab.ObjectFormats
     public class SyncFormatConstants
     {
 
-        public static readonly Size DisplayImageSize = new Size(30, 30);
+        public static readonly Size DisplayImageSize = new Size(50, 50);
         
         // values for bevel display
         public static readonly float DisplayImageDepth = 15;
@@ -24,7 +24,7 @@ namespace PowerPointLabs.SyncLab.ObjectFormats
         public static readonly string DisplaySizeUnit = "pt";
         public static readonly string DisplayFontString = "Text";
         public static readonly string DisplayDegreeSymbol = "°";
-        public static readonly int DisplayImageFontSize = 12;
+        public static readonly int DisplayImageFontSize = 24;
         public static readonly Font DisplayImageFont = new Font("Arial", DisplayImageFontSize);
 
         public static readonly int ColorBlack = 0;

--- a/PowerPointLabs/PowerPointLabs/SyncLab/Views/SyncFormatListItem.xaml
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/Views/SyncFormatListItem.xaml
@@ -8,7 +8,7 @@
              d:DesignHeight="50" d:DesignWidth="300">
     <Grid x:Name="grid">
         <CheckBox x:Name="checkBox" HorizontalAlignment="Left" Margin="5,5,0,5" VerticalAlignment="Center"/>
-        <Image x:Name="imageBox" Margin="30,5,0,5" OpacityMask="{DynamicResource {x:Static SystemColors.ControlBrushKey}}" HorizontalAlignment="Left" Width="25" Height="25"/>
+        <Image x:Name="imageBox" Margin="30,2,0,2" OpacityMask="{DynamicResource {x:Static SystemColors.ControlBrushKey}}" HorizontalAlignment="Left" Width="30" Height="30"/>
         <Label x:Name="label" Margin="65,2,10,2" HorizontalContentAlignment="Left" VerticalContentAlignment="Center"/>
 
     </Grid>

--- a/PowerPointLabs/PowerPointLabs/SyncLab/Views/SyncFormatListItem.xaml
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/Views/SyncFormatListItem.xaml
@@ -7,9 +7,9 @@
              mc:Ignorable="d" 
              d:DesignHeight="50" d:DesignWidth="300">
     <Grid x:Name="grid">
-        <CheckBox x:Name="checkBox" HorizontalAlignment="Left" Margin="5,0,0,0" VerticalAlignment="Center"/>
+        <CheckBox x:Name="checkBox" HorizontalAlignment="Left" Margin="5,5,0,5" VerticalAlignment="Center"/>
         <Image x:Name="imageBox" Margin="30,5,0,5" OpacityMask="{DynamicResource {x:Static SystemColors.ControlBrushKey}}" HorizontalAlignment="Left" Width="25" Height="25"/>
-        <Label x:Name="label" Margin="65,0,10,0" HorizontalContentAlignment="Left" VerticalContentAlignment="Center"/>
+        <Label x:Name="label" Margin="65,2,10,2" HorizontalContentAlignment="Left" VerticalContentAlignment="Center"/>
 
     </Grid>
 </UserControl>

--- a/PowerPointLabs/PowerPointLabs/SyncLab/Views/SyncFormatListItem.xaml
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/Views/SyncFormatListItem.xaml
@@ -8,7 +8,7 @@
              d:DesignHeight="50" d:DesignWidth="300">
     <Grid x:Name="grid">
         <CheckBox x:Name="checkBox" HorizontalAlignment="Left" Margin="5,0,0,0" VerticalAlignment="Center"/>
-        <Image x:Name="imageBox" Margin="30,0,0,0" OpacityMask="{DynamicResource {x:Static SystemColors.ControlBrushKey}}" HorizontalAlignment="Left" Width="20" Height="20"/>
+        <Image x:Name="imageBox" Margin="30,5,0,5" OpacityMask="{DynamicResource {x:Static SystemColors.ControlBrushKey}}" HorizontalAlignment="Left" Width="25" Height="25"/>
         <Label x:Name="label" Margin="65,0,10,0" HorizontalContentAlignment="Left" VerticalContentAlignment="Center"/>
 
     </Grid>

--- a/PowerPointLabs/PowerPointLabs/SyncLab/Views/SyncFormatListItem.xaml
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/Views/SyncFormatListItem.xaml
@@ -7,9 +7,9 @@
              mc:Ignorable="d" 
              d:DesignHeight="50" d:DesignWidth="300">
     <Grid x:Name="grid">
-        <CheckBox x:Name="checkBox" HorizontalAlignment="Left" Margin="5,17,0,18" VerticalAlignment="Center"/>
-        <Image x:Name="imageBox" Margin="30,10,0,10" OpacityMask="{DynamicResource {x:Static SystemColors.ControlBrushKey}}" HorizontalAlignment="Left" Width="30" Height="30"/>
-        <Label x:Name="label" Margin="65,7,10,7" HorizontalContentAlignment="Left" VerticalContentAlignment="Center"/>
+        <CheckBox x:Name="checkBox" HorizontalAlignment="Left" Margin="5,0,0,0" VerticalAlignment="Center"/>
+        <Image x:Name="imageBox" Margin="30,0,0,0" OpacityMask="{DynamicResource {x:Static SystemColors.ControlBrushKey}}" HorizontalAlignment="Left" Width="20" Height="20"/>
+        <Label x:Name="label" Margin="65,0,10,0" HorizontalContentAlignment="Left" VerticalContentAlignment="Center"/>
 
     </Grid>
 </UserControl>


### PR DESCRIPTION
Fixes #1681 partially.

**Outline of Solution**
Allows more item to be shown to the user by reducing the vertical margins of each item in the list.
Also made text images more sharp by upscaling the image.

Side by side comparison below. Left side is after this PR, right side is the original.

![image](https://user-images.githubusercontent.com/32454748/78226301-17523480-74fe-11ea-9857-bcfffffb38e9.png)

However, there might be better ways of allowing more items to be viewed at once, and other improvements as suggested in #1681. 
