### PR TITLE
#2014 Empty clipboard exception

### DIFF
--- a/PowerPointLabs/PowerPointLabs/Models/PowerPointShapeGalleryPresentation.cs
+++ b/PowerPointLabs/PowerPointLabs/Models/PowerPointShapeGalleryPresentation.cs
@@ -413,11 +413,7 @@ namespace PowerPointLabs.Models
                 if (Slides.All(category => category.Name.ToLower() != categoryName.ToLower()))
                 {
                     categoryLost = true;
-                    PPLClipboard.Instance.LockAndRelease(() =>
-                    {
-                        // not sure why fromClipboard is true here
-                        AddCategory(categoryName, false, true);
-                    });
+                    AddCategory(categoryName, false, false);
                 }
             }
 


### PR DESCRIPTION
Fixes #2014 partially. This fix only affects ShapeLab for now.

**Outline of Solution**
Resolve issue by removing unneeded usage of pasting from clipboard.

There might be more places that needs this fix as mentioned in #2014. 