### PR TITLE
#1994 Fix CropLab CropToShape on PowerPoint 2010

### DIFF
--- a/PowerPointLabs/PowerPointLabs/ActionFramework/EffectsLab/BlurMenuContent/EffectsLabBlurrinessActionHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/EffectsLab/BlurMenuContent/EffectsLabBlurrinessActionHandler.cs
@@ -6,6 +6,7 @@ using PowerPointLabs.ActionFramework.Common.Interface;
 using PowerPointLabs.ActionFramework.Common.Log;
 using PowerPointLabs.EffectsLab;
 using PowerPointLabs.TextCollection;
+using PowerPointLabs.Utils;
 
 namespace PowerPointLabs.ActionFramework.EffectsLab
 {
@@ -15,6 +16,7 @@ namespace PowerPointLabs.ActionFramework.EffectsLab
         protected override void ExecuteAction(string ribbonId)
         {
             this.StartNewUndoEntry();
+            Models.PowerPointPresentation pres = this.GetCurrentPresentation();
 
             bool isButton = false;
             bool isCustom = ribbonId.Contains(EffectsLabText.BlurrinessCustom);
@@ -43,7 +45,7 @@ namespace PowerPointLabs.ActionFramework.EffectsLab
             {
                 int startIndex = keywordIndex + CommonText.DynamicMenuOptionId.Length;
                 int percentage = isCustom ? GetCustomPercentage(feature) : int.Parse(ribbonId.Substring(startIndex, ribbonId.Length - startIndex));
-                ExecuteBlurAction(feature, selection, slide, percentage);
+                ExecuteBlurAction(feature, selection, pres, slide, percentage);
             }
         }
 
@@ -63,23 +65,27 @@ namespace PowerPointLabs.ActionFramework.EffectsLab
             }
         }
 
-        private void ExecuteBlurAction(string feature, Selection selection, Models.PowerPointSlide slide, int percentage)
+        private void ExecuteBlurAction(string feature, Selection selection, Models.PowerPointPresentation pres, Models.PowerPointSlide slide, int percentage)
         {
-            switch (feature)
+            ClipboardUtil.RestoreClipboardAfterAction(() =>
             {
-                case EffectsLabText.BlurrinessFeatureSelected:
-                    EffectsLabBlur.ExecuteBlurSelected(slide, selection, percentage);
-                    break;
-                case EffectsLabText.BlurrinessFeatureRemainder:
-                    EffectsLabBlur.ExecuteBlurRemainder(slide, selection, percentage);
-                    break;
-                case EffectsLabText.BlurrinessFeatureBackground:
-                    EffectsLabBlur.ExecuteBlurBackground(slide, selection, percentage);
-                    break;
-                default:
-                    Logger.Log(feature + " does not exist!", Common.Logger.LogType.Error);
-                    break;
-            }
+                switch (feature)
+                {
+                    case EffectsLabText.BlurrinessFeatureSelected:
+                        EffectsLabBlur.ExecuteBlurSelected(slide, selection, percentage);
+                        break;
+                    case EffectsLabText.BlurrinessFeatureRemainder:
+                        EffectsLabBlur.ExecuteBlurRemainder(slide, selection, percentage);
+                        break;
+                    case EffectsLabText.BlurrinessFeatureBackground:
+                        EffectsLabBlur.ExecuteBlurBackground(slide, selection, percentage);
+                        break;
+                    default:
+                        Logger.Log(feature + " does not exist!", Common.Logger.LogType.Error);
+                        break;
+                }
+                return ClipboardUtil.ClipboardRestoreSuccess;
+            }, pres, slide);
         }
     }
 }

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/EffectsLab/RecolorMenuContent/EffectsLabRecolorActionHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/EffectsLab/RecolorMenuContent/EffectsLabRecolorActionHandler.cs
@@ -7,6 +7,7 @@ using PowerPointLabs.ActionFramework.Common.Log;
 using PowerPointLabs.EffectsLab;
 using PowerPointLabs.Models;
 using PowerPointLabs.TextCollection;
+using PowerPointLabs.Utils;
 
 namespace PowerPointLabs.ActionFramework.EffectsLab
 {
@@ -16,60 +17,64 @@ namespace PowerPointLabs.ActionFramework.EffectsLab
         protected override void ExecuteAction(string ribbonId)
         {
             this.StartNewUndoEntry();
-
+            PowerPointPresentation pres = this.GetCurrentPresentation();
             PowerPointSlide curSlide = this.GetCurrentSlide();
             Selection selection = this.GetCurrentSelection();
 
-            if (ribbonId.Contains(EffectsLabText.RecolorRemainderMenuId))
+            ClipboardUtil.RestoreClipboardAfterAction(() =>
             {
-                if (ribbonId.Contains(EffectsLabText.GrayScaleTag))
+                if (ribbonId.Contains(EffectsLabText.RecolorRemainderMenuId))
                 {
-                    EffectsLabRecolor.GrayScaleRemainderEffect(curSlide, selection);
+                    if (ribbonId.Contains(EffectsLabText.GrayScaleTag))
+                    {
+                        EffectsLabRecolor.GrayScaleRemainderEffect(curSlide, selection);
+                    }
+                    else if (ribbonId.Contains(EffectsLabText.BlackWhiteTag))
+                    {
+                        EffectsLabRecolor.BlackWhiteRemainderEffect(curSlide, selection);
+                    }
+                    else if (ribbonId.Contains(EffectsLabText.GothamTag))
+                    {
+                        EffectsLabRecolor.GothamRemainderEffect(curSlide, selection);
+                    }
+                    else if (ribbonId.Contains(EffectsLabText.SepiaTag))
+                    {
+                        EffectsLabRecolor.SepiaRemainderEffect(curSlide, selection);
+                    }
+                    else
+                    {
+                        Logger.Log(ribbonId + " does not exist!", Common.Logger.LogType.Error);
+                    }
                 }
-                else if (ribbonId.Contains(EffectsLabText.BlackWhiteTag))
+                else if (ribbonId.Contains(EffectsLabText.RecolorBackgroundMenuId))
                 {
-                    EffectsLabRecolor.BlackWhiteRemainderEffect(curSlide, selection);
-                }
-                else if (ribbonId.Contains(EffectsLabText.GothamTag))
-                {
-                    EffectsLabRecolor.GothamRemainderEffect(curSlide, selection);
-                }
-                else if (ribbonId.Contains(EffectsLabText.SepiaTag))
-                {
-                    EffectsLabRecolor.SepiaRemainderEffect(curSlide, selection);
+                    if (ribbonId.Contains(EffectsLabText.GrayScaleTag))
+                    {
+                        EffectsLabRecolor.GrayScaleBackgroundEffect(curSlide, selection);
+                    }
+                    else if (ribbonId.Contains(EffectsLabText.BlackWhiteTag))
+                    {
+                        EffectsLabRecolor.BlackWhiteBackgroundEffect(curSlide, selection);
+                    }
+                    else if (ribbonId.Contains(EffectsLabText.GothamTag))
+                    {
+                        EffectsLabRecolor.GothamBackgroundEffect(curSlide, selection);
+                    }
+                    else if (ribbonId.Contains(EffectsLabText.SepiaTag))
+                    {
+                        EffectsLabRecolor.SepiaBackgroundEffect(curSlide, selection);
+                    }
+                    else
+                    {
+                        Logger.Log(ribbonId + " does not exist!", Common.Logger.LogType.Error);
+                    }
                 }
                 else
                 {
                     Logger.Log(ribbonId + " does not exist!", Common.Logger.LogType.Error);
                 }
-            }
-            else if (ribbonId.Contains(EffectsLabText.RecolorBackgroundMenuId))
-            {
-                if (ribbonId.Contains(EffectsLabText.GrayScaleTag))
-                {
-                    EffectsLabRecolor.GrayScaleBackgroundEffect(curSlide, selection);
-                }
-                else if (ribbonId.Contains(EffectsLabText.BlackWhiteTag))
-                {
-                    EffectsLabRecolor.BlackWhiteBackgroundEffect(curSlide, selection);
-                }
-                else if (ribbonId.Contains(EffectsLabText.GothamTag))
-                {
-                    EffectsLabRecolor.GothamBackgroundEffect(curSlide, selection);
-                }
-                else if (ribbonId.Contains(EffectsLabText.SepiaTag))
-                {
-                    EffectsLabRecolor.SepiaBackgroundEffect(curSlide, selection);
-                }
-                else
-                {
-                    Logger.Log(ribbonId + " does not exist!", Common.Logger.LogType.Error);
-                }
-            }
-            else
-            {
-                Logger.Log(ribbonId + " does not exist!", Common.Logger.LogType.Error);
-            }
+                return ClipboardUtil.ClipboardRestoreSuccess;
+            }, pres, curSlide);
         }
     }
 }

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/EffectsLab/Spotlight/AddSpotlight/AddSpotlightActionHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/EffectsLab/Spotlight/AddSpotlight/AddSpotlightActionHandler.cs
@@ -2,7 +2,9 @@
 using PowerPointLabs.ActionFramework.Common.Extension;
 using PowerPointLabs.ActionFramework.Common.Interface;
 using PowerPointLabs.EffectsLab;
+using PowerPointLabs.Models;
 using PowerPointLabs.TextCollection;
+using PowerPointLabs.Utils;
 
 namespace PowerPointLabs.ActionFramework.EffectsLab
 {
@@ -18,8 +20,14 @@ namespace PowerPointLabs.ActionFramework.EffectsLab
             }
 
             this.StartNewUndoEntry();
+            PowerPointPresentation pres = this.GetCurrentPresentation();
+            PowerPointSlide slide = this.GetCurrentSlide();
 
-            Spotlight.AddSpotlightEffect();
+            ClipboardUtil.RestoreClipboardAfterAction(() =>
+            {
+                Spotlight.AddSpotlightEffect();
+                return ClipboardUtil.ClipboardRestoreSuccess;
+            }, pres, slide);
         }
     }
 }

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/PasteLab/PasteIntoGroup/PasteIntoGroupActionHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/PasteLab/PasteIntoGroup/PasteIntoGroupActionHandler.cs
@@ -3,6 +3,7 @@
 using Microsoft.Office.Interop.PowerPoint;
 
 using PowerPointLabs.ActionFramework.Common.Attribute;
+using PowerPointLabs.ActionFramework.Common.Extension;
 using PowerPointLabs.ActionFramework.Common.Log;
 using PowerPointLabs.Models;
 using PowerPointLabs.PasteLab;
@@ -28,6 +29,8 @@ namespace PowerPointLabs.ActionFramework.PasteLab
                 Logger.Log("PasteIntoGroup failed. Selection is only a single shape.");
                 return null;
             }
+
+            this.StartNewUndoEntry();
 
             ShapeRange pastingShapes = ClipboardUtil.PasteShapesFromClipboard(presentation, slide);
             if (pastingShapes == null)

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/PasteLab/ReplaceWithClipboard/ReplaceWithClipboardActionHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/PasteLab/ReplaceWithClipboard/ReplaceWithClipboardActionHandler.cs
@@ -3,6 +3,7 @@
 using Microsoft.Office.Interop.PowerPoint;
 
 using PowerPointLabs.ActionFramework.Common.Attribute;
+using PowerPointLabs.ActionFramework.Common.Extension;
 using PowerPointLabs.ActionFramework.Common.Log;
 using PowerPointLabs.Models;
 using PowerPointLabs.PasteLab;
@@ -22,6 +23,8 @@ namespace PowerPointLabs.ActionFramework.PasteLab
                 MessageBox.Show(TextCollection.PasteLabText.ReplaceWithClipboardActionHandlerReminderText, TextCollection.CommonText.ErrorTitle);
                 return null;
             }
+
+            this.StartNewUndoEntry();
 
             ShapeRange pastingShapes = ClipboardUtil.PasteShapesFromClipboard(presentation, slide);
             if (pastingShapes == null)

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/ZoomLab/DrillDown/DrillDownActionHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/ZoomLab/DrillDown/DrillDownActionHandler.cs
@@ -1,7 +1,9 @@
 ﻿using PowerPointLabs.ActionFramework.Common.Attribute;
 using PowerPointLabs.ActionFramework.Common.Extension;
 using PowerPointLabs.ActionFramework.Common.Interface;
+using PowerPointLabs.Models;
 using PowerPointLabs.TextCollection;
+using PowerPointLabs.Utils;
 using PowerPointLabs.ZoomLab;
 
 namespace PowerPointLabs.ActionFramework.ZoomLab
@@ -12,8 +14,10 @@ namespace PowerPointLabs.ActionFramework.ZoomLab
         protected override void ExecuteAction(string ribbonId)
         {
             this.StartNewUndoEntry();
+            PowerPointPresentation pres = this.GetCurrentPresentation();
+            PowerPointSlide slide = this.GetCurrentSlide();
 
-            AutoZoom.AddDrillDownAnimation();
+            AutoZoom.AddDrillDownAnimation(pres, slide);
         }
     }
 }

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/ZoomLab/StepBack/StepBackActionHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/ZoomLab/StepBack/StepBackActionHandler.cs
@@ -1,7 +1,9 @@
 ﻿using PowerPointLabs.ActionFramework.Common.Attribute;
 using PowerPointLabs.ActionFramework.Common.Extension;
 using PowerPointLabs.ActionFramework.Common.Interface;
+using PowerPointLabs.Models;
 using PowerPointLabs.TextCollection;
+using PowerPointLabs.Utils;
 using PowerPointLabs.ZoomLab;
 
 namespace PowerPointLabs.ActionFramework.ZoomLab
@@ -12,8 +14,10 @@ namespace PowerPointLabs.ActionFramework.ZoomLab
         protected override void ExecuteAction(string ribbonId)
         {
             this.StartNewUndoEntry();
+            PowerPointPresentation pres = this.GetCurrentPresentation();
+            PowerPointSlide slide = this.GetCurrentSlide();
 
-            AutoZoom.AddStepBackAnimation();
+            AutoZoom.AddStepBackAnimation(pres, slide);
         }
     }
 }

--- a/PowerPointLabs/PowerPointLabs/ActionFramework/ZoomLab/ZoomToArea/ZoomToAreaActionHandler.cs
+++ b/PowerPointLabs/PowerPointLabs/ActionFramework/ZoomLab/ZoomToArea/ZoomToAreaActionHandler.cs
@@ -1,7 +1,9 @@
 ﻿using PowerPointLabs.ActionFramework.Common.Attribute;
 using PowerPointLabs.ActionFramework.Common.Extension;
 using PowerPointLabs.ActionFramework.Common.Interface;
+using PowerPointLabs.Models;
 using PowerPointLabs.TextCollection;
+using PowerPointLabs.Utils;
 using PowerPointLabs.ZoomLab;
 
 namespace PowerPointLabs.ActionFramework.ZoomLab
@@ -12,8 +14,14 @@ namespace PowerPointLabs.ActionFramework.ZoomLab
         protected override void ExecuteAction(string ribbonId)
         {
             this.StartNewUndoEntry();
+            PowerPointPresentation pres = this.GetCurrentPresentation();
+            PowerPointSlide slide = this.GetCurrentSlide();
 
-            ZoomToArea.AddZoomToArea();
+            ClipboardUtil.RestoreClipboardAfterAction(() =>
+            {
+                ZoomToArea.AddZoomToArea();
+                return ClipboardUtil.ClipboardRestoreSuccess;
+            }, pres, slide);
         }
     }
 }

--- a/PowerPointLabs/PowerPointLabs/AgendaLab/AgendaLabMain.cs
+++ b/PowerPointLabs/PowerPointLabs/AgendaLab/AgendaLabMain.cs
@@ -132,20 +132,27 @@ namespace PowerPointLabs.AgendaLab
                                                     AgendaLabText.GeneratingDialogContent);
                 currentWindow.ViewType = PpViewType.ppViewNormal;
 
-                switch (type)
-                {
-                    case Type.Beam:
-                        CreateBeamAgenda(slideTracker);
-                        break;
-                    case Type.Bullet:
-                        CreateBulletAgenda(slideTracker);
-                        break;
-                    case Type.Visual:
-                        CreateVisualAgenda(slideTracker);
-                        break;
-                }
+                PowerPointPresentation pres = PowerPointPresentation.Current;
+                PowerPointSlide slide = PowerPointCurrentPresentationInfo.CurrentSlide;
 
-                PowerPointPresentation.Current.AddAckSlide();
+                ClipboardUtil.RestoreClipboardAfterAction(() =>
+                {
+                    switch (type)
+                    {
+                        case Type.Beam:
+                            CreateBeamAgenda(slideTracker);
+                            break;
+                        case Type.Bullet:
+                            CreateBulletAgenda(slideTracker);
+                            break;
+                        case Type.Visual:
+                            CreateVisualAgenda(slideTracker);
+                            break;
+                    }
+                    return ClipboardUtil.ClipboardRestoreSuccess;
+                }, pres, slide);
+
+                pres.AddAckSlide();
                 SelectOriginalSlide(slideTracker.UserCurrentSlide, PowerPointPresentation.Current.FirstSlide);
             }
             finally
@@ -233,20 +240,27 @@ namespace PowerPointLabs.AgendaLab
                 
                 SlideUtil.CopyToDesign("Agenda Template", refSlide);
 
-                switch (type)
-                {
-                    case Type.Beam:
-                        SyncBeamAgenda(slideTracker, refSlide);
-                        break;
-                    case Type.Bullet:
-                        SyncBulletAgenda(slideTracker, refSlide);
-                        break;
-                    case Type.Visual:
-                        SyncVisualAgenda(slideTracker, refSlide);
-                        break;
-                }
+                PowerPointPresentation pres = PowerPointPresentation.Current;
+                PowerPointSlide slide = PowerPointCurrentPresentationInfo.CurrentSlide;
 
-                PowerPointPresentation.Current.AddAckSlide();
+                ClipboardUtil.RestoreClipboardAfterAction(() =>
+                {
+                    switch (type)
+                    {
+                        case Type.Beam:
+                            SyncBeamAgenda(slideTracker, refSlide);
+                            break;
+                        case Type.Bullet:
+                            SyncBulletAgenda(slideTracker, refSlide);
+                            break;
+                        case Type.Visual:
+                            SyncVisualAgenda(slideTracker, refSlide);
+                            break;
+                    }
+                    return ClipboardUtil.ClipboardRestoreSuccess;
+                }, pres, slide);
+
+                pres.AddAckSlide();
                 SelectOriginalSlide(slideTracker.UserCurrentSlide, PowerPointPresentation.Current.FirstSlide);
             }
             finally

--- a/PowerPointLabs/PowerPointLabs/ColorTheme/BaseStylesDictionary.cs
+++ b/PowerPointLabs/PowerPointLabs/ColorTheme/BaseStylesDictionary.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+
+namespace PowerPointLabs.ColorThemes
+{
+    /// <summary>
+    /// The BaseStylesDictionary class is a ResourceDictionary that contains all of the base
+    /// styles of Controls.
+    /// </summary>
+    /// <remarks>
+    /// The main purpose of this class is to be able to design styles that are based off of
+    /// the base styles defined in the Resources/Themes folder. This allows them to maintain
+    /// the colour changing properties upon the ColorTheme being changed.
+    /// 
+    /// That said, the main reason of creating this helper class is so that the path to the
+    /// Resources/Themes folder doesn't have to be written out every time.
+    /// 
+    /// <code>
+    /// <UserControl 
+    ///     x:Class="..."
+    ///     xmlns="..."
+    ///     xmlns:theme="clr-namespace:PowerPointLabs.ColorThemes">
+    ///     <UserControl.Resources>
+    ///         <ResourceDictionary>
+    ///             <ResourceDictionary.MergedDictionaries>
+    ///                 <theme:TemplateStyleDictionary/>
+    ///             </ResourceDictionary.MergedDictionaries>    
+    ///         </ResourceDictionary>
+    ///     </UserControl.Resources>
+    ///     <Button>
+    ///         <Button.Style>
+    ///             <Style TargetType="{x:Type Button}" BasedOn="{StaticResource BaseButtonStyle}">
+    ///                 <Style.Triggers>
+    ///                     <Trigger Property="IsEnabled" Value="False">
+    ///                         <Setter Property="Opacity" Value="0.3"/>
+    ///                     </Trigger>
+    ///                 </Style.Triggers>
+    ///             </Style>
+    ///         </Button.Style>
+    ///     </Button>
+    /// </UserControl>
+    /// </code>
+    /// </remarks>
+    public class BaseStylesDictionary : ResourceDictionary
+    {
+        public static readonly string PathToThemesFolder = "pack://application:,,,/PowerPointLabs;component/Resources/Themes/";
+
+        public BaseStylesDictionary()
+        {
+            Source = new Uri(PathToThemesFolder + "TemplateStyles.xaml", UriKind.RelativeOrAbsolute);
+        }
+    }
+}

--- a/PowerPointLabs/PowerPointLabs/ColorTheme/ColorTheme.cs
+++ b/PowerPointLabs/PowerPointLabs/ColorTheme/ColorTheme.cs
@@ -11,11 +11,6 @@ namespace PowerPointLabs.ColorThemes
         public const int BLACK = 4;
         public const int WHITE = 5;
 
-        public Color title;
-        public Color background;
-        public Color foreground;
-        public Color boxBackground;
-        public Color headingBackground;
-        public Color headingForeground;
+        public int ThemeId;
     }
 }

--- a/PowerPointLabs/PowerPointLabs/ColorTheme/DesignTheme.cs
+++ b/PowerPointLabs/PowerPointLabs/ColorTheme/DesignTheme.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+
+namespace PowerPointLabs.ColorThemes
+{
+    /// <summary>
+    /// The DesignTheme class is a ResourceDictionary for use in the Designer in Visual Studio.
+    /// </summary>
+    /// <remarks>
+    /// This class will apply the specified theme in the Designer preview, allowing the programmer
+    /// to design Windows or User Control .xaml files while being able to freely change the themes.
+    /// This ResourceDictionary will have no effect during runtime.
+    /// 
+    /// To use this class in a Control, simply place this class in the Resources' Merged Dictionary.
+    /// For example, to use it in a UserControl,
+    /// 
+    /// <code>
+    /// <UserControl 
+    ///     x:Class="..."
+    ///     xmlns="..."
+    ///     xmlns:theme="clr-namespace:PowerPointLabs.ColorThemes">
+    ///     <UserControl.Resources>
+    ///         <ResourceDictionary>
+    ///             <ResourceDictionary.MergedDictionaries>
+    ///                 <theme:DesignTheme Theme="Black"/>
+    ///             </ResourceDictionary.MergedDictionaries>    
+    ///         </ResourceDictionary>
+    ///     </UserControl.Resources>
+    /// </UserControl>
+    /// </code>
+    /// </remarks>
+    public class DesignTheme : ResourceDictionary
+    {
+        public static readonly string PathToThemesFolder = "pack://application:,,,/PowerPointLabs;component/Resources/Themes/";
+
+        private string theme;
+
+        /// <summary>
+        /// The theme to apply. Valid values are "Colorful", "Black", "White" and "Dark Gray".
+        /// </summary>
+        public string Theme
+        {
+            get => theme;
+            set
+            {
+                theme = value;
+
+                // Set the Source of the Resource Dictionary only when in Designer mode(and not runtime).
+                if ((bool)DesignerProperties.IsInDesignModeProperty.GetMetadata(typeof(DependencyObject)).DefaultValue)
+                {
+                    var themeUri = PathToThemesFolder + theme + "Theme.xaml";
+                    Source = new Uri(themeUri);
+                }
+            }
+        }
+    }
+}

--- a/PowerPointLabs/PowerPointLabs/ColorTheme/INotifyOnThemeChanged.cs
+++ b/PowerPointLabs/PowerPointLabs/ColorTheme/INotifyOnThemeChanged.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace PowerPointLabs.ColorThemes
+{
+    /// <summary>
+    /// The INotifyOnThemeChanged interface is to indicate that the class implementing this interface
+    /// should be notified when the ColorTheme has changed.
+    /// </summary>
+    /// <remarks>
+    /// This interface should only be implemented by classes that are subscribed to the 
+    /// <see cref="ThemeManager.ColorThemeChanged"/> event via the
+    /// <see cref="Extensions.ThemeExtensions.ApplyTheme(System.Windows.FrameworkElement, object, ColorTheme)"/>
+    /// method. The <see cref="OnThemeChanged(ColorTheme)"/> method only gets called via that ApplyTheme method.
+    /// </remarks>
+    public interface INotifyOnThemeChanged
+    {
+        /// <summary>
+        /// Notifies the class that the Color Theme has changed.
+        /// </summary>
+        /// <param name="updatedColorTheme">The updated ColorTheme</param>
+        void OnThemeChanged(ColorTheme updatedColorTheme);
+    }
+}

--- a/PowerPointLabs/PowerPointLabs/ColorTheme/ThemeExtensions.cs
+++ b/PowerPointLabs/PowerPointLabs/ColorTheme/ThemeExtensions.cs
@@ -16,6 +16,8 @@ namespace PowerPointLabs.ColorThemes.Extensions
 {
     public static class ThemeExtensions
     {
+        public static readonly string PathToMahAppsAccents = "pack://application:,,,/MahApps.Metro;component/Styles/Accents/";
+
         /// <summary>
         /// Shows a thematic dialog and waits for the window to close.
         /// </summary>
@@ -43,6 +45,211 @@ namespace PowerPointLabs.ColorThemes.Extensions
         }
 
         /// <summary>
+        /// Applies a theme to the specified FrameworkElement by updating its Resources.
+        /// </summary>
+        /// <param name="element">The WPF FrameworkElement to apply the theme to.</param>
+        /// <param name="sender">The object that triggered the event.</param>
+        /// <param name="theme">The ColorTheme to apply.</param>
+        public static void ApplyTheme(this FrameworkElement element, object sender, ColorTheme theme)
+        {
+            // Three things to update:
+            // 1. The ThemeResourceDictionary at the front of the element's Resources.
+            // 2. MahApps resource dictionaries if the element has them.
+            // 3. Calling the element's own OnThemeChanged method if it implements INotifyOnThemeChanged.
+
+            element.UpdateThemeResourceDictionary(theme);
+            element.UpdateMahAppsTheme(theme);
+
+            if (element is INotifyOnThemeChanged)
+            {
+                element.Dispatcher.Invoke(new Action(() => (element as INotifyOnThemeChanged).OnThemeChanged(theme)));
+            }
+        }
+
+        /// <summary>
+        /// Removes any existing ThemeResourceDictionary in the specified element's Merged Dictionaries and
+        /// prepends a ThemeResourceDictionary based on the specified color theme to the Merged Dictionaries
+        /// </summary>
+        /// <param name="element">The element whose Merged Dictionaries will be updated</param>
+        /// <param name="colorTheme">The current ColorTheme of the Application</param>
+        public static void UpdateThemeResourceDictionary(this FrameworkElement element, ColorTheme colorTheme)
+        {
+            var mergedDictionaries = element.Resources.MergedDictionaries;
+
+            foreach (var resourceDictionary in mergedDictionaries)
+            {
+                if (!(resourceDictionary is ThemeResourceDictionary))
+                {
+                    continue;
+                }
+
+                element.Dispatcher.Invoke(new Action(() => mergedDictionaries.Remove(resourceDictionary)));
+                break;
+            }
+
+            // We are inserting this Theme at the front of the MergedDictionaries because default styles are applied in
+            // the order in which the Resource Dictionaries appear in the MergedDictionaries. If this were appended to
+            // the back of a Window or Pane which uses the MahApps styles, for example, the styles in this theme will
+            // be applied instead of the MahApps' styles, which is (usually) undesirable.
+            var newThemeDictionary = ThemeResourceDictionary.FromColorTheme(colorTheme);
+            element.Dispatcher.Invoke(new Action(() => mergedDictionaries.Insert(0, newThemeDictionary)));
+        }
+
+        /// <summary>
+        /// Updates the MahApps Theme in the specified FrameworkElement based on the specified colorTheme.
+        /// </summary>
+        /// <remarks>
+        /// This method will only set either the BaseDark or the BaseLight theme to the specified element. 
+        /// If the FrameworkElement did not contain any MahApps Resource Dictionaries prior to this method's 
+        /// invocation, the FrameworkElement will be left unchanged.
+        /// </remarks>
+        /// <param name="element">The element whose Merged Dictionaries will be updated (if applicable).</param>
+        /// <param name="colorTheme">The current ColorTheme of the Application</param>
+        public static void UpdateMahAppsTheme(this FrameworkElement element, ColorTheme colorTheme)
+        {
+            // Currently, this method will only set the BaseLight or BaseDark accents based on the ColorTheme.
+            // Any other accents will be left untouched.
+
+            // First, check if this element's Resources contains MahApps Accent Dictionaries. If not, exit the method.
+            var mergedDictionaries = element.Resources.MergedDictionaries;
+            if (mergedDictionaries.All(dictionary => !MahApps.Metro.ThemeManager.IsAccentDictionary(dictionary)))
+            {
+                return;
+            }
+
+            // If the element is a Window, we can use methods that already exists in the MahApps.Metro.ThemeManager class.
+            if (element is Window)
+            {
+                var window = element as Window;
+
+                // Obtain the Accent currently being used.
+                Tuple<MahApps.Metro.AppTheme, MahApps.Metro.Accent> currentStyle;
+                currentStyle = MahApps.Metro.ThemeManager.DetectAppStyle(window);
+                var currentAccent = currentStyle.Item2;
+
+                // Determine the new theme to apply based on the ColorTheme.
+                MahApps.Metro.AppTheme newTheme;
+                switch (colorTheme.ThemeId)
+                {
+                    case ColorTheme.BLACK:
+                    case ColorTheme.DARK_GRAY:
+                        newTheme = MahApps.Metro.ThemeManager.GetAppTheme("BaseDark");
+                        break;
+                    default:
+                        newTheme = MahApps.Metro.ThemeManager.GetAppTheme("BaseLight");
+                        break;
+                }
+
+                // Change the style using the built-in methods.
+                MahApps.Metro.ThemeManager.ChangeAppStyle(window, currentAccent, newTheme);
+                return;
+            }
+
+            // If the element is not a Window, the dictionaries will be changed manually.
+            for (int i = 0; i < mergedDictionaries.Count; ++i)
+            {
+                var resourceDictionary = mergedDictionaries[i];
+                var source = resourceDictionary.Source?.OriginalString;
+                if (string.IsNullOrEmpty(source))
+                {
+                    continue;
+                }
+
+                // Identify the BaseLight or BaseDark accents by checking the ResourceDictionary's Source
+                // and seeing if it starts with the path to the MahApps's Accents folder, followed by "Base".
+                //
+                // Developer note: I realise this isn't the best way to check this. If there is a better method,
+                // do let me know, or go ahead and implement it yourself.
+                if (!source.StartsWith(PathToMahAppsAccents + "Base", true, null))
+                {
+                    continue;
+                }
+
+                string newSource;
+                switch (colorTheme.ThemeId)
+                {
+                    case ColorTheme.BLACK:
+                    case ColorTheme.DARK_GRAY:
+                        newSource = PathToMahAppsAccents + "BaseDark.xaml";
+                        break;
+                    default:
+                        newSource = PathToMahAppsAccents + "BaseLight.xaml";
+                        break;
+                }
+
+                var newMahAppsDictionary = new ResourceDictionary
+                {
+                    Source = new Uri(newSource)
+                };
+                // Replace this ResourceDictionary with a new one with the appropriate Base Accent.
+                element.Dispatcher.Invoke(new Action(() => mergedDictionaries[i] = newMahAppsDictionary));
+                break;
+            }
+        }
+
+        /// <summary>
+        /// Changes the mahApps Accent in the specified framework element.
+        /// </summary>
+        /// <remarks>
+        /// If the specified element did not contain any MahApps Resource Dictionaries prior to this method's invocation,
+        /// the FrameworkElement will be left unchanged.
+        /// </remarks>
+        /// <param name="element">The element whose accent is to updated.</param>
+        /// <param name="accentName">The name of the new MahApps Accent.</param>
+        public static void ChangeMahAppsAccent(this FrameworkElement element, string accentName)
+        {
+            // First, check if this element's Resources contains MahApps Accent Dictionaries. If not, exit the method.
+            var mergedDictionaries = element.Resources.MergedDictionaries;
+            if (mergedDictionaries.All(dictionary => !MahApps.Metro.ThemeManager.IsAccentDictionary(dictionary)))
+            {
+                return;
+            }
+
+            // If the element is a Window, we can use methods that already exists in the MahApps.Metro.ThemeManager class.
+            if (element is Window)
+            {
+                var window = element as Window;
+
+                // Obtain the Theme currently being used.
+                Tuple<MahApps.Metro.AppTheme, MahApps.Metro.Accent> currentStyle;
+                currentStyle = MahApps.Metro.ThemeManager.DetectAppStyle(window);
+                var currentTheme = currentStyle.Item1;
+
+
+                var newAccent = MahApps.Metro.ThemeManager.GetAccent(accentName);
+                
+                // Change the style using the built-in methods.
+                MahApps.Metro.ThemeManager.ChangeAppStyle(window, newAccent, currentTheme);
+                return;
+            }
+
+            // If the element is not a Window, the dicionaries will be changed manually
+            for (int i = 0; i < mergedDictionaries.Count; ++i)
+            {
+                var resourceDictionary = mergedDictionaries[i];
+                var source = resourceDictionary.Source?.OriginalString;
+                if (string.IsNullOrEmpty(source))
+                {
+                    continue;
+                }
+
+                // The MahApps Colors resource dictionary is also considered an AccentDictionary,
+                // which is why the former check is required.
+                if (!source.StartsWith(PathToMahAppsAccents) || !MahApps.Metro.ThemeManager.IsAccentDictionary(resourceDictionary))
+                {
+                    continue;
+                }
+
+                var newSource = PathToMahAppsAccents + accentName + ".xaml";
+                var newAccentDictionary = new ResourceDictionary
+                {
+                    Source = new Uri(newSource)
+                };
+                element.Dispatcher.Invoke(new Action(() => mergedDictionaries[i] = newAccentDictionary));
+            }
+        }
+        
+        /// <summary>
         /// Invalidates the visual of the FrameworkElement.
         /// </summary>
         public static void RefreshVisual(this FrameworkElement element, object sender, RoutedEventArgs e)
@@ -50,343 +257,9 @@ namespace PowerPointLabs.ColorThemes.Extensions
             element.InvalidateVisual();
         }
 
-        /// <summary>
-        /// Applies a theme to the element recursively.
-        /// </summary>
-        /// <param name="element">WPF element to apply theme to.</param>
-        /// <param name="sender">Object that triggered the event</param>
-        /// <param name="theme">Color theme to update with.</param>
-        public static void ApplyTheme(this DependencyObject element, object sender, ColorTheme theme)
-        {
-            if (!element.Dispatcher.CheckAccess())
-            {
-                element.Dispatcher.Invoke(() => element.ApplyTheme(sender, theme));
-                return;
-            }
-            if (element.IsUpdated(theme)) { return; }
-            RemoveConflictingTheme(element);
-
-            if (element is TextBox)
-            {
-                TextBox t = element as TextBox;
-                t.Foreground = new SolidColorBrush(theme.foreground);
-                t.Background = Brushes.Transparent;
-            }
-            else if (element is TextBlock)
-            {
-                TextBlock t = element as TextBlock;
-                t.Foreground = new SolidColorBrush(theme.foreground);
-                t.Background = Brushes.Transparent;
-            }
-            else if (element is Label)
-            {
-                Label l = element as Label;
-                l.Foreground = new SolidColorBrush(theme.foreground);
-                l.Background = Brushes.Transparent;
-                l.BorderBrush = Brushes.Transparent;
-            }
-            else if (element is ListBox)
-            {
-                ListBox l = element as ListBox;
-                l.Background = new SolidColorBrush(theme.background);
-                l.Foreground = new SolidColorBrush(theme.foreground);
-                l.ResubscribeColorChangedHandler(sender, theme);
-            }
-            else if (element is Frame)
-            {
-                Frame f = element as Frame;
-                f.Background = new SolidColorBrush(theme.background);
-                f.Foreground = new SolidColorBrush(theme.foreground);
-                f.ResubscribeColorChangedHandler(sender, theme);
-            }
-            else if (element is Window)
-            {
-                Window w = element as Window;
-                w.Background = new SolidColorBrush(theme.background);
-                w.Foreground = new SolidColorBrush(theme.foreground);
-                w.UpdateColors(sender, theme);
-            }
-            else if (element is Panel)
-            {
-                Panel p = element as Panel;
-                p.Background = new SolidColorBrush(theme.background);
-                p.UpdateColors(sender, theme); // the window is being update but doesn't show correctly
-            }
-            else if (element is Page)
-            {
-                Page p = element as Page;
-                p.Foreground = new SolidColorBrush(theme.foreground);
-                p.Background = new SolidColorBrush(theme.background);
-                p.UpdateColorsVisual(sender, theme);
-            }
-            else if (element is Control)
-            {
-                Control c = element as Control;
-                c.Background = new SolidColorBrush(theme.background);
-                c.Foreground = new SolidColorBrush(theme.foreground);
-                c.BorderBrush = new SolidColorBrush(theme.foreground);
-                c.UpdateColorsVisual(sender, theme);
-            }
-            else if (element is Border)
-            {
-                (element as Border).Background = new SolidColorBrush(theme.background);
-            }
-            else if (element is Path)
-            {
-                (element as Path).Stroke = new SolidColorBrush(theme.foreground);
-            }
-        }
-
         public static Control GetIWpfControl(this object control)
         {
             return (control as IWpfContainer)?.WpfControl;
-        }
-
-        /// <summary>
-        /// Checks if an element has been updated with the current theme.
-        /// </summary>
-        /// <param name="element">WPF element to be updated</param>
-        /// <param name="theme">Color theme</param>
-        /// <returns></returns>
-        public static bool IsUpdated(this DependencyObject element, ColorTheme theme)
-        {
-            if (element is TextBlock)
-            {
-                return (element as TextBlock).Foreground.IsBrushColor(theme.foreground);
-            }
-            else if (element is Label)
-            {
-                return (element as Label).Foreground.IsBrushColor(theme.foreground);
-            }
-            else if (element is ListBox)
-            {
-                ListBox l = element as ListBox;
-                return l.Background.IsBrushColor(theme.background) &&
-                    l.Foreground.IsBrushColor(theme.foreground);
-            }
-            else if (element is Frame)
-            {
-                Frame f = element as Frame;
-                return f.Background.IsBrushColor(theme.background) &&
-                    f.Foreground.IsBrushColor(theme.foreground);
-            }
-            else if (element is Window)
-            {
-                Window w = element as Window;
-                return w.Background.IsBrushColor(theme.background) &&
-                    w.Foreground.IsBrushColor(theme.foreground);
-            }
-            else if (element is Panel)
-            {
-                return (element as Panel).Background.IsBrushColor(theme.boxBackground);
-            }
-            else if (element is Page)
-            {
-                Page p = element as Page;
-                return p.Foreground.IsBrushColor(theme.foreground) &&
-                    p.Background.IsBrushColor(theme.background);
-            }
-            else if (element is Control)
-            {
-                Control c = element as Control;
-                return c.Background.IsBrushColor(theme.background) &&
-                    c.Foreground.IsBrushColor(theme.foreground) &&
-                    c.BorderBrush.IsBrushColor(theme.foreground);
-            }
-            else if (element is Border)
-            {
-                return (element as Border).Background.IsBrushColor(theme.boxBackground);
-            }
-            else if (element is Path)
-            {
-                return (element as Path).Stroke.IsBrushColor(theme.foreground);
-            }
-            return true;
-        }
-
-        // hotfix for combobox for AudioSettingsDialogWindow
-        private static void RemoveConflictingTheme(DependencyObject element)
-        {
-            if (element is AudioSettingsDialogWindow)
-            {
-                AudioSettingsDialogWindow window = (AudioSettingsDialogWindow)element;
-                Page p = window.MainPage;
-                ResourceDictionary r = p.Resources.MergedDictionaries.FirstOrDefault(
-                    (d) => d.Source.AbsoluteUri == "pack://application:,,,/MahApps.Metro;component/Styles/Controls.xaml");
-                p.Resources.MergedDictionaries.Remove(r);
-            }
-        }
-
-        private static bool IsBrushColor(this Brush b, Color color)
-        {
-            return b is SolidColorBrush && ((SolidColorBrush)b).Color == color;
-        }
-
-        // Uses VisualChildren, as some elements are ommitted if logical chlidren are used
-        private static void UpdateColorsVisual(this FrameworkElement element, object sender, ColorTheme theme)
-        {
-            foreach (Visual visual in GetVisualChildCollection<Visual>(element))
-            {
-                visual.ApplyTheme(sender, theme);
-            }
-            element.ApplyTemplate();
-        }
-
-        // Uses LogicalChildren as it is much cheaper
-        private static void UpdateColors(this DependencyObject element, object sender, ColorTheme theme)
-        {
-            foreach (DependencyObject dependencyObject in GetLogicalChildCollection<DependencyObject>(element))
-            {
-                dependencyObject.ApplyTheme(sender, theme);
-            }
-        }
-
-        private static void ResubscribeColorChangedHandler(this Frame frame, object sender, ColorTheme theme)
-        {
-            EventHandler statusChangedHandler = new EventHandler((_o, _e) =>
-            {
-                if (frame.Content != null)
-                {
-                    frame.UpdateColorsChildren(sender, theme);
-                }
-            });
-            ActionCommand command = new ActionCommand(() =>
-            {
-                frame.ContentRendered -= statusChangedHandler;
-            });
-            CommandBinding commandBinding = new CommandBinding() { Command = command };
-            foreach (CommandBinding binding in frame.CommandBindings)
-            {
-                binding.Command.Execute(null);
-            }
-            frame.CommandBindings.Clear();
-            frame.ContentRendered += statusChangedHandler;
-            frame.CommandBindings.Add(commandBinding);
-        }
-
-        private static void UpdateColorsChildren(this Frame frame, object sender, ColorTheme theme)
-        {
-            Visual visual = frame.Content as Visual;
-            if (visual == null) { return; }
-            foreach (Visual element in GetVisualChildCollection<Visual>(visual))
-            {
-                element.UpdateColors(sender, theme);
-            }
-            visual.UpdateColors(sender, theme);
-        }
-
-        // Exploits the CommandBindings on Control to store actions to unsubscribe events
-        private static void ResubscribeColorChangedHandler(this ListBox listBox, object sender, ColorTheme theme)
-        {
-            EventHandler statusChangedHandler = new EventHandler((_o, _e) =>
-            {
-                if (listBox.ItemContainerGenerator.Status == GeneratorStatus.ContainersGenerated)
-                {
-                    listBox.UpdateColorsChildren(sender, theme);
-                }
-            });
-            ActionCommand command = new ActionCommand(() =>
-            {
-                listBox.ItemContainerGenerator.StatusChanged -= statusChangedHandler;
-            });
-            CommandBinding commandBinding = new CommandBinding() { Command = command };
-            foreach (CommandBinding binding in listBox.CommandBindings)
-            {
-                binding.Command.Execute(null);
-            }
-            listBox.CommandBindings.Clear();
-            listBox.UpdateColorsChildren(sender, theme);
-            listBox.ItemContainerGenerator.StatusChanged += statusChangedHandler;
-            listBox.CommandBindings.Add(commandBinding);
-        }
-
-        private static void UpdateColorsChildren(this ListBox listBox, object sender, ColorTheme theme)
-        {
-            listBox.UpdateColors(sender, theme);
-            for (int i = 0; i < listBox.Items.Count; i++)
-            {
-                Visual visual = listBox.ItemContainerGenerator.ContainerFromIndex(i) as Visual;
-                if (visual == null) { break; }
-                foreach (Visual element in GetVisualChildCollection<Visual>(visual))
-                {
-                    element.UpdateColors(sender, theme);
-                }
-                visual.UpdateColors(sender, theme);
-            }
-        }
-
-        private static IEnumerable<T> GetChildCollection<T>(DependencyObject parent) where T : DependencyObject
-        {
-            foreach (object child in LogicalTreeHelper.GetChildren(parent))
-            {
-                if (child is DependencyObject)
-                {
-                    DependencyObject depChild = child as DependencyObject;
-                    if (child is T)
-                    {
-                        yield return child as T;
-                    }
-                    foreach (T childOfChild in GetChildCollection<T>(depChild))
-                    {
-                        yield return childOfChild;
-                    }
-                }
-            }
-
-            if (parent is Visual || parent is Visual3D)
-            {
-                for (int i = 0; i < VisualTreeHelper.GetChildrenCount(parent); i++)
-                {
-                    DependencyObject depChild = VisualTreeHelper.GetChild(parent, i);
-                    if (depChild is T)
-                    {
-                        yield return depChild as T;
-                    }
-                    foreach (T childOfChild in GetChildCollection<T>(depChild))
-                    {
-                        yield return childOfChild;
-                    }
-                }
-            }
-        }
-
-        private static IEnumerable<T> GetVisualChildCollection<T>(Visual parent) where T : Visual
-        {
-            for (int i = 0; i < VisualTreeHelper.GetChildrenCount(parent); i++)
-            {
-                Visual depChild = VisualTreeHelper.GetChild(parent, i) as Visual;
-                if (depChild == null)
-                {
-                    continue;
-                }
-                if (depChild is T)
-                {
-                    yield return depChild as T;
-                }
-                foreach (T childOfChild in GetVisualChildCollection<T>(depChild))
-                {
-                    yield return childOfChild;
-                }
-            }
-        }
-
-        private static IEnumerable<T> GetLogicalChildCollection<T>(DependencyObject parent) where T : DependencyObject
-        {
-            foreach (object child in LogicalTreeHelper.GetChildren(parent))
-            {
-                if (child is DependencyObject)
-                {
-                    DependencyObject depChild = child as DependencyObject;
-                    if (child is T)
-                    {
-                        yield return child as T;
-                    }
-                    foreach (T childOfChild in GetLogicalChildCollection<T>(depChild))
-                    {
-                        yield return childOfChild;
-                    }
-                }
-            }
         }
     }
 }

--- a/PowerPointLabs/PowerPointLabs/ColorTheme/ThemeManager.cs
+++ b/PowerPointLabs/PowerPointLabs/ColorTheme/ThemeManager.cs
@@ -47,10 +47,7 @@ namespace PowerPointLabs.ColorThemes
         {
             add
             {
-                if (!themeWatcher.IsDefaultKey)
-                {
-                    value(this, _colorTheme);
-                }
+                value(this, _colorTheme);
                 _ColorThemeChanged += value;
             }
             remove
@@ -66,24 +63,11 @@ namespace PowerPointLabs.ColorThemes
 
         private ThemeManager()
         {
-            themeWatcher = new RegistryWatcher<int>(ThemeRegistryPath, ThemeRegistryKey, GetDefaultKeys());
+            // The ThemeWatcher will have no default keys.
+            themeWatcher = new RegistryWatcher<int>(ThemeRegistryPath, ThemeRegistryKey, new List<int>());
             themeWatcher.ValueChanged += ThemeChangedHandler;
             themeWatcher.Fire();
             themeWatcher.Start();
-        }
-
-        private List<int> GetDefaultKeys()
-        {
-            if (!Globals.ThisAddIn.IsApplicationVersion2013())
-            {
-                return new List<int>() { ColorTheme.COLORFUL };
-            }
-            return new List<int>()
-            {
-                ColorTheme.WHITE,
-                ColorTheme.LIGHT_GRAY,
-                ColorTheme.DARK_GRAY
-            };
         }
 
         private void ThemeChangedHandler(object sender, int newValue)
@@ -96,48 +80,17 @@ namespace PowerPointLabs.ColorThemes
         {
             switch (newValue)
             {
-                case ColorTheme.COLORFUL:
-                    _colorTheme.title = Color.FromRgb(181, 71, 42);
-                    _colorTheme.background = Color.FromRgb(230, 230, 230);
-                    _colorTheme.foreground = Color.FromRgb(37, 37, 37);
-                    _colorTheme.boxBackground = Color.FromRgb(255, 255, 255);
-                    _colorTheme.headingBackground = Color.FromRgb(181, 71, 42);
-                    _colorTheme.headingForeground = Color.FromRgb(238, 238, 238);
-                    break;
-                case ColorTheme.WHITE:
-                case ColorTheme.LIGHT_GRAY:
-                case ColorTheme.DARK_GRAY_ALT:
-                    _colorTheme.title = Color.FromRgb(181, 71, 42);
-                    _colorTheme.background = Color.FromRgb(255, 255, 255);
-                    _colorTheme.foreground = Color.FromRgb(37, 37, 37);
-                    _colorTheme.boxBackground = Color.FromRgb(230, 230, 230);
-                    _colorTheme.headingBackground = Color.FromRgb(181, 71, 42);
-                    _colorTheme.headingForeground = Color.FromRgb(238, 238, 238);
-                    break;
-                case ColorTheme.DARK_GRAY:
-                    _colorTheme.title = Color.FromRgb(181, 71, 42);
-                    _colorTheme.background = Color.FromRgb(102, 102, 102);
-                    _colorTheme.foreground = Color.FromRgb(238, 238, 238);
-                    _colorTheme.boxBackground = Color.FromRgb(64, 64, 64);
-                    _colorTheme.headingBackground = Color.FromRgb(208, 71, 38);
-                    _colorTheme.headingForeground = Color.FromRgb(238, 238, 238);
-                    break;
                 case ColorTheme.BLACK:
-                    _colorTheme.title = Color.FromRgb(239, 239, 239);
-                    _colorTheme.background = Color.FromRgb(37, 37, 37);
-                    _colorTheme.foreground = Color.FromRgb(238, 238, 238);
-                    _colorTheme.boxBackground = Color.FromRgb(64, 64, 64);
-                    _colorTheme.headingBackground = Color.FromRgb(208, 71, 38);
-                    _colorTheme.headingForeground = Color.FromRgb(238, 238, 238);
+                case ColorTheme.COLORFUL:
+                case ColorTheme.DARK_GRAY:
+                case ColorTheme.DARK_GRAY_ALT:
+                case ColorTheme.LIGHT_GRAY:
+                case ColorTheme.WHITE:
+                    _colorTheme.ThemeId = newValue;
                     break;
                 default:
                     Logger.Log("Unknown UI Theme!");
-                    _colorTheme.title = Color.FromRgb(181, 71, 42);
-                    _colorTheme.background = Color.FromRgb(230, 230, 230);
-                    _colorTheme.foreground = Color.FromRgb(37, 37, 37);
-                    _colorTheme.boxBackground = Color.FromRgb(255, 255, 255);
-                    _colorTheme.headingBackground = Color.FromRgb(181, 71, 42);
-                    _colorTheme.headingForeground = Color.FromRgb(238, 238, 238);
+                    _colorTheme.ThemeId = ColorTheme.COLORFUL;
                     break;
             }
         }

--- a/PowerPointLabs/PowerPointLabs/ColorTheme/ThemeResourceDictionary.cs
+++ b/PowerPointLabs/PowerPointLabs/ColorTheme/ThemeResourceDictionary.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using PowerPointLabs.ActionFramework.Common.Log;
+
+namespace PowerPointLabs.ColorThemes
+{
+    /// <summary>
+    /// The ThemeResourceDictionary class is a Resource Dictionary representing a Color Theme, to be added to the
+    /// resources of a <see cref="FrameworkElement"/>.
+    /// </summary>
+    /// <remarks>
+    /// The purpose of this class is to be able to uniquely identify the resource dictionary in a
+    /// <see cref="FrameworkElement"/>'s resources that represents a Color Theme, so that it can be
+    /// replaced when the Application's Color Theme changes.
+    /// </remarks>
+    public class ThemeResourceDictionary : ResourceDictionary
+    {
+        public static readonly string PathToThemesFolder = "pack://application:,,,/PowerPointLabs;component/Resources/Themes/";
+
+        public static ThemeResourceDictionary FromColorTheme(ColorTheme colorTheme)
+        {
+            string themeName = "";
+            switch (colorTheme.ThemeId)
+            {
+                case ColorTheme.BLACK:
+                    themeName = "Black";
+                    break;
+                case ColorTheme.COLORFUL:
+                    themeName = "Colorful";
+                    break;
+                case ColorTheme.DARK_GRAY:
+                    themeName = "DarkGray";
+                    break;
+                case ColorTheme.WHITE:
+                    themeName = "White";
+                    break;
+                default:
+                    Logger.Log("Unknown UI Theme!");
+                    themeName = "Colorful";
+                    break;
+            }
+
+            return new ThemeResourceDictionary
+            {
+                Source = new Uri(PathToThemesFolder + themeName + "Theme.xaml", UriKind.RelativeOrAbsolute)
+            };
+        }
+    }
+}

--- a/PowerPointLabs/PowerPointLabs/ColorsLab/ColorsLabPaneWPF.xaml
+++ b/PowerPointLabs/PowerPointLabs/ColorsLab/ColorsLabPaneWPF.xaml
@@ -7,12 +7,14 @@
              xmlns:textCollection="clr-namespace:PowerPointLabs.TextCollection"
              xmlns:converter="clr-namespace:PowerPointLabs.Converters.ColorPane"
              xmlns:Controls="clr-namespace:MahApps.Metro.Controls;assembly=MahApps.Metro"
+             xmlns:theme="clr-namespace:PowerPointLabs.ColorThemes"
              mc:Ignorable="d" 
              Loaded="ColorsLabPaneWPF_Loaded"
              Height="725" Width="300">
     <UserControl.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
+                <theme:DesignTheme Theme="Colorful"/>
                 <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Controls.xaml" />
                 <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Fonts.xaml" />
                 <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Colors.xaml" />
@@ -26,6 +28,9 @@
             </ContextMenu>
         </ResourceDictionary>
     </UserControl.Resources>
+    <UserControl.Background>
+        <DynamicResource ResourceKey="Theme.PaneBackgroundBrush"/>
+    </UserControl.Background>
     <ScrollViewer x:Name="PaneScroll" >
         <Grid>
             <Grid.RowDefinitions>

--- a/PowerPointLabs/PowerPointLabs/ColorsLab/ColorsLabPaneWPF.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/ColorsLab/ColorsLabPaneWPF.xaml.cs
@@ -10,6 +10,7 @@ using System.Windows.Threading;
 using Microsoft.Office.Core;
 
 using PowerPointLabs.ActionFramework.Common.Extension;
+using PowerPointLabs.ColorThemes;
 using PowerPointLabs.ColorThemes.Extensions;
 using PowerPointLabs.DataSources;
 using PowerPointLabs.TextCollection;
@@ -26,7 +27,7 @@ namespace PowerPointLabs.ColorsLab
     /// <summary>
     /// Interaction logic for ColorsLabPaneWPF.xaml
     /// </summary>
-    public partial class ColorsLabPaneWPF : UserControl
+    public partial class ColorsLabPaneWPF : UserControl, INotifyOnThemeChanged
     {
         #region Functional Test API
 
@@ -185,6 +186,33 @@ namespace PowerPointLabs.ColorsLab
 
             // Hook the mouse process if it has not
             PPExtraEventHelper.PPMouse.TryStartHook();
+        }
+
+        #endregion
+
+        #region INotifyOnThemeChanged Interface methods
+
+        /// <summary>
+        /// Changes the MahApps accent of this pane based on the Color Theme.
+        /// </summary>
+        /// <remarks>
+        /// The Steel accent will be used on all themes, except for the DarkGray
+        /// theme, which will use the Teal accent.
+        /// </remarks>
+        /// <param name="updatedColorTheme">The new color theme</param>
+        public void OnThemeChanged(ColorTheme updatedColorTheme)
+        {
+            // The Steel accent doesn't look good on the DarkGray background.
+            // The closest accent that looks okay is Teal.
+            switch (updatedColorTheme.ThemeId)
+            {
+                case ColorTheme.DARK_GRAY:
+                    ThemeExtensions.ChangeMahAppsAccent(this, "Teal");
+                    break;
+                default:
+                    ThemeExtensions.ChangeMahAppsAccent(this, "Steel");
+                    break;
+            }
         }
 
         #endregion

--- a/PowerPointLabs/PowerPointLabs/CropLab/CropToShape.cs
+++ b/PowerPointLabs/PowerPointLabs/CropLab/CropToShape.cs
@@ -109,6 +109,14 @@ namespace PowerPointLabs.CropLab
                 double newY = startY + (1 - inverseRatio) / 2 * width;
                 double newX = startX + (1 - inverseRatio) / 2 * width;
 
+                const string officeVersion2010 = "14.0";
+                if (Globals.ThisAddIn.Application.Version == officeVersion2010)
+                {
+                    newWidth *= 0.928;
+                    newHeight *= 0.999;
+                    newX *= 0.932;
+                }
+
                 Graphics inputGraphics = Graphics.FromImage(outputImage);
                 inputGraphics.DrawImage(original,
                     new Rectangle(0, 0, (int)width, (int)height),

--- a/PowerPointLabs/PowerPointLabs/ELearningLab/Converters/ShapeNameWidthConverter.cs
+++ b/PowerPointLabs/PowerPointLabs/ELearningLab/Converters/ShapeNameWidthConverter.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Windows;
+using System.Windows.Data;
+
+namespace PowerPointLabs.ELearningLab.Converters
+{
+    public class ShapeNameWidthConverter : IValueConverter
+    {
+        private const int leftIconWidth = 45;
+        public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        {
+            if (value is double)
+            {
+                return (double)value - leftIconWidth;
+            }
+            return null;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        {
+            if (value is double)
+            {
+                return (double)value + leftIconWidth;
+            }
+            return null;
+        }
+    }
+}

--- a/PowerPointLabs/PowerPointLabs/ELearningLab/Views/AudioSettingsViews/AudioMainSettingsPage.xaml
+++ b/PowerPointLabs/PowerPointLabs/ELearningLab/Views/AudioSettingsViews/AudioMainSettingsPage.xaml
@@ -80,17 +80,7 @@
                         <Button Cursor="Hand" Grid.Column="2" x:Name="azureVoiceBtn" Content="Click to Log In" Margin="0.333,10,20,0" 
                         Grid.ColumnSpan="2" Click="AzureVoiceBtn_Click"
                         BorderThickness="0" Background="Transparent" FontWeight="Medium"
-                        Width="150" Height="25" VerticalAlignment="Center">
-                            <Button.Style>
-                                <Style TargetType="Button">
-                                    <Style.Triggers>
-                                        <Trigger Property="IsMouseOver" Value="True">
-                                            <Setter Property="Background" Value="Transparent"/>
-                                        </Trigger>
-                                    </Style.Triggers>
-                                </Style>
-                            </Button.Style>
-                        </Button>
+                         Height="25" VerticalAlignment="Center"/>
                     </Grid>
                     <Grid>
                         <Grid.ColumnDefinitions>
@@ -137,18 +127,7 @@
                         <Button Cursor="Hand" Grid.Column="2" x:Name="watsonVoiceLoginBtn" 
                         Content="Click to Log In" Margin="0.333,10,20,0" 
                         Grid.ColumnSpan="2" Click="WatsonVoiceBtn_Click"
-                        BorderThickness="0" Background="Transparent" FontWeight="Medium"
-                        Width="150" Height="25" VerticalAlignment="Center">
-                            <Button.Style>
-                                <Style TargetType="Button">
-                                    <Style.Triggers>
-                                        <Trigger Property="IsMouseOver" Value="True">
-                                            <Setter Property="Background" Value="Transparent"/>
-                                        </Trigger>
-                                    </Style.Triggers>
-                                </Style>
-                            </Button.Style>
-                        </Button>
+                        BorderThickness="0" Background="Transparent" FontWeight="Medium" Height="25" VerticalAlignment="Center"/>
                     </Grid>
                 </StackPanel>
             </Border>
@@ -193,18 +172,9 @@
                         </ListView.ItemTemplate>
                     </ListView>
                     <Button Cursor="Hand" x:Name="updatePreferenceButton"                         
-                    Content="Update" Width="50" HorizontalAlignment="Right"
+                        Content="Update" Width="50" HorizontalAlignment="Right"
                         FontWeight="Thin" Margin="0 0 30 10" 
                         VerticalAlignment="Center" Click="UpdateRankingButton_Clicked">
-                        <Button.Style>
-                            <Style TargetType="Button">
-                                <Style.Triggers>
-                                    <Trigger Property="IsMouseOver" Value="True">
-                                        <Setter Property="Background" Value="Transparent"/>
-                                    </Trigger>
-                                </Style.Triggers>
-                            </Style>
-                        </Button.Style>
                         <Button.ToolTip>
                             <StackPanel FlowDirection="LeftToRight">
                                 <TextBlock FontWeight="Bold" FontSize="14" Margin="0,0,0,5">Update voice preferences</TextBlock>
@@ -248,15 +218,6 @@
                         Content="Edit" Width="50" HorizontalAlignment="Right"
                         FontWeight="Thin" Margin="0 0 30 10" 
                     Click="EditRankingButton_Clicked">
-                        <Button.Style>
-                            <Style TargetType="Button">
-                                <Style.Triggers>
-                                    <Trigger Property="IsMouseOver" Value="True">
-                                        <Setter Property="Background" Value="Transparent"/>
-                                    </Trigger>
-                                </Style.Triggers>
-                            </Style>
-                        </Button.Style>
                         <Button.ToolTip>
                             <StackPanel FlowDirection="LeftToRight">
                                 <TextBlock FontWeight="Bold" FontSize="14" Margin="0,0,0,5">Edit Voice Preferences</TextBlock>

--- a/PowerPointLabs/PowerPointLabs/ELearningLab/Views/AudioSettingsViews/AudioSettingsDialogWindow.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/ELearningLab/Views/AudioSettingsViews/AudioSettingsDialogWindow.xaml.cs
@@ -82,6 +82,12 @@ namespace PowerPointLabs.ELearningLab.Views
             DataContext = this;
             audioSettingsDialogWindow.AllowsTransparency = true;
             audioSettingsDialogWindow.Opacity = 0;
+
+            // Add this DialogWindow's Resources to the MergedDictionaries of the pages so that
+            // when they get updated due to theme changes, the updates get propagated to the pages.
+            mainPage.Resources.MergedDictionaries.Add(Resources);
+            subAzureLoginPage.Resources.MergedDictionaries.Add(Resources);
+            subWatsonLoginPage.Resources.MergedDictionaries.Add(Resources);
         }
         protected override void OnRenderSizeChanged(SizeChangedInfo sizeInfo)
         {

--- a/PowerPointLabs/PowerPointLabs/ELearningLab/Views/ELearningWorkspaceViews/CustomItemView.xaml
+++ b/PowerPointLabs/PowerPointLabs/ELearningLab/Views/ELearningWorkspaceViews/CustomItemView.xaml
@@ -9,6 +9,7 @@
              mc:Ignorable="d">
     <Control.Resources>
         <BooleanToVisibilityConverter x:Key="BoolToVisibility" />
+        <converters:ShapeNameWidthConverter x:Key="ShapeNameConverter" />
     </Control.Resources>
     <Grid>
         <Grid.ColumnDefinitions>
@@ -16,11 +17,11 @@
             <ColumnDefinition Width="*"/>
         </Grid.ColumnDefinitions>
         <Border Grid.Column="0" Width="30" Height="30" CornerRadius="15"
-                    VerticalAlignment="Top" Background="Black">
+                    VerticalAlignment="Center" Background="Black">
             <Label Content="{Binding ClickNo}" VerticalAlignment="Center" HorizontalAlignment="Center"
                                        FontFamily="Century Gothic" FontWeight="SemiBold" Foreground="White" FontSize="13"/>
         </Border>
-        <ListView Grid.Column="1" ItemsSource="{Binding CustomItems}" BorderThickness="0" Margin="0" IsHitTestVisible="False">
+        <ListView x:Name="list" Grid.Column="1" ItemsSource="{Binding CustomItems}" BorderThickness="0" Margin="0" IsHitTestVisible="False">
             <ListView.ItemTemplate>
                 <DataTemplate DataType="{x:Type data:CustomSubItem}">
                     <Grid>
@@ -29,9 +30,11 @@
                             <ColumnDefinition Width="*" />
                         </Grid.ColumnDefinitions>
                         <Image Grid.Column="0" MinHeight="15" MaxHeight="15" MinWidth="15" MaxWidth="15" VerticalAlignment="Center"
-                   Source="{Binding Type, Converter={converters:AnimationTypeToImageSourceConverter}}" 
+                               Source="{Binding Type, Converter={converters:AnimationTypeToImageSourceConverter}}" 
                                Stretch="Uniform" HorizontalAlignment="Center"/>
-                        <TextBlock Grid.Column="1" Text="{Binding ShapeName}"/>
+                        <TextBlock Grid.Column="1" 
+                                   Width="{Binding ActualWidth, ElementName=list, Converter={StaticResource ShapeNameConverter}}"
+                                   TextWrapping="Wrap"  HorizontalAlignment="Stretch" Text="{Binding ShapeName}"/>
                     </Grid>
                 </DataTemplate>
             </ListView.ItemTemplate>

--- a/PowerPointLabs/PowerPointLabs/ELearningLab/Views/ELearningWorkspaceViews/ELearningLabMainPanel.xaml
+++ b/PowerPointLabs/PowerPointLabs/ELearningLab/Views/ELearningWorkspaceViews/ELearningLabMainPanel.xaml
@@ -3,6 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:theme="clr-namespace:PowerPointLabs.ColorThemes"
              xmlns:views="clr-namespace:PowerPointLabs.ELearningLab.Views"
              xmlns:model="clr-namespace:PowerPointLabs.ELearningLab.ELearningWorkspace.Model"
              xmlns:converters="clr-namespace:PowerPointLabs.ELearningLab.Converters"
@@ -12,15 +13,29 @@
              views:ExplanationItemView.TriggerTypeSelectionChangedHandler="HandleTriggerTypeComboBoxSelectionChangedEvent"
              mc:Ignorable="d"  d:DesignHeight="700" d:DesignWidth="600">
     <UserControl.Resources>
-        <ContextMenu x:Key="ItemContextMenu">
-            <MenuItem Header="Add Explanation Above" 
-                      Click="AddItemAboveContextMenu_Click"
-                      CommandParameter="{Binding}"/>
-            <MenuItem Header="Add Explanation Below" 
-                      Click="AddItemBelowContextMenu_Click"
-                      CommandParameter="{Binding}"/>
-        </ContextMenu>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <theme:DesignTheme Theme="Colorful"/>
+                <theme:BaseStylesDictionary/>
+            </ResourceDictionary.MergedDictionaries>
+            <ContextMenu x:Key="ItemContextMenu">
+                <MenuItem Header="Add Explanation Above" 
+                          Click="AddItemAboveContextMenu_Click"
+                          CommandParameter="{Binding}"/>
+                <MenuItem Header="Add Explanation Below" 
+                          Click="AddItemBelowContextMenu_Click"
+                          CommandParameter="{Binding}"/>
+            </ContextMenu>
+            <Style x:Key="ImageButtonStyle" TargetType="Button">
+                <Setter Property="Background" Value="#FFDDDDDD"/>
+            </Style>
+        </ResourceDictionary>
     </UserControl.Resources>
+
+    <UserControl.Background>
+        <DynamicResource ResourceKey="Theme.PaneBackgroundBrush"/>
+    </UserControl.Background>
+    
     <Grid x:Name="grid">
         <Grid.RowDefinitions>
             <RowDefinition Height="40" />
@@ -29,7 +44,7 @@
         <StackPanel Grid.Row="0" Orientation="Horizontal" FlowDirection="LeftToRight">
             <StackPanel Margin="10,0,20,0" Orientation="Horizontal">
                 <Button x:Name="createButton" Height="35" 
-                VerticalAlignment="Center" Width="35" Padding="5" Click="CreateButton_Click">
+                VerticalAlignment="Center" Width="35" Padding="5" Click="CreateButton_Click" Style="{StaticResource ImageButtonStyle}">
                     <Image x:Name="createImage" Stretch="Fill"/>
                     <Button.ToolTip>
                         <StackPanel FlowDirection="LeftToRight">
@@ -48,7 +63,7 @@
             </StackPanel>
             <StackPanel Orientation="Horizontal">
                 <Button x:Name="syncButton" Height="35" 
-                VerticalAlignment="Center" Width="35" Padding="5" Click="SyncButton_Click">
+                VerticalAlignment="Center" Width="35" Padding="5" Click="SyncButton_Click" Style="{StaticResource ImageButtonStyle}">
                     <Image x:Name="syncImage" Stretch="Fill"/>
                     <Button.ToolTip>
                         <StackPanel FlowDirection="LeftToRight">
@@ -71,7 +86,7 @@
         <DockPanel Grid.Row="1" x:Name="eLLPane">
             <ListView x:Name="listView" ItemsSource="{Binding Items}"
                   BorderThickness="0" Margin="0" SelectionMode="Single"
-                      ScrollViewer.HorizontalScrollBarVisibility="Disabled">
+                      ScrollViewer.HorizontalScrollBarVisibility="Disabled" Background="{DynamicResource Theme.PaneBackgroundBrush}">
                 <ListView.ItemContainerStyle>
                     <Style TargetType="{x:Type ListViewItem}" >
                         <Setter Property="ContextMenu" Value="{StaticResource ItemContextMenu}" />
@@ -86,7 +101,7 @@
                                     <Setter.Value>
                                         <ControlTemplate>
                                             <DockPanel>
-                                                <TextBlock HorizontalAlignment="Center" VerticalAlignment="Center"
+                                                <TextBlock HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="{DynamicResource Theme.ForegroundBrush}"
                                                        FontWeight="Bold" FontSize="20">
                                                 No items to display
                                                 </TextBlock>
@@ -106,7 +121,7 @@
                     </DataTemplate>
                     <DataTemplate DataType="{x:Type model:ExplanationItem}">
                         <StackPanel Margin="2 2 2 2">
-                            <Border BorderThickness="0.2" BorderBrush="LightGray" CornerRadius="4" Background="WhiteSmoke">
+                            <Border BorderThickness="0.2" BorderBrush="{DynamicResource Theme.BackgroundBrush3}" CornerRadius="4" Background="{DynamicResource Theme.BackgroundBrush2}">
                                 <StackPanel Margin="5 5 5 5">
                                     <views:ExplanationItemView DataContext="{Binding}"/>
                                 </StackPanel>

--- a/PowerPointLabs/PowerPointLabs/ELearningLab/Views/ELearningWorkspaceViews/ExplanationItemView.xaml
+++ b/PowerPointLabs/PowerPointLabs/ELearningLab/Views/ELearningWorkspaceViews/ExplanationItemView.xaml
@@ -3,72 +3,85 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:theme="clr-namespace:PowerPointLabs.ColorThemes"
              xmlns:views="clr-namespace:PowerPointLabs.ELearningLab.Views"
              xmlns:converters="clr-namespace:PowerPointLabs.ELearningLab.Converters"
              Loaded="SelfExplanationBlockView_Loaded"
+             d:DesignWidth="400"
              mc:Ignorable="d">
-
     <Control.Resources>
-        <Style x:Key="EditCaptionVoiceContentButtonStyle" TargetType="Button">
-            <Setter Property="OverridesDefaultStyle" Value="True" />
-            <Setter Property="Cursor" Value="Hand" />
-            <Setter Property="Template">
-                <Setter.Value>
-                    <ControlTemplate TargetType="Button">
-                        <Border Name="border" BorderThickness="0" BorderBrush="Black" Background="{TemplateBinding Background}">
-                            <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center" />
-                        </Border>
-                        <ControlTemplate.Triggers>
-                            <Trigger Property="IsMouseOver" Value="True">
-                                <Setter Property="Opacity" Value="0.9" />
-                            </Trigger>
-                        </ControlTemplate.Triggers>
-                    </ControlTemplate>
-                </Setter.Value>
-            </Setter>
-        </Style>
-        <Style x:Key="TextBoxWithPlaceHolder" TargetType="{x:Type TextBox}" BasedOn="{StaticResource {x:Type TextBox}}">
-            <Setter Property="Template">
-                <Setter.Value>
-                    <ControlTemplate TargetType="{x:Type TextBox}">
-                        <Border Background="{TemplateBinding Background}" 
-                          x:Name="Bd" BorderBrush="SlateGray" 
-                          BorderThickness="{TemplateBinding BorderThickness}" CornerRadius="2">
-                            <Grid Margin="2 2 2 2">
-                                <TextBox Text="{Binding Path=Text,
-                                                RelativeSource={RelativeSource TemplatedParent}, 
-                                                Mode=TwoWay,
-                                                UpdateSourceTrigger=PropertyChanged}"
-                                 x:Name="textSource" AcceptsReturn="True" TextWrapping="Wrap"
-                                 Background="Transparent" BorderThickness="0" 
-                                         ScrollViewer.HorizontalScrollBarVisibility="Disabled" 
-                         ScrollViewer.VerticalScrollBarVisibility="Auto"
-                                 Panel.ZIndex="2" />
-                                <TextBox Text="{TemplateBinding Tag}" Background="{TemplateBinding Background}" 
-                                         AcceptsReturn="True" Panel.ZIndex="1" BorderThickness="0" TextWrapping="Wrap"
-                                          ScrollViewer.HorizontalScrollBarVisibility="Disabled" 
-                         ScrollViewer.VerticalScrollBarVisibility="Auto">
-                                    <TextBox.Style>
-                                        <Style TargetType="{x:Type TextBox}">
-                                            <Setter Property="Foreground" Value="Transparent"/>
-                                            <Style.Triggers>
-                                                <DataTrigger Binding="{Binding Path=Text, Source={x:Reference textSource}}" Value="">
-                                                    <Setter Property="Foreground" Value="Gray"/>
-                                                    <Setter Property="HorizontalContentAlignment" Value="Left"/>
-                                                    <Setter Property="VerticalContentAlignment" Value="Center"/>
-                                                </DataTrigger>
-                                            </Style.Triggers>
-                                        </Style>
-                                    </TextBox.Style>
-                                </TextBox>
-                            </Grid>
-                        </Border>
-                    </ControlTemplate>
-                </Setter.Value>
-            </Setter>
-        </Style>
-        <BooleanToVisibilityConverter x:Key="BoolToVisibility" />
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <theme:DesignTheme Theme="Colorful"/>
+                <theme:BaseStylesDictionary/>
+            </ResourceDictionary.MergedDictionaries>
+            <Style x:Key="ImageButtonStyle" TargetType="Button">
+                <Setter Property="Background" Value="#FFDDDDDD"/>
+            </Style>
+            <Style x:Key="EditCaptionVoiceContentButtonStyle" TargetType="Button">
+                <Setter Property="OverridesDefaultStyle" Value="True" />
+                <Setter Property="Cursor" Value="Hand" />
+                <Setter Property="Template">
+                    <Setter.Value>
+                        <ControlTemplate TargetType="Button">
+                            <Border Name="border" BorderThickness="0" BorderBrush="Black" Background="{TemplateBinding Background}">
+                                <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center" />
+                            </Border>
+                            <ControlTemplate.Triggers>
+                                <Trigger Property="IsMouseOver" Value="True">
+                                    <Setter Property="Opacity" Value="0.9" />
+                                </Trigger>
+                            </ControlTemplate.Triggers>
+                        </ControlTemplate>
+                    </Setter.Value>
+                </Setter>
+            </Style>
+            <Style x:Key="TextBoxWithPlaceHolder" TargetType="{x:Type TextBox}" BasedOn="{StaticResource BaseTextBoxStyle}">
+                <Setter Property="Template">
+                    <Setter.Value>
+                        <ControlTemplate TargetType="{x:Type TextBox}">
+                            <Border Background="{TemplateBinding Background}" 
+                              x:Name="Bd" BorderBrush="SlateGray" 
+                              BorderThickness="{TemplateBinding BorderThickness}" CornerRadius="2">
+                                <Grid Margin="2 2 2 2">
+                                    <TextBox Text="{Binding Path=Text,
+                                                    RelativeSource={RelativeSource TemplatedParent}, 
+                                                    Mode=TwoWay,
+                                                    UpdateSourceTrigger=PropertyChanged}"
+                                     x:Name="textSource" AcceptsReturn="True" TextWrapping="Wrap"
+                                     Background="Transparent" BorderThickness="0" 
+                                             ScrollViewer.HorizontalScrollBarVisibility="Disabled" 
+                             ScrollViewer.VerticalScrollBarVisibility="Auto"
+                                     Panel.ZIndex="2" />
+                                    <TextBox Text="{TemplateBinding Tag}" Background="{TemplateBinding Background}" 
+                                             AcceptsReturn="True" Panel.ZIndex="1" BorderThickness="0" TextWrapping="Wrap"
+                                              ScrollViewer.HorizontalScrollBarVisibility="Disabled" 
+                             ScrollViewer.VerticalScrollBarVisibility="Auto">
+                                        <TextBox.Style>
+                                            <Style TargetType="{x:Type TextBox}">
+                                                <Setter Property="Foreground" Value="Transparent"/>
+                                                <Style.Triggers>
+                                                    <DataTrigger Binding="{Binding Path=Text, Source={x:Reference textSource}}" Value="">
+                                                        <Setter Property="Foreground" Value="Gray"/>
+                                                        <Setter Property="HorizontalContentAlignment" Value="Left"/>
+                                                        <Setter Property="VerticalContentAlignment" Value="Center"/>
+                                                    </DataTrigger>
+                                                </Style.Triggers>
+                                            </Style>
+                                        </TextBox.Style>
+                                    </TextBox>
+                                </Grid>
+                            </Border>
+                        </ControlTemplate>
+                    </Setter.Value>
+                </Setter>
+            </Style>
+            <BooleanToVisibilityConverter x:Key="BoolToVisibility" />
+        </ResourceDictionary>
     </Control.Resources>
+    <UserControl.Background>
+        <DynamicResource ResourceKey="Theme.BackgroundBrush2"/>
+    </UserControl.Background>
     <StackPanel>
         <Grid>
             <Grid.ColumnDefinitions>
@@ -97,7 +110,7 @@
                 </Border>
                 <Button Grid.Row="1" HorizontalAlignment="Center" Margin="2 2 2 2"
                     MinWidth="15" MaxWidth="15" MinHeight="15" MaxHeight="15" Click="UpButton_Click"
-                        CommandParameter="{Binding .}">
+                        CommandParameter="{Binding .}" Style="{StaticResource ImageButtonStyle}">
                     <Image x:Name="upImage" Stretch="Fill"/>
                     <Button.ToolTip>
                         <StackPanel>
@@ -111,7 +124,7 @@
                 </Button>
                 <Button x:Name="deleteButton" Grid.Row="2" HorizontalAlignment="Center" Margin="2 2 2 2"
                     MinWidth="15" MaxWidth="15" MinHeight="15" MaxHeight="15" Click="DeleteButton_Click"
-                        CommandParameter="{Binding .}">
+                        CommandParameter="{Binding .}" Style="{StaticResource ImageButtonStyle}">
                     <Image x:Name="deleteImage" Stretch="Fill"/>
                     <Button.ToolTip>
                         <StackPanel>
@@ -125,7 +138,7 @@
                 </Button>
                 <Button x:Name="downButton" Grid.Row="3" HorizontalAlignment="Center" Margin="2 2 2 2"
                     MinWidth="15" MaxWidth="15" MinHeight="15" MaxHeight="15" Click="DownButton_Click"
-                        CommandParameter="{Binding .}">
+                        CommandParameter="{Binding .}" Style="{StaticResource ImageButtonStyle}">
                     <Image x:Name="downImage" Stretch="Fill"/>
                     <Button.ToolTip>
                         <StackPanel>
@@ -162,7 +175,7 @@
                                Text="{Binding VoiceLabel, Mode=TwoWay}" FontSize="8" Padding="0" 
                                VerticalAlignment="Center" FontStyle="Italic">
                          <TextBlock.Style>
-                            <Style TargetType="TextBlock">
+                            <Style TargetType="TextBlock" BasedOn="{StaticResource BaseTextBlockStyle}">
                                 <Style.Triggers>
                                     <DataTrigger Binding="{Binding Path=IsVoiceLabelInvalid}" Value="True">
                                         <Setter Property="TextDecorations">
@@ -186,7 +199,7 @@
                     </TextBlock>
                 </StackPanel>
                 <Button Grid.Row="0" x:Name="audioPreviewButton" Margin="2 0 2 0" HorizontalAlignment="Right"
-                    MinWidth="15" MaxWidth="15" MinHeight="15" MaxHeight="15" Click="VoicePreviewButton_Click">
+                    MinWidth="15" MaxWidth="15" MinHeight="15" MaxHeight="15" Click="VoicePreviewButton_Click" Style="{StaticResource ImageButtonStyle}">
                     <Image x:Name="audioImage" Stretch="Fill"/>
                     <Button.ToolTip>
                         <StackPanel>

--- a/PowerPointLabs/PowerPointLabs/EffectsLab/Spotlight.cs
+++ b/PowerPointLabs/PowerPointLabs/EffectsLab/Spotlight.cs
@@ -32,7 +32,7 @@ namespace PowerPointLabs.EffectsLab
                     spotlightShapes.Add(spotlightShape);
                     PostFormatShapeOnCurrentSlide(currentSlide, spotShape);
                 }
-                
+
                 addedSlide.PrepareForSpotlight();
                 addedSlide.AddSpotlightEffect(spotlightShapes);
                 currentSlide.DeleteShapesWithPrefix("SpotlightShape");

--- a/PowerPointLabs/PowerPointLabs/HighlightLab/HighlightBulletsBackground.cs
+++ b/PowerPointLabs/PowerPointLabs/HighlightLab/HighlightBulletsBackground.cs
@@ -43,7 +43,6 @@ namespace PowerPointLabs.HighlightLab
                         break;
                     case HighlightBackgroundSelection.kNoneSelected:
                         currentSlide.DeleteIndicator();
-                        currentSlide.DeleteShapesWithPrefix("PPTLabsHighlightBackgroundShape");
                         shapesToUse = GetAllUsableShapesInSlide(currentSlide);
                         break;
                     default:
@@ -183,11 +182,6 @@ namespace PowerPointLabs.HighlightLab
                         sh.Select(Office.MsoTriState.msoFalse);
                     }
                 }
-                //Remove existing animations for highlight text as well
-                if (sh.Name.Contains("HighlightTextShape"))
-                {
-                    currentSlide.DeleteShapeAnimations(sh);
-                }
             }
 
             if (shapesToDelete.Count > 0)
@@ -211,7 +205,6 @@ namespace PowerPointLabs.HighlightLab
                                     .Where(sh => !sh.Name.Contains("PPTLabsHighlightBackgroundShape")
                                                     && HasText(sh))
                                     .ToList();
-            shapesToUse.ForEach(currentSlide.DeleteShapeAnimations);
             return shapesToUse;
         }
 
@@ -237,12 +230,10 @@ namespace PowerPointLabs.HighlightLab
 
             if (usableShapesWithBullets.Count == 0)
             {
-                allUsableShapes.ForEach(currentSlide.DeleteShapeAnimations);
                 return allUsableShapes;
             }
             else
             {
-                usableShapesWithBullets.ForEach(currentSlide.DeleteShapeAnimations);
                 return usableShapesWithBullets;
             }
         }

--- a/PowerPointLabs/PowerPointLabs/HighlightLab/HighlightBulletsBackground.cs
+++ b/PowerPointLabs/PowerPointLabs/HighlightLab/HighlightBulletsBackground.cs
@@ -68,6 +68,12 @@ namespace PowerPointLabs.HighlightLab
                     AnimationLabSettings.IsUseFrameAnimation = oldValue;
                     PowerPointPresentation.Current.AddAckSlide();
                 }
+
+                if (currentSlide.HasAnimationForClick(clickNumber: 1))
+                {
+                    Globals.ThisAddIn.Application.CommandBars.ExecuteMso("AnimationPreview");
+                }
+
                 Globals.ThisAddIn.Application.ActiveWindow.Selection.Unselect();
             }
             catch (Exception e)

--- a/PowerPointLabs/PowerPointLabs/HighlightLab/HighlightBulletsText.cs
+++ b/PowerPointLabs/PowerPointLabs/HighlightLab/HighlightBulletsText.cs
@@ -41,13 +41,12 @@ namespace PowerPointLabs.HighlightLab
                         break;
                     case HighlightTextSelection.kNoneSelected:
                         currentSlide.DeleteIndicator();
-                        currentSlide.DeleteShapesWithPrefix("PPTLabsHighlightBackgroundShape");
                         shapesToUse = GetAllUsableShapesInSlide(currentSlide);
                         break;
                     default:
                         break;
                 }
-                
+
                 if (currentSlide.Name.Contains("PPTLabsHighlightBulletsSlide"))
                 {
                     ProcessExistingHighlightSlide(currentSlide, shapesToUse);
@@ -135,7 +134,6 @@ namespace PowerPointLabs.HighlightLab
         private static void ProcessExistingHighlightSlide(PowerPointSlide currentSlide, List<PowerPoint.Shape> shapesToUse)
         {
             currentSlide.DeleteIndicator();
-            currentSlide.DeleteShapesWithPrefix("PPTLabsHighlightBackgroundShape");
 
             foreach (PowerPoint.Shape tmp in currentSlide.Shapes)
             {

--- a/PowerPointLabs/PowerPointLabs/Models/PowerPointShapeGalleryPresentation.cs
+++ b/PowerPointLabs/PowerPointLabs/Models/PowerPointShapeGalleryPresentation.cs
@@ -413,11 +413,7 @@ namespace PowerPointLabs.Models
                 if (Slides.All(category => category.Name.ToLower() != categoryName.ToLower()))
                 {
                     categoryLost = true;
-                    PPLClipboard.Instance.LockAndRelease(() =>
-                    {
-                        // not sure why fromClipboard is true here
-                        AddCategory(categoryName, false, true);
-                    });
+                    AddCategory(categoryName, false, false);
                 }
             }
 

--- a/PowerPointLabs/PowerPointLabs/Models/PowerPointSlide.cs
+++ b/PowerPointLabs/PowerPointLabs/Models/PowerPointSlide.cs
@@ -686,19 +686,14 @@ namespace PowerPointLabs.Models
         public void TransferAnimation(Shape source, Shape destination)
         {
             Sequence sequence = _slide.TimeLine.MainSequence;
-            List<Effect> enumerableSequence = sequence.Cast<Effect>().ToList();
+            List<Effect> effectList = sequence.Cast<Effect>().ToList();
 
-            Effect entryDetails = enumerableSequence.FirstOrDefault(effect => effect.Shape.Equals(source));
-            if (entryDetails != null)
+            foreach (Effect effect in effectList)
             {
-                InsertAnimationAtIndex(destination, entryDetails.Index, entryDetails.EffectType, entryDetails.Timing.TriggerType);
-            }
-
-            Effect exitDetails = enumerableSequence.LastOrDefault(effect => effect.Shape.Equals(source));
-            if (exitDetails != null && !exitDetails.Equals(entryDetails))
-            {
-                InsertAnimationAtIndex(destination, exitDetails.Index, exitDetails.EffectType,
-                    exitDetails.Timing.TriggerType);
+                if (effect.Shape.Equals(source))
+                {
+                    InsertAnimationAtIndex(destination, effect.Index, effect.EffectType, effect.Timing.TriggerType, IsExitEffect(effect));
+                }
             }
         }
 
@@ -1300,11 +1295,17 @@ namespace PowerPointLabs.Models
         }
 
         private Effect InsertAnimationAtIndex(Shape shape, int index, MsoAnimEffect animationEffect,
-            MsoAnimTriggerType triggerType)
+            MsoAnimTriggerType triggerType, bool isExitEffect = false)
         {
             Sequence animationSequence = _slide.TimeLine.MainSequence;
             Effect effect = animationSequence.AddEffect(shape, animationEffect, MsoAnimateByLevel.msoAnimateLevelNone,
                 triggerType);
+
+            if (isExitEffect)
+            {
+                effect.Exit = MsoTriState.msoTrue;
+            }
+
             effect.MoveTo(index);
             return effect;
         }
@@ -1385,6 +1386,11 @@ namespace PowerPointLabs.Models
         private bool IsEntryEffect(Effect effect)
         {
             return effect.Exit == MsoTriState.msoFalse && entryEffects.Contains(effect.EffectType);
+        }
+
+        private bool IsExitEffect(Effect effect)
+        {
+            return effect.Exit == MsoTriState.msoTrue;
         }
     }
 }

--- a/PowerPointLabs/PowerPointLabs/PasteLab/ReplaceWithClipboard.cs
+++ b/PowerPointLabs/PowerPointLabs/PasteLab/ReplaceWithClipboard.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 
 using Microsoft.Office.Interop.PowerPoint;
 using PowerPointLabs.ActionFramework.Common.Extension;
@@ -39,6 +39,8 @@ namespace PowerPointLabs.PasteLab
 
                 slide.DeleteShapeAnimations(pastingShape);
                 slide.TransferAnimation(selectedShape, pastingShape);
+                // Must remove animations from source shape or else undo will fail
+                slide.RemoveAnimationsForShape(selectedShape);
 
                 if (pastingShape.IsPicture())
                 {

--- a/PowerPointLabs/PowerPointLabs/PasteLab/ReplaceWithClipboard.cs
+++ b/PowerPointLabs/PowerPointLabs/PasteLab/ReplaceWithClipboard.cs
@@ -15,7 +15,14 @@ namespace PowerPointLabs.PasteLab
         {
             // ignore height & width, it doesn't always make sense to sync the height & width especially for circles, squares
             List<Format> formatsToIgnore = new List<Format> {new PositionHeightFormat(), new PositionWidthFormat()};
-            
+
+            // the following effects are not useful for pictures and cause degradation of picture quality
+            List<Format> formatsToIgnoreIfPicture = new List<Format>
+            {
+                new ContourColorFormat(), new ContourWidthFormat(), new DepthSizeFormat(), new LightingAngleFormat(),
+                new MaterialEffectFormat(), new PositionHeightFormat(), new PositionWidthFormat(), new ThreeDRotationEffectFormat()
+            };
+
             // Replacing individual shape
             if (selectedChildShapes.Count == 0)
             {
@@ -32,7 +39,16 @@ namespace PowerPointLabs.PasteLab
 
                 slide.DeleteShapeAnimations(pastingShape);
                 slide.TransferAnimation(selectedShape, pastingShape);
-                ShapeUtil.ApplyAllPossibleFormats(selectedShape, pastingShape, formatsToIgnore);
+
+                if (pastingShape.IsPicture())
+                {
+                    ShapeUtil.ApplyAllPossibleFormats(selectedShape, pastingShape, formatsToIgnoreIfPicture);
+                }
+                else
+                {
+                    ShapeUtil.ApplyAllPossibleFormats(selectedShape, pastingShape, formatsToIgnore);
+                }
+
                 selectedShape.SafeDelete();
 
                 return slide.ToShapeRange(pastingShape);
@@ -74,10 +90,17 @@ namespace PowerPointLabs.PasteLab
 
                 List<Format> positionFormats = new List<Format> {new PositionXFormat(), new PositionYFormat()};
                 formatsToIgnore.AddRange(positionFormats);
-                
+
                 for (int i = 1; i <= pastingShapes.Count; i++)
                 {
-                    ShapeUtil.ApplyAllPossibleFormats(selectedChildShape, pastingShapes[i], formatsToIgnore);
+                    if (pastingShapes[i].IsPicture())
+                    {
+                        ShapeUtil.ApplyAllPossibleFormats(selectedChildShape, pastingShapes[i], formatsToIgnoreIfPicture);
+                    }
+                    else
+                    {
+                        ShapeUtil.ApplyAllPossibleFormats(selectedChildShape, pastingShapes[i], formatsToIgnore);
+                    }
                 }
 
                 // Remove selected child since it is being replaced

--- a/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Util/StoragePath.cs
+++ b/PowerPointLabs/PowerPointLabs/PictureSlidesLab/Util/StoragePath.cs
@@ -202,11 +202,11 @@ namespace PowerPointLabs.PictureSlidesLab.Util
         {
             try
             {
-                Resources.Loading.Save(LoadingImgPath);
-                Resources.ChoosePicturesIcon.Save(ChoosePicturesImgPath);
-                Resources.DefaultPicture.Save(NoPicturePlaceholderImgPath);
-                Resources.PslSample1.Save(SampleImg1Path);
-                Resources.PslSample2.Save(SampleImg2Path);
+                Properties.Resources.Loading.Save(LoadingImgPath);
+                Properties.Resources.ChoosePicturesIcon.Save(ChoosePicturesImgPath);
+                Properties.Resources.DefaultPicture.Save(NoPicturePlaceholderImgPath);
+                Properties.Resources.PslSample1.Save(SampleImg1Path);
+                Properties.Resources.PslSample2.Save(SampleImg2Path);
             }
             catch
             {

--- a/PowerPointLabs/PowerPointLabs/PositionsLab/PositionsPaneWPF.xaml
+++ b/PowerPointLabs/PowerPointLabs/PositionsLab/PositionsPaneWPF.xaml
@@ -1,14 +1,16 @@
-﻿<UserControl
-             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+﻿<UserControl xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:WPF="clr-namespace:PowerPointLabs.WPF" x:Class="PowerPointLabs.PositionsLab.PositionsPaneWpf"
+             xmlns:WPF="clr-namespace:PowerPointLabs.WPF"
+             xmlns:theme="clr-namespace:PowerPointLabs.ColorThemes"
+             x:Class="PowerPointLabs.PositionsLab.PositionsPaneWpf"
              mc:Ignorable="d" Height="725" Width="310"
              x:Name="positionLabPane" FocusVisualStyle="{x:Null}">
     <UserControl.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
+                <theme:DesignTheme Theme="Colorful"/>
                 <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Controls.xaml" />
                 <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Fonts.xaml" />
                 <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Colors.xaml" />
@@ -20,6 +22,9 @@
             </Style>
         </ResourceDictionary>
     </UserControl.Resources>
+    <UserControl.Background>
+        <DynamicResource ResourceKey="Theme.PaneBackgroundBrush"/>
+    </UserControl.Background>
     <UserControl.InputBindings>
         <KeyBinding Key="LeftCtrl"/>
     </UserControl.InputBindings>

--- a/PowerPointLabs/PowerPointLabs/PositionsLab/PositionsPaneWPF.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/PositionsLab/PositionsPaneWPF.xaml.cs
@@ -9,6 +9,7 @@ using Microsoft.Office.Interop.PowerPoint;
 
 using PowerPointLabs.ActionFramework.Common.Extension;
 using PowerPointLabs.ActionFramework.Common.Log;
+using PowerPointLabs.ColorThemes;
 using PowerPointLabs.ColorThemes.Extensions;
 using PowerPointLabs.PositionsLab.Views;
 using PowerPointLabs.TextCollection;
@@ -26,7 +27,7 @@ namespace PowerPointLabs.PositionsLab
     /// <summary>
     /// Interaction logic for PositionsPaneWPF.xaml
     /// </summary>
-    public partial class PositionsPaneWpf
+    public partial class PositionsPaneWpf : INotifyOnThemeChanged
     {
         private PositionsDistributeGridDialog _positionsDistributeGridDialog;
 
@@ -74,6 +75,33 @@ namespace PowerPointLabs.PositionsLab
         {
             ClearAllEventHandlers();
         }
+
+        #region INotifyOnThemeChanged Interface methods
+
+        /// <summary>
+        /// Changes the MahApps accent of this pane based on the Color Theme.
+        /// </summary>
+        /// <remarks>
+        /// The Steel accent will be used on all themes, except for the DarkGray
+        /// theme, which will use the Teal accent.
+        /// </remarks>
+        /// <param name="updatedColorTheme">The new color theme</param>
+        public void OnThemeChanged(ColorTheme updatedColorTheme)
+        {
+            // The Steel accent doesn't look good on the DarkGray background.
+            // The closest accent that looks okay is Teal.
+            switch (updatedColorTheme.ThemeId)
+            {
+                case ColorTheme.DARK_GRAY:
+                    ThemeExtensions.ChangeMahAppsAccent(this, "Teal");
+                    break;
+                default:
+                    ThemeExtensions.ChangeMahAppsAccent(this, "Steel");
+                    break;
+            }
+        }
+
+        #endregion
 
         private void InitializeHotKeys()
         {

--- a/PowerPointLabs/PowerPointLabs/PowerPointLabs.csproj
+++ b/PowerPointLabs/PowerPointLabs/PowerPointLabs.csproj
@@ -720,6 +720,7 @@
       <DependentUpon>ColorInformationDialog.xaml</DependentUpon>
     </Compile>
     <Compile Include="ColorTheme\ActionCommand.cs" />
+    <Compile Include="ELearningLab\Converters\ShapeNameWidthConverter.cs" />
     <Compile Include="Converters\ColorPane\HSLColorToHex.cs" />
     <Compile Include="Converters\ColorPane\SelectedColorShiftByAngle.cs" />
     <Compile Include="Converters\ColorPane\SelectedColorShiftSaturationByFactor.cs" />

--- a/PowerPointLabs/PowerPointLabs/PowerPointLabs.csproj
+++ b/PowerPointLabs/PowerPointLabs/PowerPointLabs.csproj
@@ -720,6 +720,9 @@
       <DependentUpon>ColorInformationDialog.xaml</DependentUpon>
     </Compile>
     <Compile Include="ColorTheme\ActionCommand.cs" />
+    <Compile Include="ColorTheme\BaseStylesDictionary.cs" />
+    <Compile Include="ColorTheme\INotifyOnThemeChanged.cs" />
+    <Compile Include="ColorTheme\ThemeResourceDictionary.cs" />
     <Compile Include="ELearningLab\Converters\ShapeNameWidthConverter.cs" />
     <Compile Include="Converters\ColorPane\HSLColorToHex.cs" />
     <Compile Include="Converters\ColorPane\SelectedColorShiftByAngle.cs" />
@@ -804,6 +807,7 @@
     <Compile Include="ELearningLab\Service\FunctionService\CaptionService.cs" />
     <Compile Include="ELearningLab\Service\ELearningService.cs" />
     <Compile Include="ELearningLab\Service\FunctionService\AudioService.cs" />
+    <Compile Include="ColorTheme\DesignTheme.cs" />
     <Compile Include="ShapesLab\Views\CustomComboBoxItem.cs" />
     <Compile Include="ShapesLab\Views\CustomMenuItem.cs" />
     <Compile Include="ShapesLab\Views\ShapesLabCategoryInfoDialogBox.xaml.cs">
@@ -1688,6 +1692,238 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="Resources\Themes\Black\BaseBlackColors.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Include="Resources\Themes\Black\CheckBoxColors.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Include="Resources\Themes\Black\HyperlinkColors.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Include="Resources\Themes\Black\ToolTipColors.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Include="Resources\Themes\Black\TextBlockColors.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Include="Resources\Themes\Black\WindowColors.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Include="Resources\Themes\Black\TreeViewColors.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Include="Resources\Themes\Black\TextBoxColors.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Include="Resources\Themes\Black\LabelColors.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Include="Resources\Themes\Black\ButtonColors.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Include="Resources\Themes\Black\BlackColors.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Include="Resources\Themes\Colorful\BaseColorfulColors.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Include="Resources\Themes\Colorful\ColorfulColors.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Include="Resources\Themes\Colorful\ButtonColors.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Include="Resources\Themes\Colorful\CheckBoxColors.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Include="Resources\Themes\Colorful\HyperlinkColors.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Include="Resources\Themes\Colorful\LabelColors.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Include="Resources\Themes\Colorful\TextBlockColors.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Include="Resources\Themes\Colorful\TextBoxColors.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Include="Resources\Themes\Colorful\ToolTipColors.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Include="Resources\Themes\Colorful\TreeViewColors.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Include="Resources\Themes\Colorful\WindowColors.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Include="Resources\Themes\DarkGray\BaseDarkGrayColors.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Include="Resources\Themes\DarkGray\CheckBoxColors.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Include="Resources\Themes\DarkGray\DarkGrayColors.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Include="Resources\Themes\DarkGray\ButtonColors.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Include="Resources\Themes\DarkGray\HyperlinkColors.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Include="Resources\Themes\DarkGray\LabelColors.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Include="Resources\Themes\DarkGray\TextBlockColors.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Include="Resources\Themes\DarkGray\TextBoxColors.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Include="Resources\Themes\DarkGray\ToolTipColors.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Include="Resources\Themes\DarkGray\TreeViewColors.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Include="Resources\Themes\DarkGray\WindowColors.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Include="Resources\Themes\TemplateStyles.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Include="Resources\Themes\TemplateStyles\HyperlinkStyle.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Include="Resources\Themes\TemplateStyles\ToolTipStyle.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Include="Resources\Themes\TemplateStyles\TextBlockStyle.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Include="Resources\Themes\TemplateStyles\CheckBoxStyle.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Include="Resources\Themes\TemplateStyles\WindowStyle.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Include="Resources\Themes\TemplateStyles\TreeViewStyle.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Include="Resources\Themes\TemplateStyles\TextBoxStyle.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Include="Resources\Themes\TemplateStyles\LabelStyle.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Include="Resources\Themes\TemplateStyles\ButtonStyle.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Include="Resources\Themes\WhiteTheme.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Include="Resources\Themes\DarkGrayTheme.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Include="Resources\Themes\BlackTheme.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Include="Resources\Themes\ColorfulTheme.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="Resources\Themes\White\BaseWhiteColors.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Include="Resources\Themes\White\ButtonColors.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Include="Resources\Themes\White\CheckBoxColors.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Include="Resources\Themes\White\HyperlinkColors.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Include="Resources\Themes\White\LabelColors.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Include="Resources\Themes\White\TextBlockColors.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Include="Resources\Themes\White\TextBoxColors.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Include="Resources\Themes\White\ToolTipColors.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Include="Resources\Themes\White\TreeViewColors.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Include="Resources\Themes\White\WhiteColors.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Include="Resources\Themes\White\WindowColors.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
     <Page Include="SaveLab\Views\SaveLabSettingsDialogBox.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
@@ -2366,6 +2602,7 @@
   <ItemGroup>
     <None Include="Resources\Animation Zoom.png" />
   </ItemGroup>
+  <ItemGroup />
   <!-- Include the build rules for a C# project. -->
   <PropertyGroup>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>

--- a/PowerPointLabs/PowerPointLabs/PowerPointLabs.csproj
+++ b/PowerPointLabs/PowerPointLabs/PowerPointLabs.csproj
@@ -45,7 +45,7 @@
     <PublishUrl>C:\publish_online\</PublishUrl>
     <InstallUrl>https://www.comp.nus.edu.sg/~pptlabs/download/dev/</InstallUrl>
     <TargetCulture>en</TargetCulture>
-    <ApplicationVersion>6.0.0.1</ApplicationVersion>
+    <ApplicationVersion>6.1.0.0</ApplicationVersion>
     <AutoIncrementApplicationRevision>false</AutoIncrementApplicationRevision>
     <UpdateEnabled>true</UpdateEnabled>
     <UpdateInterval>0</UpdateInterval>

--- a/PowerPointLabs/PowerPointLabs/Properties/Settings.Designer.cs
+++ b/PowerPointLabs/PowerPointLabs/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace PowerPointLabs.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "15.9.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.4.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
@@ -61,7 +61,7 @@ namespace PowerPointLabs.Properties {
         
         [global::System.Configuration.ApplicationScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("6.0.0.1")]
+        [global::System.Configuration.DefaultSettingValueAttribute("6.1.0.0")]
         public string Version {
             get {
                 return ((string)(this["Version"]));
@@ -70,7 +70,7 @@ namespace PowerPointLabs.Properties {
         
         [global::System.Configuration.ApplicationScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("2 August 2019")]
+        [global::System.Configuration.DefaultSettingValueAttribute("8 May 2020")]
         public string ReleaseDate {
             get {
                 return ((string)(this["ReleaseDate"]));

--- a/PowerPointLabs/PowerPointLabs/Properties/Settings.settings
+++ b/PowerPointLabs/PowerPointLabs/Properties/Settings.settings
@@ -15,10 +15,10 @@
       <Value Profile="(Default)">https://www.comp.nus.edu.sg/~pptlabs/download/dev/</Value>
     </Setting>
     <Setting Name="Version" Type="System.String" Scope="Application">
-      <Value Profile="(Default)">6.0.0.1</Value>
+      <Value Profile="(Default)">6.1.0.0</Value>
     </Setting>
     <Setting Name="ReleaseDate" Type="System.String" Scope="Application">
-      <Value Profile="(Default)">2 August 2019</Value>
+      <Value Profile="(Default)">8 May 2020</Value>
     </Setting>
   </Settings>
 </SettingsFile>

--- a/PowerPointLabs/PowerPointLabs/ResizeLab/ResizeLabPaneWPF.xaml
+++ b/PowerPointLabs/PowerPointLabs/ResizeLab/ResizeLabPaneWPF.xaml
@@ -1,10 +1,10 @@
-﻿<UserControl
-             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+﻿<UserControl xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              xmlns:cc="clr-namespace:PowerPointLabs.WPF"
              xmlns:resizeLab="clr-namespace:PowerPointLabs.ResizeLab"
+             xmlns:theme="clr-namespace:PowerPointLabs.ColorThemes"
              x:Class="PowerPointLabs.ResizeLab.ResizeLabPaneWPF"
              mc:Ignorable="d" 
              d:DesignHeight="1030" d:DesignWidth="300" 
@@ -12,6 +12,7 @@
     <UserControl.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
+                <theme:DesignTheme Theme="Colorful"/>
                 <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Controls.xaml" />
                 <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Fonts.xaml" />
                 <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Colors.xaml" />
@@ -20,6 +21,9 @@
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
     </UserControl.Resources>
+    <UserControl.Background>
+        <DynamicResource ResourceKey="Theme.PaneBackgroundBrush"/>
+    </UserControl.Background>
     <UserControl.InputBindings>
         <KeyBinding Key="LeftCtrl"/>
     </UserControl.InputBindings>

--- a/PowerPointLabs/PowerPointLabs/ResizeLab/ResizeLabPaneWPF.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/ResizeLab/ResizeLabPaneWPF.xaml.cs
@@ -6,6 +6,7 @@ using System.Windows.Controls;
 using System.Windows.Input;
 
 using PowerPointLabs.ActionFramework.Common.Extension;
+using PowerPointLabs.ColorThemes;
 using PowerPointLabs.ColorThemes.Extensions;
 using PowerPointLabs.ResizeLab.Views;
 
@@ -16,7 +17,7 @@ namespace PowerPointLabs.ResizeLab
     /// <summary>
     /// Interaction logic for ResizePane.xaml
     /// </summary>
-    public partial class ResizeLabPaneWPF : IResizeLabPane
+    public partial class ResizeLabPaneWPF : IResizeLabPane, INotifyOnThemeChanged
     {
         private ResizeLabMain _resizeLab;
         private readonly ResizeLabErrorHandler _errorHandler;
@@ -47,6 +48,33 @@ namespace PowerPointLabs.ResizeLab
             
             Focusable = true;
         }
+
+        #region INotifyOnThemeChanged Interface methods
+
+        /// <summary>
+        /// Changes the MahApps accent of this pane based on the Color Theme.
+        /// </summary>
+        /// <remarks>
+        /// The Steel accent will be used on all themes, except for the DarkGray
+        /// theme, which will use the Teal accent.
+        /// </remarks>
+        /// <param name="updatedColorTheme">The new color theme</param>
+        public void OnThemeChanged(ColorTheme updatedColorTheme)
+        {
+            // The Steel accent doesn't look good on the DarkGray background.
+            // The closest accent that looks okay is Teal.
+            switch (updatedColorTheme.ThemeId)
+            {
+                case ColorTheme.DARK_GRAY:
+                    ThemeExtensions.ChangeMahAppsAccent(this, "Teal");
+                    break;
+                default:
+                    ThemeExtensions.ChangeMahAppsAccent(this, "Steel");
+                    break;
+            }
+        }
+
+        #endregion
 
         #region Initialise
         internal void InitialiseLogicInstance()

--- a/PowerPointLabs/PowerPointLabs/Resources/Themes/Black/BaseBlackColors.xaml
+++ b/PowerPointLabs/PowerPointLabs/Resources/Themes/Black/BaseBlackColors.xaml
@@ -1,0 +1,21 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <!-- This is the default background colour of a Pane. -->
+    <Color x:Key="Theme.PaneBackground">#FF262626</Color>
+    
+    <Color x:Key="Theme.Background1">#FF212121</Color>
+    <Color x:Key="Theme.Background2">#FF363636</Color>
+    <Color x:Key="Theme.Background3">#FF4A4A4A</Color>
+    
+    <Color x:Key="Theme.Foreground">#FFFFFFFF</Color>
+
+    <SolidColorBrush x:Key="Theme.PaneBackgroundBrush" Color="{StaticResource Theme.PaneBackground}"/>
+
+    <SolidColorBrush x:Key="Theme.BackgroundBrush1" Color="{StaticResource Theme.Background1}"/>
+    <SolidColorBrush x:Key="Theme.BackgroundBrush2" Color="{StaticResource Theme.Background2}"/>
+    <SolidColorBrush x:Key="Theme.BackgroundBrush3" Color="{StaticResource Theme.Background3}"/>
+
+    <SolidColorBrush x:Key="Theme.ForegroundBrush" Color="{StaticResource Theme.Foreground}"/>
+
+</ResourceDictionary> 

--- a/PowerPointLabs/PowerPointLabs/Resources/Themes/Black/BlackColors.xaml
+++ b/PowerPointLabs/PowerPointLabs/Resources/Themes/Black/BlackColors.xaml
@@ -1,0 +1,18 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <ResourceDictionary.MergedDictionaries>
+        <ResourceDictionary Source="BaseBlackColors.xaml"/>
+
+        <ResourceDictionary Source="ButtonColors.xaml"/>
+        <ResourceDictionary Source="CheckBoxColors.xaml"/>
+        <ResourceDictionary Source="LabelColors.xaml"/>
+        <ResourceDictionary Source="HyperlinkColors.xaml"/>
+        <ResourceDictionary Source="TextBlockColors.xaml"/>
+        <ResourceDictionary Source="TextBoxColors.xaml"/>
+        <ResourceDictionary Source="ToolTipColors.xaml"/>
+        <ResourceDictionary Source="TreeViewColors.xaml"/>
+        <ResourceDictionary Source="WindowColors.xaml"/>
+    </ResourceDictionary.MergedDictionaries>
+
+</ResourceDictionary>

--- a/PowerPointLabs/PowerPointLabs/Resources/Themes/Black/ButtonColors.xaml
+++ b/PowerPointLabs/PowerPointLabs/Resources/Themes/Black/ButtonColors.xaml
@@ -1,0 +1,15 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <SolidColorBrush x:Key="Button.Static.Background" Color="#FF444444"/>
+    <SolidColorBrush x:Key="Button.Static.Border" Color="#FF6A6A6A"/>
+    <SolidColorBrush x:Key="Button.Static.Foreground" Color="#FFFFFFFF"/>
+    <SolidColorBrush x:Key="Button.MouseOver.Background" Color="#FF444444"/>
+    <SolidColorBrush x:Key="Button.MouseOver.Border" Color="#FF969696"/>
+    <SolidColorBrush x:Key="Button.Pressed.Background" Color="#FF6A6A6A"/>
+    <SolidColorBrush x:Key="Button.Pressed.Border" Color="#FF969696"/>
+    <SolidColorBrush x:Key="Button.Disabled.Background" Color="#FF252525"/>
+    <SolidColorBrush x:Key="Button.Disabled.Border" Color="#FF444444"/>
+    <SolidColorBrush x:Key="Button.Disabled.Foreground" Color="#FF495A52"/>
+    
+</ResourceDictionary>

--- a/PowerPointLabs/PowerPointLabs/Resources/Themes/Black/CheckBoxColors.xaml
+++ b/PowerPointLabs/PowerPointLabs/Resources/Themes/Black/CheckBoxColors.xaml
@@ -1,0 +1,26 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <ResourceDictionary.MergedDictionaries>
+        <ResourceDictionary Source="BaseBlackColors.xaml"/>
+    </ResourceDictionary.MergedDictionaries>
+
+    <SolidColorBrush x:Key="OptionMark.Static.Background" Color="#FF444444"/>
+    <SolidColorBrush x:Key="OptionMark.Static.Border" Color="#FF9E9E9E"/>
+    <SolidColorBrush x:Key="OptionMark.Static.Glyph" Color="#FFFFFFFF"/>
+    
+    <SolidColorBrush x:Key="OptionMark.MouseOver.Background" Color="#FF6A6A6A"/>
+    <SolidColorBrush x:Key="OptionMark.MouseOver.Border" Color="#FFAEAEAE"/>
+    <SolidColorBrush x:Key="OptionMark.MouseOver.Glyph" Color="#FFFFFFFF"/>
+    
+    <SolidColorBrush x:Key="OptionMark.Disabled.Background" Color="#FF252525"/>
+    <SolidColorBrush x:Key="OptionMark.Disabled.Border" Color="#FF444444"/>
+    <SolidColorBrush x:Key="OptionMark.Disabled.Glyph" Color="#FF444444"/>
+    
+    <SolidColorBrush x:Key="OptionMark.Pressed.Background" Color="#FFAEAEAE"/>
+    <SolidColorBrush x:Key="OptionMark.Pressed.Border" Color="#FFAEAEAE"/>
+    <SolidColorBrush x:Key="OptionMark.Pressed.Glyph" Color="#FFFFFFFF"/>
+    
+    <SolidColorBrush x:Key="CheckBox.Static.Foreground" Color="{StaticResource Theme.Foreground}"/>
+
+</ResourceDictionary>

--- a/PowerPointLabs/PowerPointLabs/Resources/Themes/Black/HyperlinkColors.xaml
+++ b/PowerPointLabs/PowerPointLabs/Resources/Themes/Black/HyperlinkColors.xaml
@@ -1,0 +1,8 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <SolidColorBrush x:Key="Hyperlink.Static.Foreground" Color="#3CA4FF"/>
+    <SolidColorBrush x:Key="Hyperlink.MouseOver.Foreground" Color="#FF378AD4"/>
+    <SolidColorBrush x:Key="Hyperlink.Disabled.Foreground" Color="#FFAAAAAA"/>
+
+</ResourceDictionary>

--- a/PowerPointLabs/PowerPointLabs/Resources/Themes/Black/LabelColors.xaml
+++ b/PowerPointLabs/PowerPointLabs/Resources/Themes/Black/LabelColors.xaml
@@ -1,0 +1,10 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <ResourceDictionary.MergedDictionaries>
+        <ResourceDictionary Source="BaseBlackColors.xaml"/>
+    </ResourceDictionary.MergedDictionaries>
+
+    <SolidColorBrush x:Key="Label.Static.Foreground" Color="{StaticResource Theme.Foreground}"/>
+
+</ResourceDictionary> 

--- a/PowerPointLabs/PowerPointLabs/Resources/Themes/Black/TextBlockColors.xaml
+++ b/PowerPointLabs/PowerPointLabs/Resources/Themes/Black/TextBlockColors.xaml
@@ -1,0 +1,10 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <ResourceDictionary.MergedDictionaries>
+        <ResourceDictionary Source="BaseBlackColors.xaml"/>
+    </ResourceDictionary.MergedDictionaries>
+
+    <SolidColorBrush x:Key="TextBlock.Static.Foreground" Color="{StaticResource Theme.Foreground}"/>
+
+</ResourceDictionary>

--- a/PowerPointLabs/PowerPointLabs/Resources/Themes/Black/TextBoxColors.xaml
+++ b/PowerPointLabs/PowerPointLabs/Resources/Themes/Black/TextBoxColors.xaml
@@ -1,0 +1,17 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <ResourceDictionary.MergedDictionaries>
+        <ResourceDictionary Source="BaseBlackColors.xaml"/>
+    </ResourceDictionary.MergedDictionaries>
+
+    <SolidColorBrush x:Key="TextBox.Static.Background" Color="#FF444444"/>
+    <SolidColorBrush x:Key="TextBox.Static.Border" Color="#FF686868"/>
+    <SolidColorBrush x:Key="TextBox.Static.Foreground" Color="{StaticResource Theme.Foreground}"/>
+    <SolidColorBrush x:Key="TextBox.Static.CaretBrush" Color="{StaticResource Theme.Foreground}"/>
+    <SolidColorBrush x:Key="TextBox.MouseOver.Background" Color="#FF333337"/>
+    <SolidColorBrush x:Key="TextBox.MouseOver.Border" Color="#FFB5B5B5"/>
+    <SolidColorBrush x:Key="TextBox.Focus.Border" Color="#FF569DE5"/>
+    
+</ResourceDictionary>
+    

--- a/PowerPointLabs/PowerPointLabs/Resources/Themes/Black/ToolTipColors.xaml
+++ b/PowerPointLabs/PowerPointLabs/Resources/Themes/Black/ToolTipColors.xaml
@@ -1,0 +1,12 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <ResourceDictionary.MergedDictionaries>
+        <ResourceDictionary Source="BaseBlackColors.xaml"/>
+    </ResourceDictionary.MergedDictionaries>
+
+    <SolidColorBrush x:Key="ToolTip.Static.Background" Color="#FF424245"/>
+    <SolidColorBrush x:Key="ToolTip.Static.Foreground" Color="{StaticResource Theme.Foreground}"/>
+    <SolidColorBrush x:Key="ToolTip.Static.BorderBrush" Color="#FF4D4D50"/>
+
+</ResourceDictionary>

--- a/PowerPointLabs/PowerPointLabs/Resources/Themes/Black/TreeViewColors.xaml
+++ b/PowerPointLabs/PowerPointLabs/Resources/Themes/Black/TreeViewColors.xaml
@@ -1,0 +1,11 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <ResourceDictionary.MergedDictionaries>
+        <ResourceDictionary Source="BaseBlackColors.xaml"/>
+    </ResourceDictionary.MergedDictionaries>
+
+    <SolidColorBrush x:Key="TreeView.Static.Background" Color="{StaticResource Theme.Background2}"/>
+    <SolidColorBrush x:Key="TreeView.Static.Border" Color="#FF828790"/>
+    
+</ResourceDictionary>

--- a/PowerPointLabs/PowerPointLabs/Resources/Themes/Black/WindowColors.xaml
+++ b/PowerPointLabs/PowerPointLabs/Resources/Themes/Black/WindowColors.xaml
@@ -1,0 +1,10 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <ResourceDictionary.MergedDictionaries>
+        <ResourceDictionary Source="BaseBlackColors.xaml"/>
+    </ResourceDictionary.MergedDictionaries>
+
+    <SolidColorBrush x:Key="Window.Static.Background" Color="{StaticResource Theme.Background1}"/>
+    
+</ResourceDictionary>

--- a/PowerPointLabs/PowerPointLabs/Resources/Themes/BlackTheme.xaml
+++ b/PowerPointLabs/PowerPointLabs/Resources/Themes/BlackTheme.xaml
@@ -1,0 +1,9 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <ResourceDictionary.MergedDictionaries>
+        <ResourceDictionary Source="Black/BlackColors.xaml"/>
+        <ResourceDictionary Source="TemplateStyles.xaml"/>
+    </ResourceDictionary.MergedDictionaries>
+
+</ResourceDictionary> 

--- a/PowerPointLabs/PowerPointLabs/Resources/Themes/Colorful/BaseColorfulColors.xaml
+++ b/PowerPointLabs/PowerPointLabs/Resources/Themes/Colorful/BaseColorfulColors.xaml
@@ -1,0 +1,21 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <!-- This is the default background colour of a Pane. -->
+    <Color x:Key="Theme.PaneBackground">#FFE6E6E6</Color>
+
+    <Color x:Key="Theme.Background1">#FFFFFFFF</Color>
+    <Color x:Key="Theme.Background2">#FFFFFFFF</Color>
+    <Color x:Key="Theme.Background3">#FFEBEBEB</Color>
+
+    <Color x:Key="Theme.Foreground">#FF000000</Color>
+
+    <SolidColorBrush x:Key="Theme.PaneBackgroundBrush" Color="{StaticResource Theme.PaneBackground}"/>
+
+    <SolidColorBrush x:Key="Theme.BackgroundBrush1" Color="{StaticResource Theme.Background1}"/>
+    <SolidColorBrush x:Key="Theme.BackgroundBrush2" Color="{StaticResource Theme.Background2}"/>
+    <SolidColorBrush x:Key="Theme.BackgroundBrush3" Color="{StaticResource Theme.Background3}"/>
+
+    <SolidColorBrush x:Key="Theme.ForegroundBrush" Color="{StaticResource Theme.Foreground}"/>
+
+</ResourceDictionary>

--- a/PowerPointLabs/PowerPointLabs/Resources/Themes/Colorful/ButtonColors.xaml
+++ b/PowerPointLabs/PowerPointLabs/Resources/Themes/Colorful/ButtonColors.xaml
@@ -1,0 +1,15 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <SolidColorBrush x:Key="Button.Static.Background" Color="#FFFFFFFF"/>
+    <SolidColorBrush x:Key="Button.Static.Border" Color="#FF969696"/>
+    <SolidColorBrush x:Key="Button.Static.Foreground" Color="#FF000000"/>
+    <SolidColorBrush x:Key="Button.MouseOver.Background" Color="#FFFDC9B5"/>
+    <SolidColorBrush x:Key="Button.MouseOver.Border" Color="#FFE86E58"/>
+    <SolidColorBrush x:Key="Button.Pressed.Background" Color="#FFED9583"/>
+    <SolidColorBrush x:Key="Button.Pressed.Border" Color="#FFC75033"/>
+    <SolidColorBrush x:Key="Button.Disabled.Background" Color="#FFFDFDFD"/>
+    <SolidColorBrush x:Key="Button.Disabled.Border" Color="#FFE1E1E1"/>
+    <SolidColorBrush x:Key="Button.Disabled.Foreground" Color="#FFCCB1BF"/>
+    
+</ResourceDictionary>

--- a/PowerPointLabs/PowerPointLabs/Resources/Themes/Colorful/CheckBoxColors.xaml
+++ b/PowerPointLabs/PowerPointLabs/Resources/Themes/Colorful/CheckBoxColors.xaml
@@ -1,0 +1,26 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <ResourceDictionary.MergedDictionaries>
+        <ResourceDictionary Source="BaseColorfulColors.xaml"/>
+    </ResourceDictionary.MergedDictionaries>
+
+    <SolidColorBrush x:Key="OptionMark.Static.Background" Color="#FFFDFDFD"/>
+    <SolidColorBrush x:Key="OptionMark.Static.Border" Color="#FFABABAB"/>
+    <SolidColorBrush x:Key="OptionMark.Static.Glyph" Color="#FF7D7D7D"/>
+    
+    <SolidColorBrush x:Key="OptionMark.MouseOver.Background" Color="#FFFCE4DC"/>
+    <SolidColorBrush x:Key="OptionMark.MouseOver.Border" Color="#FFF5BA9D"/>
+    <SolidColorBrush x:Key="OptionMark.MouseOver.Glyph" Color="#FF3B3B3B"/>
+    
+    <SolidColorBrush x:Key="OptionMark.Disabled.Background" Color="#FFFDFDFD"/>
+    <SolidColorBrush x:Key="OptionMark.Disabled.Border" Color="#FFC6C6C6"/>
+    <SolidColorBrush x:Key="OptionMark.Disabled.Glyph" Color="#FFC6C6C6"/>
+    
+    <SolidColorBrush x:Key="OptionMark.Pressed.Background" Color="#FFF5BA9D"/>
+    <SolidColorBrush x:Key="OptionMark.Pressed.Border" Color="#FFF5BA9D"/>
+    <SolidColorBrush x:Key="OptionMark.Pressed.Glyph" Color="#FF000000"/>
+    
+    <SolidColorBrush x:Key="CheckBox.Static.Foreground" Color="{StaticResource Theme.Foreground}"/>
+
+</ResourceDictionary>

--- a/PowerPointLabs/PowerPointLabs/Resources/Themes/Colorful/ColorfulColors.xaml
+++ b/PowerPointLabs/PowerPointLabs/Resources/Themes/Colorful/ColorfulColors.xaml
@@ -1,0 +1,18 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <ResourceDictionary.MergedDictionaries>
+        <ResourceDictionary Source="BaseColorfulColors.xaml"/>
+        
+        <ResourceDictionary Source="ButtonColors.xaml"/>
+        <ResourceDictionary Source="CheckBoxColors.xaml"/>
+        <ResourceDictionary Source="HyperlinkColors.xaml"/>
+        <ResourceDictionary Source="LabelColors.xaml"/>
+        <ResourceDictionary Source="TextBlockColors.xaml"/>
+        <ResourceDictionary Source="TextBoxColors.xaml"/>
+        <ResourceDictionary Source="ToolTipColors.xaml"/>
+        <ResourceDictionary Source="TreeViewColors.xaml"/>
+        <ResourceDictionary Source="WindowColors.xaml"/>
+    </ResourceDictionary.MergedDictionaries>
+
+</ResourceDictionary>

--- a/PowerPointLabs/PowerPointLabs/Resources/Themes/Colorful/HyperlinkColors.xaml
+++ b/PowerPointLabs/PowerPointLabs/Resources/Themes/Colorful/HyperlinkColors.xaml
@@ -1,0 +1,8 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <SolidColorBrush x:Key="Hyperlink.Static.Foreground" Color="#FF0000FF"/>
+    <SolidColorBrush x:Key="Hyperlink.MouseOver.Foreground" Color="#FFFF0000"/>
+    <SolidColorBrush x:Key="Hyperlink.Disabled.Foreground" Color="#FFAAAAAA"/>
+
+</ResourceDictionary> 

--- a/PowerPointLabs/PowerPointLabs/Resources/Themes/Colorful/LabelColors.xaml
+++ b/PowerPointLabs/PowerPointLabs/Resources/Themes/Colorful/LabelColors.xaml
@@ -1,0 +1,10 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <ResourceDictionary.MergedDictionaries>
+        <ResourceDictionary Source="BaseColorfulColors.xaml"/>
+    </ResourceDictionary.MergedDictionaries>
+    
+    <SolidColorBrush x:Key="Label.Static.Foreground" Color="{StaticResource Theme.Foreground}"/>
+
+</ResourceDictionary>

--- a/PowerPointLabs/PowerPointLabs/Resources/Themes/Colorful/TextBlockColors.xaml
+++ b/PowerPointLabs/PowerPointLabs/Resources/Themes/Colorful/TextBlockColors.xaml
@@ -1,0 +1,10 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <ResourceDictionary.MergedDictionaries>
+        <ResourceDictionary Source="BaseColorfulColors.xaml"/>
+    </ResourceDictionary.MergedDictionaries>
+
+    <SolidColorBrush x:Key="TextBlock.Static.Foreground" Color="{StaticResource Theme.Foreground}"/>
+
+</ResourceDictionary>

--- a/PowerPointLabs/PowerPointLabs/Resources/Themes/Colorful/TextBoxColors.xaml
+++ b/PowerPointLabs/PowerPointLabs/Resources/Themes/Colorful/TextBoxColors.xaml
@@ -1,0 +1,16 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <ResourceDictionary.MergedDictionaries>
+        <ResourceDictionary Source="BaseColorfulColors.xaml"/>
+    </ResourceDictionary.MergedDictionaries>
+
+    <SolidColorBrush x:Key="TextBox.Static.Background" Color="White"/>
+    <SolidColorBrush x:Key="TextBox.Static.Border" Color="#FFABABAB"/>
+    <SolidColorBrush x:Key="TextBox.Static.Foreground" Color="{StaticResource Theme.Foreground}"/>
+    <SolidColorBrush x:Key="TextBox.Static.CaretBrush" Color="{StaticResource Theme.Foreground}"/>
+    <SolidColorBrush x:Key="TextBox.MouseOver.Background" Color="White"/>
+    <SolidColorBrush x:Key="TextBox.MouseOver.Border" Color="#FFF5BA9D"/>
+    <SolidColorBrush x:Key="TextBox.Focus.Border" Color="#FFDC5939"/>
+    
+</ResourceDictionary>

--- a/PowerPointLabs/PowerPointLabs/Resources/Themes/Colorful/ToolTipColors.xaml
+++ b/PowerPointLabs/PowerPointLabs/Resources/Themes/Colorful/ToolTipColors.xaml
@@ -1,0 +1,12 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <ResourceDictionary.MergedDictionaries>
+        <ResourceDictionary Source="BaseColorfulColors.xaml"/>
+    </ResourceDictionary.MergedDictionaries>
+
+    <SolidColorBrush x:Key="ToolTip.Static.Background" Color="#FFFFFFFF"/>
+    <SolidColorBrush x:Key="ToolTip.Static.Foreground" Color="{StaticResource Theme.Foreground}"/>
+    <SolidColorBrush x:Key="ToolTip.Static.BorderBrush" Color="#FFBEBEBE"/>
+
+</ResourceDictionary>

--- a/PowerPointLabs/PowerPointLabs/Resources/Themes/Colorful/TreeViewColors.xaml
+++ b/PowerPointLabs/PowerPointLabs/Resources/Themes/Colorful/TreeViewColors.xaml
@@ -1,0 +1,7 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <SolidColorBrush x:Key="TreeView.Static.Background" Color="White"/>
+    <SolidColorBrush x:Key="TreeView.Static.Border" Color="#FFABABAB"/>
+    
+</ResourceDictionary>

--- a/PowerPointLabs/PowerPointLabs/Resources/Themes/Colorful/WindowColors.xaml
+++ b/PowerPointLabs/PowerPointLabs/Resources/Themes/Colorful/WindowColors.xaml
@@ -1,0 +1,6 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <SolidColorBrush x:Key="Window.Static.Background" Color="White"/>
+    
+</ResourceDictionary>

--- a/PowerPointLabs/PowerPointLabs/Resources/Themes/ColorfulTheme.xaml
+++ b/PowerPointLabs/PowerPointLabs/Resources/Themes/ColorfulTheme.xaml
@@ -1,0 +1,9 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <ResourceDictionary.MergedDictionaries>
+        <ResourceDictionary Source="Colorful/ColorfulColors.xaml"/>
+        <ResourceDictionary Source="TemplateStyles.xaml"/>
+    </ResourceDictionary.MergedDictionaries>
+
+</ResourceDictionary>

--- a/PowerPointLabs/PowerPointLabs/Resources/Themes/DarkGray/BaseDarkGrayColors.xaml
+++ b/PowerPointLabs/PowerPointLabs/Resources/Themes/DarkGray/BaseDarkGrayColors.xaml
@@ -1,0 +1,21 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    
+    <!-- This is the default background colour of a Pane. -->
+    <Color x:Key="Theme.PaneBackground">#FF666666</Color>
+
+    <Color x:Key="Theme.Background1">#FF666666</Color>
+    <Color x:Key="Theme.Background2">#FF444444</Color>
+    <Color x:Key="Theme.Background3">#FF4A4A4A</Color>
+
+    <Color x:Key="Theme.Foreground">#FFFFFFFF</Color>
+
+    <SolidColorBrush x:Key="Theme.PaneBackgroundBrush" Color="{StaticResource Theme.PaneBackground}"/>
+
+    <SolidColorBrush x:Key="Theme.BackgroundBrush1" Color="{StaticResource Theme.Background1}"/>
+    <SolidColorBrush x:Key="Theme.BackgroundBrush2" Color="{StaticResource Theme.Background2}"/>
+    <SolidColorBrush x:Key="Theme.BackgroundBrush3" Color="{StaticResource Theme.Background3}"/>
+
+    <SolidColorBrush x:Key="Theme.ForegroundBrush" Color="{StaticResource Theme.Foreground}"/>
+
+</ResourceDictionary>

--- a/PowerPointLabs/PowerPointLabs/Resources/Themes/DarkGray/ButtonColors.xaml
+++ b/PowerPointLabs/PowerPointLabs/Resources/Themes/DarkGray/ButtonColors.xaml
@@ -1,0 +1,15 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <SolidColorBrush x:Key="Button.Static.Background" Color="#FF444444"/>
+    <SolidColorBrush x:Key="Button.Static.Border" Color="#FF808080"/>
+    <SolidColorBrush x:Key="Button.Static.Foreground" Color="#FFFFFFFF"/>
+    <SolidColorBrush x:Key="Button.MouseOver.Background" Color="#FF363636"/>
+    <SolidColorBrush x:Key="Button.MouseOver.Border" Color="#FFB1B1B1"/>
+    <SolidColorBrush x:Key="Button.Pressed.Background" Color="#FF262626"/>
+    <SolidColorBrush x:Key="Button.Pressed.Border" Color="#FF262626"/>
+    <SolidColorBrush x:Key="Button.Disabled.Background" Color="#FF252525"/>
+    <SolidColorBrush x:Key="Button.Disabled.Border" Color="#FF444444"/>
+    <SolidColorBrush x:Key="Button.Disabled.Foreground" Color="#FF495A52"/>
+    
+</ResourceDictionary>

--- a/PowerPointLabs/PowerPointLabs/Resources/Themes/DarkGray/CheckBoxColors.xaml
+++ b/PowerPointLabs/PowerPointLabs/Resources/Themes/DarkGray/CheckBoxColors.xaml
@@ -1,0 +1,26 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <ResourceDictionary.MergedDictionaries>
+        <ResourceDictionary Source="BaseDarkGrayColors.xaml"/>
+    </ResourceDictionary.MergedDictionaries>
+
+    <SolidColorBrush x:Key="OptionMark.Static.Background" Color="#FF444444"/>
+    <SolidColorBrush x:Key="OptionMark.Static.Border" Color="#FF262626"/>
+    <SolidColorBrush x:Key="OptionMark.Static.Glyph" Color="#FFF0F0F0"/>
+    
+    <SolidColorBrush x:Key="OptionMark.MouseOver.Background" Color="#FFD24726"/>
+    <SolidColorBrush x:Key="OptionMark.MouseOver.Border" Color="#FF262626"/>
+    <SolidColorBrush x:Key="OptionMark.MouseOver.Glyph" Color="#FFF0F0F0"/>
+    
+    <SolidColorBrush x:Key="OptionMark.Disabled.Background" Color="#FF6A6A6A"/>
+    <SolidColorBrush x:Key="OptionMark.Disabled.Border" Color="#FF444444"/>
+    <SolidColorBrush x:Key="OptionMark.Disabled.Glyph" Color="#FF444444"/>
+    
+    <SolidColorBrush x:Key="OptionMark.Pressed.Background" Color="#FFB83B1D"/>
+    <SolidColorBrush x:Key="OptionMark.Pressed.Border" Color="#FFB83B1D"/>
+    <SolidColorBrush x:Key="OptionMark.Pressed.Glyph" Color="#FFF0F0F0"/>
+    
+    <SolidColorBrush x:Key="CheckBox.Static.Foreground" Color="{StaticResource Theme.Foreground}"/>
+
+</ResourceDictionary>

--- a/PowerPointLabs/PowerPointLabs/Resources/Themes/DarkGray/DarkGrayColors.xaml
+++ b/PowerPointLabs/PowerPointLabs/Resources/Themes/DarkGray/DarkGrayColors.xaml
@@ -1,0 +1,18 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <ResourceDictionary.MergedDictionaries>
+        <ResourceDictionary Source="BaseDarkGrayColors.xaml"/>
+
+        <ResourceDictionary Source="ButtonColors.xaml"/>
+        <ResourceDictionary Source="CheckBoxColors.xaml"/>
+        <ResourceDictionary Source="HyperlinkColors.xaml"/>
+        <ResourceDictionary Source="LabelColors.xaml"/>
+        <ResourceDictionary Source="TextBlockColors.xaml"/>
+        <ResourceDictionary Source="TextBoxColors.xaml"/>
+        <ResourceDictionary Source="ToolTipColors.xaml"/>
+        <ResourceDictionary Source="TreeViewColors.xaml"/>
+        <ResourceDictionary Source="WindowColors.xaml"/>
+    </ResourceDictionary.MergedDictionaries>
+
+</ResourceDictionary>

--- a/PowerPointLabs/PowerPointLabs/Resources/Themes/DarkGray/HyperlinkColors.xaml
+++ b/PowerPointLabs/PowerPointLabs/Resources/Themes/DarkGray/HyperlinkColors.xaml
@@ -1,0 +1,8 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <SolidColorBrush x:Key="Hyperlink.Static.Foreground" Color="#FF93CDFF"/>
+    <SolidColorBrush x:Key="Hyperlink.MouseOver.Foreground" Color="#FF378AD4"/>
+    <SolidColorBrush x:Key="Hyperlink.Disabled.Foreground" Color="#FFAAAAAA"/>
+
+</ResourceDictionary>

--- a/PowerPointLabs/PowerPointLabs/Resources/Themes/DarkGray/LabelColors.xaml
+++ b/PowerPointLabs/PowerPointLabs/Resources/Themes/DarkGray/LabelColors.xaml
@@ -1,0 +1,10 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <ResourceDictionary.MergedDictionaries>
+        <ResourceDictionary Source="BaseDarkGrayColors.xaml"/>
+    </ResourceDictionary.MergedDictionaries>
+
+    <SolidColorBrush x:Key="Label.Static.Foreground" Color="{StaticResource Theme.Foreground}"/>
+
+</ResourceDictionary>

--- a/PowerPointLabs/PowerPointLabs/Resources/Themes/DarkGray/TextBlockColors.xaml
+++ b/PowerPointLabs/PowerPointLabs/Resources/Themes/DarkGray/TextBlockColors.xaml
@@ -1,0 +1,10 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <ResourceDictionary.MergedDictionaries>
+        <ResourceDictionary Source="BaseDarkGrayColors.xaml"/>
+    </ResourceDictionary.MergedDictionaries>
+
+    <SolidColorBrush x:Key="TextBlock.Static.Foreground" Color="{StaticResource Theme.Foreground}"/>
+
+</ResourceDictionary>

--- a/PowerPointLabs/PowerPointLabs/Resources/Themes/DarkGray/TextBoxColors.xaml
+++ b/PowerPointLabs/PowerPointLabs/Resources/Themes/DarkGray/TextBoxColors.xaml
@@ -1,0 +1,16 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <ResourceDictionary.MergedDictionaries>
+        <ResourceDictionary Source="BaseDarkGrayColors.xaml"/>
+    </ResourceDictionary.MergedDictionaries>
+
+    <SolidColorBrush x:Key="TextBox.Static.Background" Color="#FF444444"/>
+    <SolidColorBrush x:Key="TextBox.Static.Border" Color="#FF686868"/>
+    <SolidColorBrush x:Key="TextBox.Static.Foreground" Color="{StaticResource Theme.Foreground}"/>
+    <SolidColorBrush x:Key="TextBox.Static.CaretBrush" Color="{StaticResource Theme.Foreground}"/>
+    <SolidColorBrush x:Key="TextBox.MouseOver.Background" Color="#FF333337"/>
+    <SolidColorBrush x:Key="TextBox.MouseOver.Border" Color="#FFB5B5B5"/>
+    <SolidColorBrush x:Key="TextBox.Focus.Border" Color="#FF569DE5"/>
+
+</ResourceDictionary>

--- a/PowerPointLabs/PowerPointLabs/Resources/Themes/DarkGray/ToolTipColors.xaml
+++ b/PowerPointLabs/PowerPointLabs/Resources/Themes/DarkGray/ToolTipColors.xaml
@@ -1,0 +1,12 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <ResourceDictionary.MergedDictionaries>
+        <ResourceDictionary Source="BaseDarkGrayColors.xaml"/>
+    </ResourceDictionary.MergedDictionaries>
+
+    <SolidColorBrush x:Key="ToolTip.Static.Background" Color="#FFF0F0F0"/>
+    <SolidColorBrush x:Key="ToolTip.Static.Foreground" Color="#FF000000"/>
+    <SolidColorBrush x:Key="ToolTip.Static.BorderBrush" Color="#FFBEBEBE"/>
+
+</ResourceDictionary>

--- a/PowerPointLabs/PowerPointLabs/Resources/Themes/DarkGray/TreeViewColors.xaml
+++ b/PowerPointLabs/PowerPointLabs/Resources/Themes/DarkGray/TreeViewColors.xaml
@@ -1,0 +1,11 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <ResourceDictionary.MergedDictionaries>
+        <ResourceDictionary Source="BaseDarkGrayColors.xaml"/>
+    </ResourceDictionary.MergedDictionaries>
+
+    <SolidColorBrush x:Key="TreeView.Static.Background" Color="{StaticResource Theme.Background2}"/>
+    <SolidColorBrush x:Key="TreeView.Static.Border" Color="#FF828790"/>
+
+</ResourceDictionary>

--- a/PowerPointLabs/PowerPointLabs/Resources/Themes/DarkGray/WindowColors.xaml
+++ b/PowerPointLabs/PowerPointLabs/Resources/Themes/DarkGray/WindowColors.xaml
@@ -1,0 +1,10 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <ResourceDictionary.MergedDictionaries>
+        <ResourceDictionary Source="BaseDarkGrayColors.xaml"/>
+    </ResourceDictionary.MergedDictionaries>
+
+    <SolidColorBrush x:Key="Window.Static.Background" Color="{StaticResource Theme.Background1}"/>
+
+</ResourceDictionary>

--- a/PowerPointLabs/PowerPointLabs/Resources/Themes/DarkGrayTheme.xaml
+++ b/PowerPointLabs/PowerPointLabs/Resources/Themes/DarkGrayTheme.xaml
@@ -1,0 +1,9 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <ResourceDictionary.MergedDictionaries>
+        <ResourceDictionary Source="DarkGray/DarkGrayColors.xaml"/>
+        <ResourceDictionary Source="TemplateStyles.xaml"/>
+    </ResourceDictionary.MergedDictionaries>
+
+</ResourceDictionary>

--- a/PowerPointLabs/PowerPointLabs/Resources/Themes/TemplateStyles.xaml
+++ b/PowerPointLabs/PowerPointLabs/Resources/Themes/TemplateStyles.xaml
@@ -1,0 +1,23 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <!-- 
+        The TemplateStyles Resource Dictionary contains the Styles of different 
+        controls, such as Button or Label, but without the properties related to
+        color, such as Background or Foreground. Instead, they are obtained as
+        DynamicResources from other ResourceDictionaries, linked together by the
+        respective Theme.xaml files.
+    -->
+    <ResourceDictionary.MergedDictionaries>
+        <ResourceDictionary Source="TemplateStyles/ButtonStyle.xaml"/>
+        <ResourceDictionary Source="TemplateStyles/CheckBoxStyle.xaml"/>
+        <ResourceDictionary Source="TemplateStyles/HyperlinkStyle.xaml"/>
+        <ResourceDictionary Source="TemplateStyles/LabelStyle.xaml"/>
+        <ResourceDictionary Source="TemplateStyles/TextBlockStyle.xaml"/>
+        <ResourceDictionary Source="TemplateStyles/TextBoxStyle.xaml"/>
+        <ResourceDictionary Source="TemplateStyles/ToolTipStyle.xaml"/>
+        <ResourceDictionary Source="TemplateStyles/TreeViewStyle.xaml"/>
+        <ResourceDictionary Source="TemplateStyles/WindowStyle.xaml"/>
+    </ResourceDictionary.MergedDictionaries>
+
+</ResourceDictionary>

--- a/PowerPointLabs/PowerPointLabs/Resources/Themes/TemplateStyles/ButtonStyle.xaml
+++ b/PowerPointLabs/PowerPointLabs/Resources/Themes/TemplateStyles/ButtonStyle.xaml
@@ -1,0 +1,67 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <!-- 
+    List of colors to define:
+    - Button.Static.Background
+    - Button.Static.Border
+    - Button.Static.Foreground
+    - Button.MouseOver.Background
+    - Button.MouseOver.Border
+    - Button.Pressed.Background
+    - Button.Pressed.Border
+    - Button.Disabled.Background
+    - Button.Disabled.Border
+    - Button.Disabled.Foreground
+    -->
+
+    <!-- This style has a Key so that it can be referenced. -->
+    <Style TargetType="{x:Type Button}"
+           x:Key="BaseButtonStyle">
+        <Setter Property="Background" Value="{DynamicResource Button.Static.Background}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource Button.Static.Border}"/>
+        <Setter Property="Foreground" Value="{DynamicResource Button.Static.Foreground}"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type Button}">
+                    <Border x:Name="border" 
+                            BorderBrush="{TemplateBinding BorderBrush}" 
+                            BorderThickness="{TemplateBinding BorderThickness}" 
+                            Background="{TemplateBinding Background}" 
+                            SnapsToDevicePixels="true">
+                        <ContentPresenter x:Name="contentPresenter" 
+                                          Focusable="False" 
+                                          HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" 
+                                          Margin="{TemplateBinding Padding}" 
+                                          RecognizesAccessKey="True"
+                                          SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" 
+                                          VerticalAlignment="{TemplateBinding VerticalContentAlignment}"/>
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsDefaulted" Value="true">
+                            <Setter Property="BorderBrush" TargetName="border" Value="{DynamicResource {x:Static SystemColors.HighlightBrushKey}}"/>
+                        </Trigger>
+                        <Trigger Property="IsMouseOver" Value="true">
+                            <Setter Property="Background" TargetName="border" Value="{DynamicResource Button.MouseOver.Background}"/>
+                            <Setter Property="BorderBrush" TargetName="border" Value="{DynamicResource Button.MouseOver.Border}"/>
+                        </Trigger>
+                        <Trigger Property="IsPressed" Value="true">
+                            <Setter Property="Background" TargetName="border" Value="{DynamicResource Button.Pressed.Background}"/>
+                            <Setter Property="BorderBrush" TargetName="border" Value="{DynamicResource Button.Pressed.Border}"/>
+                        </Trigger>
+                        <Trigger Property="IsEnabled" Value="false">
+                            <Setter Property="Background" TargetName="border" Value="{DynamicResource Button.Disabled.Background}"/>
+                            <Setter Property="BorderBrush" TargetName="border" Value="{DynamicResource Button.Disabled.Border}"/>
+                            <Setter Property="TextElement.Foreground" TargetName="contentPresenter" Value="{DynamicResource Button.Disabled.Foreground}"/>
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <!-- This Style has no Key, so it will be applied to all Buttons by default. -->
+    <Style TargetType="{x:Type Button}"
+           BasedOn="{StaticResource BaseButtonStyle}"/>
+
+</ResourceDictionary>

--- a/PowerPointLabs/PowerPointLabs/Resources/Themes/TemplateStyles/CheckBoxStyle.xaml
+++ b/PowerPointLabs/PowerPointLabs/Resources/Themes/TemplateStyles/CheckBoxStyle.xaml
@@ -1,0 +1,94 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <!-- 
+    List of colors to define:
+    - OptionMark.Static.Background
+    - OptionMark.Static.Border
+    - OptionMark.Static.Glyph
+    - OptionMark.MouseOver.Background
+    - OptionMark.MouseOver.Border
+    - OptionMark.MouseOver.Glyph    
+    - OptionMark.Disabled.Background
+    - OptionMark.Disabled.Border
+    - OptionMark.Disabled.Glyph
+    - OptionMark.Pressed.Background
+    - OptionMark.Pressed.Border
+    - OptionMark.Pressed.Glyph
+    - CheckBox.Static.Foreground
+    -->
+    
+    <Style x:Key="OptionMarkFocusVisual">
+        <Setter Property="Control.Template">
+            <Setter.Value>
+                <ControlTemplate>
+                    <Rectangle Margin="14,0,0,0" SnapsToDevicePixels="true" Stroke="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}" StrokeThickness="1" StrokeDashArray="1 2"/>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <!-- This style has a Key so that it can be referenced. -->
+    <Style TargetType="{x:Type CheckBox}"
+           x:Key="BaseCheckBoxStyle">
+        <Setter Property="Background" Value="{DynamicResource OptionMark.Static.Background}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource OptionMark.Static.Border}"/>
+        <Setter Property="Foreground" Value="{DynamicResource CheckBox.Static.Foreground}"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type CheckBox}">
+                    <Grid x:Name="templateRoot" Background="Transparent" SnapsToDevicePixels="True">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="*"/>
+                        </Grid.ColumnDefinitions>
+                        <Border x:Name="checkBoxBorder" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" Margin="1" VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
+                            <Grid x:Name="markGrid">
+                                <Path x:Name="optionMark" Data="F1 M 9.97498,1.22334L 4.6983,9.09834L 4.52164,9.09834L 0,5.19331L 1.27664,3.52165L 4.255,6.08833L 8.33331,1.52588e-005L 9.97498,1.22334 Z " Fill="{DynamicResource OptionMark.Static.Glyph}" Margin="1" Opacity="0" Stretch="None"/>
+                                <Rectangle x:Name="indeterminateMark" Fill="{DynamicResource OptionMark.Static.Glyph}" Margin="2" Opacity="0"/>
+                            </Grid>
+                        </Border>
+                        <ContentPresenter x:Name="contentPresenter" Grid.Column="1" Focusable="False" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" Margin="{TemplateBinding Padding}" RecognizesAccessKey="True" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}"/>
+                    </Grid>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="HasContent" Value="true">
+                            <Setter Property="FocusVisualStyle" Value="{StaticResource OptionMarkFocusVisual}"/>
+                            <Setter Property="Padding" Value="4,-1,0,0"/>
+                        </Trigger>
+                        <Trigger Property="IsMouseOver" Value="true">
+                            <Setter Property="Background" TargetName="checkBoxBorder" Value="{DynamicResource OptionMark.MouseOver.Background}"/>
+                            <Setter Property="BorderBrush" TargetName="checkBoxBorder" Value="{DynamicResource OptionMark.MouseOver.Border}"/>
+                            <Setter Property="Fill" TargetName="optionMark" Value="{DynamicResource OptionMark.MouseOver.Glyph}"/>
+                            <Setter Property="Fill" TargetName="indeterminateMark" Value="{DynamicResource OptionMark.MouseOver.Glyph}"/>
+                        </Trigger>
+                        <Trigger Property="IsEnabled" Value="false">
+                            <Setter Property="Background" TargetName="checkBoxBorder" Value="{DynamicResource OptionMark.Disabled.Background}"/>
+                            <Setter Property="BorderBrush" TargetName="checkBoxBorder" Value="{DynamicResource OptionMark.Disabled.Border}"/>
+                            <Setter Property="Fill" TargetName="optionMark" Value="{DynamicResource OptionMark.Disabled.Glyph}"/>
+                            <Setter Property="Fill" TargetName="indeterminateMark" Value="{DynamicResource OptionMark.Disabled.Glyph}"/>
+                        </Trigger>
+                        <Trigger Property="IsPressed" Value="true">
+                            <Setter Property="Background" TargetName="checkBoxBorder" Value="{DynamicResource OptionMark.Pressed.Background}"/>
+                            <Setter Property="BorderBrush" TargetName="checkBoxBorder" Value="{DynamicResource OptionMark.Pressed.Border}"/>
+                            <Setter Property="Fill" TargetName="optionMark" Value="{DynamicResource OptionMark.Pressed.Glyph}"/>
+                            <Setter Property="Fill" TargetName="indeterminateMark" Value="{DynamicResource OptionMark.Pressed.Glyph}"/>
+                        </Trigger>
+                        <Trigger Property="IsChecked" Value="true">
+                            <Setter Property="Opacity" TargetName="optionMark" Value="1"/>
+                            <Setter Property="Opacity" TargetName="indeterminateMark" Value="0"/>
+                        </Trigger>
+                        <Trigger Property="IsChecked" Value="{x:Null}">
+                            <Setter Property="Opacity" TargetName="optionMark" Value="0"/>
+                            <Setter Property="Opacity" TargetName="indeterminateMark" Value="1"/>
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <!-- This Style has no Key, so it will be applied to all CheckBoxes by default. -->
+    <Style TargetType="{x:Type CheckBox}"
+           BasedOn="{StaticResource BaseCheckBoxStyle}"/>
+
+</ResourceDictionary>

--- a/PowerPointLabs/PowerPointLabs/Resources/Themes/TemplateStyles/HyperlinkStyle.xaml
+++ b/PowerPointLabs/PowerPointLabs/Resources/Themes/TemplateStyles/HyperlinkStyle.xaml
@@ -1,0 +1,32 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    
+    <!-- 
+    List of colors to define:
+    - Hyperlink.Static.Foreground
+    - Hyperlink.MouseOver.Foreground
+    - Hyperlink.Disabled.Foreground
+    -->
+
+    <!-- This style has a Key so that it can be referenced. -->
+    <Style x:Key="BaseHyperlinkStyle" TargetType="{x:Type Hyperlink}">
+        <Style.Triggers>
+            <Trigger Property="IsMouseOver" Value="true">
+                <Setter Property="Foreground" Value="{DynamicResource Hyperlink.MouseOver.Foreground}" />
+            </Trigger>
+            <Trigger Property="IsEnabled" Value="false">
+                <Setter Property="Foreground" Value="{DynamicResource Hyperlink.Disabled.Foreground}" />
+            </Trigger>
+            <Trigger Property="IsEnabled" Value="true">
+                <Setter Property="Cursor" Value="Hand" />
+            </Trigger>
+        </Style.Triggers>
+        <Setter Property="Foreground" Value="{DynamicResource Hyperlink.Static.Foreground}" />
+        <Setter Property="TextDecorations" Value="Underline" />
+    </Style>
+
+    <!-- This Style has no Key, so it will be applied to all Hyperlinks by default. -->
+    <Style TargetType="{x:Type Hyperlink}"
+           BasedOn="{StaticResource BaseHyperlinkStyle}"/>
+
+</ResourceDictionary> 

--- a/PowerPointLabs/PowerPointLabs/Resources/Themes/TemplateStyles/LabelStyle.xaml
+++ b/PowerPointLabs/PowerPointLabs/Resources/Themes/TemplateStyles/LabelStyle.xaml
@@ -1,0 +1,29 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    
+    <!-- 
+    List of colors to define:
+    - Label.Static.Foreground
+    -->
+
+    <!-- This style has a Key so that it can be referenced. -->
+    <Style TargetType="{x:Type Label}"
+           x:Key="BaseLabelStyle">
+        <!-- 
+        If the content is text, the content presenter will be a TextBlock, which will
+        use the BaseTextBlock style defined in TextBlockStyle.xaml, which will use the
+        Foreground set in the style instead of the Foreground set here, or whatever was
+        set by the user. Hence, this empty Style is here for the TextBlock to use so that
+        the Foreground property does not get overwritten.
+        -->
+        <Style.Resources>
+            <Style TargetType="TextBlock"/>
+        </Style.Resources>
+        <Setter Property="Foreground" Value="{DynamicResource Label.Static.Foreground}"/>
+    </Style>
+
+    <!-- This Style has no Key, so it will be applied to all Labels by default. -->
+    <Style TargetType="{x:Type Label}"
+           BasedOn="{StaticResource BaseLabelStyle}"/>
+
+</ResourceDictionary> 

--- a/PowerPointLabs/PowerPointLabs/Resources/Themes/TemplateStyles/TextBlockStyle.xaml
+++ b/PowerPointLabs/PowerPointLabs/Resources/Themes/TemplateStyles/TextBlockStyle.xaml
@@ -1,0 +1,19 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <!-- 
+    List of colors to define:
+    - TextBlock.Static.Foreground
+    -->
+
+    <!-- This style has a Key so that it can be referenced. -->
+    <Style TargetType="{x:Type TextBlock}"
+           x:Key="BaseTextBlockStyle">
+        <Setter Property="Foreground" Value="{DynamicResource TextBlock.Static.Foreground}"/>
+    </Style>
+
+    <!-- This Style has no Key, so it will be applied to all TextBlocks by default. -->
+    <Style TargetType="{x:Type TextBlock}"
+           BasedOn="{StaticResource BaseTextBlockStyle}"/>
+
+</ResourceDictionary>

--- a/PowerPointLabs/PowerPointLabs/Resources/Themes/TemplateStyles/TextBoxStyle.xaml
+++ b/PowerPointLabs/PowerPointLabs/Resources/Themes/TemplateStyles/TextBoxStyle.xaml
@@ -1,0 +1,47 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <!-- 
+    List of colors to define:
+    - TextBox.Static.Background
+    - TextBox.Static.Border
+    - TextBox.Static.Foreground
+    - TextBox.Static.CaretBrush
+    - TextBox.MouseOver.Border
+    - TextBox.Focus.Border
+    -->
+
+    <!-- This style has a Key so that it can be referenced. -->
+    <Style TargetType="{x:Type TextBox}"
+           x:Key="BaseTextBoxStyle">
+        <Setter Property="Background" Value="{DynamicResource TextBox.Static.Background}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource TextBox.Static.Border}"/>
+        <Setter Property="Foreground" Value="{DynamicResource TextBox.Static.Foreground}"/>
+        <Setter Property="CaretBrush" Value="{DynamicResource TextBox.Static.CaretBrush}"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type TextBox}">
+                    <Border x:Name="border" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}" SnapsToDevicePixels="True">
+                        <ScrollViewer x:Name="PART_ContentHost" Focusable="false" HorizontalScrollBarVisibility="Hidden" VerticalScrollBarVisibility="Hidden"/>
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsEnabled" Value="false">
+                            <Setter Property="Opacity" TargetName="border" Value="0.56"/>
+                        </Trigger>
+                        <Trigger Property="IsMouseOver" Value="true">
+                            <Setter Property="BorderBrush" TargetName="border" Value="{DynamicResource TextBox.MouseOver.Border}"/>
+                        </Trigger>
+                        <Trigger Property="IsKeyboardFocused" Value="true">
+                            <Setter Property="BorderBrush" TargetName="border" Value="{DynamicResource TextBox.Focus.Border}"/>
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <!-- This Style has no Key, so it will be applied to all TextBoxes by default. -->
+    <Style TargetType="{x:Type TextBox}"
+           BasedOn="{StaticResource BaseTextBoxStyle}"/>
+
+</ResourceDictionary>

--- a/PowerPointLabs/PowerPointLabs/Resources/Themes/TemplateStyles/ToolTipStyle.xaml
+++ b/PowerPointLabs/PowerPointLabs/Resources/Themes/TemplateStyles/ToolTipStyle.xaml
@@ -1,0 +1,31 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <!-- 
+    List of colors to define:
+    - ToolTip.Static.Background
+    - ToolTip.Static.Foreground
+    - ToolTip.Static.BorderBrush
+    -->
+
+    <!-- This style has a Key so that it can be referenced. -->
+    <Style TargetType="{x:Type ToolTip}"
+           x:Key="BaseToolTipStyle">
+        <!-- 
+        The text element of a ToolTip is a TextBlock, and the default style of a TextBlock (as defined
+        in TextBlockStyle.xaml) will be applied. Hence, this empty style is here to be used by TextBlocks
+        so that it does not overwrite the Foreground property.
+        -->
+        <Style.Resources>
+            <Style TargetType="TextBlock"/>
+        </Style.Resources>
+        <Setter Property="Foreground" Value="{DynamicResource ToolTip.Static.Foreground}"/>
+        <Setter Property="Background" Value="{DynamicResource ToolTip.Static.Background}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource ToolTip.Static.BorderBrush}"/>
+    </Style>
+
+    <!-- This Style has no Key, so it will be applied to all TextBlocks by default. -->
+    <Style TargetType="{x:Type ToolTip}"
+           BasedOn="{StaticResource BaseToolTipStyle}"/>
+
+</ResourceDictionary>

--- a/PowerPointLabs/PowerPointLabs/Resources/Themes/TemplateStyles/TreeViewStyle.xaml
+++ b/PowerPointLabs/PowerPointLabs/Resources/Themes/TemplateStyles/TreeViewStyle.xaml
@@ -1,0 +1,21 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <!-- 
+    List of colors to define:
+    - TreeView.Static.Background
+    - TreeView.Static.Border
+    -->
+
+    <!-- This style has a Key so that it can be referenced. -->
+    <Style TargetType="{x:Type TreeView}"
+           x:Key="BaseTreeViewStyle">
+        <Setter Property="Background" Value="{DynamicResource TreeView.Static.Background}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource TreeView.Static.Border}"/>
+    </Style>
+
+    <!-- This Style has no Key, so it will be applied to all TreeViews by default. -->
+    <Style TargetType="{x:Type TreeView}"
+           BasedOn="{StaticResource BaseTreeViewStyle}"/>
+
+</ResourceDictionary>

--- a/PowerPointLabs/PowerPointLabs/Resources/Themes/TemplateStyles/WindowStyle.xaml
+++ b/PowerPointLabs/PowerPointLabs/Resources/Themes/TemplateStyles/WindowStyle.xaml
@@ -1,0 +1,19 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <!-- 
+    List of colors to define:
+    - Window.Static.Background
+    -->
+
+    <!-- This style has a Key so that it can be referenced. -->
+    <Style TargetType="{x:Type Window}"
+           x:Key="BaseWindowStyle">
+        <Setter Property="Background" Value="{DynamicResource Window.Static.Background}"/>
+    </Style>
+
+    <!-- This Style has no Key, so it will be applied to all Windows by default. -->
+    <Style TargetType="{x:Type Window}"
+           BasedOn="{StaticResource BaseWindowStyle}"/>
+
+</ResourceDictionary>

--- a/PowerPointLabs/PowerPointLabs/Resources/Themes/White/BaseWhiteColors.xaml
+++ b/PowerPointLabs/PowerPointLabs/Resources/Themes/White/BaseWhiteColors.xaml
@@ -1,0 +1,21 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <!-- This is the default background colour of a Pane. -->
+    <Color x:Key="Theme.PaneBackground">#FFFFFFFF</Color>
+
+    <Color x:Key="Theme.Background1">#FFFFFFFF</Color>
+    <Color x:Key="Theme.Background2">#FFFFFFFF</Color>
+    <Color x:Key="Theme.Background3">#FFEBEBEB</Color>
+
+    <Color x:Key="Theme.Foreground">#FF000000</Color>
+
+    <SolidColorBrush x:Key="Theme.PaneBackgroundBrush" Color="{StaticResource Theme.PaneBackground}"/>
+
+    <SolidColorBrush x:Key="Theme.BackgroundBrush1" Color="{StaticResource Theme.Background1}"/>
+    <SolidColorBrush x:Key="Theme.BackgroundBrush2" Color="{StaticResource Theme.Background2}"/>
+    <SolidColorBrush x:Key="Theme.BackgroundBrush3" Color="{StaticResource Theme.Background3}"/>
+
+    <SolidColorBrush x:Key="Theme.ForegroundBrush" Color="{StaticResource Theme.Foreground}"/>
+
+</ResourceDictionary>

--- a/PowerPointLabs/PowerPointLabs/Resources/Themes/White/ButtonColors.xaml
+++ b/PowerPointLabs/PowerPointLabs/Resources/Themes/White/ButtonColors.xaml
@@ -1,0 +1,15 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <SolidColorBrush x:Key="Button.Static.Background" Color="#FFFDFDFD"/>
+    <SolidColorBrush x:Key="Button.Static.Border" Color="#FFABABAB"/>
+    <SolidColorBrush x:Key="Button.Static.Foreground" Color="#FF252525"/>
+    <SolidColorBrush x:Key="Button.MouseOver.Background" Color="#FFFCE4DC"/>
+    <SolidColorBrush x:Key="Button.MouseOver.Border" Color="#FF969696"/>
+    <SolidColorBrush x:Key="Button.Pressed.Background" Color="#FFF5BA9D"/>
+    <SolidColorBrush x:Key="Button.Pressed.Border" Color="#FF2C628B"/>
+    <SolidColorBrush x:Key="Button.Disabled.Background" Color="#FFF4F4F4"/>
+    <SolidColorBrush x:Key="Button.Disabled.Border" Color="#FFADB2B5"/>
+    <SolidColorBrush x:Key="Button.Disabled.Foreground" Color="#FF838383"/>
+
+</ResourceDictionary>

--- a/PowerPointLabs/PowerPointLabs/Resources/Themes/White/CheckBoxColors.xaml
+++ b/PowerPointLabs/PowerPointLabs/Resources/Themes/White/CheckBoxColors.xaml
@@ -1,0 +1,26 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <ResourceDictionary.MergedDictionaries>
+        <ResourceDictionary Source="BaseWhiteColors.xaml"/>
+    </ResourceDictionary.MergedDictionaries>
+
+    <SolidColorBrush x:Key="OptionMark.Static.Background" Color="#FFFDFDFD"/>
+    <SolidColorBrush x:Key="OptionMark.Static.Border" Color="#FFABABAB"/>
+    <SolidColorBrush x:Key="OptionMark.Static.Glyph" Color="#FF7D7D7D"/>
+
+    <SolidColorBrush x:Key="OptionMark.MouseOver.Background" Color="#FFFCE4DC"/>
+    <SolidColorBrush x:Key="OptionMark.MouseOver.Border" Color="#FFF5BA9D"/>
+    <SolidColorBrush x:Key="OptionMark.MouseOver.Glyph" Color="#FF3B3B3B"/>
+
+    <SolidColorBrush x:Key="OptionMark.Disabled.Background" Color="#FFFDFDFD"/>
+    <SolidColorBrush x:Key="OptionMark.Disabled.Border" Color="#FFC6C6C6"/>
+    <SolidColorBrush x:Key="OptionMark.Disabled.Glyph" Color="#FFC6C6C6"/>
+
+    <SolidColorBrush x:Key="OptionMark.Pressed.Background" Color="#FFF5BA9D"/>
+    <SolidColorBrush x:Key="OptionMark.Pressed.Border" Color="#FFF5BA9D"/>
+    <SolidColorBrush x:Key="OptionMark.Pressed.Glyph" Color="#FF000000"/>
+
+    <SolidColorBrush x:Key="CheckBox.Static.Foreground" Color="{StaticResource Theme.Foreground}"/>
+
+</ResourceDictionary>

--- a/PowerPointLabs/PowerPointLabs/Resources/Themes/White/HyperlinkColors.xaml
+++ b/PowerPointLabs/PowerPointLabs/Resources/Themes/White/HyperlinkColors.xaml
@@ -1,0 +1,8 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <SolidColorBrush x:Key="Hyperlink.Static.Foreground" Color="#FF0000FF"/>
+    <SolidColorBrush x:Key="Hyperlink.MouseOver.Foreground" Color="#FFFF0000"/>
+    <SolidColorBrush x:Key="Hyperlink.Disabled.Foreground" Color="#FFAAAAAA"/>
+
+</ResourceDictionary>

--- a/PowerPointLabs/PowerPointLabs/Resources/Themes/White/LabelColors.xaml
+++ b/PowerPointLabs/PowerPointLabs/Resources/Themes/White/LabelColors.xaml
@@ -1,0 +1,10 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <ResourceDictionary.MergedDictionaries>
+        <ResourceDictionary Source="BaseWhiteColors.xaml"/>
+    </ResourceDictionary.MergedDictionaries>
+
+    <SolidColorBrush x:Key="Label.Static.Foreground" Color="{StaticResource Theme.Foreground}"/>
+
+</ResourceDictionary>

--- a/PowerPointLabs/PowerPointLabs/Resources/Themes/White/TextBlockColors.xaml
+++ b/PowerPointLabs/PowerPointLabs/Resources/Themes/White/TextBlockColors.xaml
@@ -1,0 +1,10 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <ResourceDictionary.MergedDictionaries>
+        <ResourceDictionary Source="BaseWhiteColors.xaml"/>
+    </ResourceDictionary.MergedDictionaries>
+
+    <SolidColorBrush x:Key="TextBlock.Static.Foreground" Color="{StaticResource Theme.Foreground}"/>
+
+</ResourceDictionary>

--- a/PowerPointLabs/PowerPointLabs/Resources/Themes/White/TextBoxColors.xaml
+++ b/PowerPointLabs/PowerPointLabs/Resources/Themes/White/TextBoxColors.xaml
@@ -1,0 +1,16 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <ResourceDictionary.MergedDictionaries>
+        <ResourceDictionary Source="BaseWhiteColors.xaml"/>
+    </ResourceDictionary.MergedDictionaries>
+
+    <SolidColorBrush x:Key="TextBox.Static.Background" Color="White"/>
+    <SolidColorBrush x:Key="TextBox.Static.Border" Color="#FFABABAB"/>
+    <SolidColorBrush x:Key="TextBox.Static.Foreground" Color="{StaticResource Theme.Foreground}"/>
+    <SolidColorBrush x:Key="TextBox.Static.CaretBrush" Color="{StaticResource Theme.Foreground}"/>
+    <SolidColorBrush x:Key="TextBox.MouseOver.Background" Color="White"/>
+    <SolidColorBrush x:Key="TextBox.MouseOver.Border" Color="#FFF5BA9D"/>
+    <SolidColorBrush x:Key="TextBox.Focus.Border" Color="#FFDC5939"/>
+
+</ResourceDictionary>

--- a/PowerPointLabs/PowerPointLabs/Resources/Themes/White/ToolTipColors.xaml
+++ b/PowerPointLabs/PowerPointLabs/Resources/Themes/White/ToolTipColors.xaml
@@ -1,0 +1,12 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <ResourceDictionary.MergedDictionaries>
+        <ResourceDictionary Source="BaseWhiteColors.xaml"/>
+    </ResourceDictionary.MergedDictionaries>
+
+    <SolidColorBrush x:Key="ToolTip.Static.Background" Color="#FFFFFFFF"/>
+    <SolidColorBrush x:Key="ToolTip.Static.Foreground" Color="{StaticResource Theme.Foreground}"/>
+    <SolidColorBrush x:Key="ToolTip.Static.BorderBrush" Color="#FFBEBEBE"/>
+
+</ResourceDictionary>

--- a/PowerPointLabs/PowerPointLabs/Resources/Themes/White/TreeViewColors.xaml
+++ b/PowerPointLabs/PowerPointLabs/Resources/Themes/White/TreeViewColors.xaml
@@ -1,0 +1,7 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <SolidColorBrush x:Key="TreeView.Static.Background" Color="White"/>
+    <SolidColorBrush x:Key="TreeView.Static.Border" Color="#FFABABAB"/>
+
+</ResourceDictionary>

--- a/PowerPointLabs/PowerPointLabs/Resources/Themes/White/WhiteColors.xaml
+++ b/PowerPointLabs/PowerPointLabs/Resources/Themes/White/WhiteColors.xaml
@@ -1,0 +1,18 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <ResourceDictionary.MergedDictionaries>
+        <ResourceDictionary Source="BaseWhiteColors.xaml"/>
+
+        <ResourceDictionary Source="ButtonColors.xaml"/>
+        <ResourceDictionary Source="CheckBoxColors.xaml"/>
+        <ResourceDictionary Source="HyperlinkColors.xaml"/>
+        <ResourceDictionary Source="LabelColors.xaml"/>
+        <ResourceDictionary Source="TextBlockColors.xaml"/>
+        <ResourceDictionary Source="TextBoxColors.xaml"/>
+        <ResourceDictionary Source="ToolTipColors.xaml"/>
+        <ResourceDictionary Source="TreeViewColors.xaml"/>
+        <ResourceDictionary Source="WindowColors.xaml"/>
+    </ResourceDictionary.MergedDictionaries>
+
+</ResourceDictionary>

--- a/PowerPointLabs/PowerPointLabs/Resources/Themes/White/WindowColors.xaml
+++ b/PowerPointLabs/PowerPointLabs/Resources/Themes/White/WindowColors.xaml
@@ -1,0 +1,6 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <SolidColorBrush x:Key="Window.Static.Background" Color="White"/>
+
+</ResourceDictionary>

--- a/PowerPointLabs/PowerPointLabs/Resources/Themes/WhiteTHeme.xaml
+++ b/PowerPointLabs/PowerPointLabs/Resources/Themes/WhiteTHeme.xaml
@@ -1,0 +1,9 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <ResourceDictionary.MergedDictionaries>
+        <ResourceDictionary Source="White/WhiteColors.xaml"/>
+        <ResourceDictionary Source="TemplateStyles.xaml"/>
+    </ResourceDictionary.MergedDictionaries>
+
+</ResourceDictionary>

--- a/PowerPointLabs/PowerPointLabs/ShapesLab/Views/CustomShapePaneWPF.xaml
+++ b/PowerPointLabs/PowerPointLabs/ShapesLab/Views/CustomShapePaneWPF.xaml
@@ -3,10 +3,22 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:theme="clr-namespace:PowerPointLabs.ColorThemes"
              mc:Ignorable="d" 
              d:DesignHeight="833" d:DesignWidth="300"
              MouseDown="ClickOutsideShapeList"
              Loaded="CustomShapePaneWPF_Loaded">
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <theme:DesignTheme Theme="DarkGray"/>
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </UserControl.Resources>
+    <UserControl.Background>
+        <DynamicResource ResourceKey="Theme.PaneBackgroundBrush"/>
+    </UserControl.Background>
+    
     <Grid x:Name="grid" IsHitTestVisible="True" Background="Transparent">
         <Button x:Name="addShapeButton" HorizontalAlignment="Left" Height="45" Margin="10,10,0,0" ToolTipService.ShowOnDisabled="True" VerticalAlignment="Top" Width="45" Click="AddShapeButton_Click" Background="White" IsEnabled="True">
             <Button.Style>
@@ -34,10 +46,17 @@
             </Hyperlink>
         </TextBlock>
         <Canvas x:Name="categoryBoxHolder" Margin="10,106,10,700">
-            <ComboBox x:Name="categoryBox" SelectionChanged="CategoryBoxSelectedIndexChanged" Width="{Binding ActualWidth, ElementName=categoryBoxHolder}">
+            <ComboBox x:Name="categoryBox" SelectionChanged="CategoryBoxSelectedIndexChanged" Width="{Binding ActualWidth, ElementName=categoryBoxHolder}" Foreground="Black">
+                <ComboBox.Resources>
+                    <!-- 
+                    Prevent the ComboBox elements from following the TextBlock styles defined
+                    in the theme. This way, the foreground remains Black.
+                    -->
+                    <Style TargetType="TextBlock"/>
+                </ComboBox.Resources>
             </ComboBox>
         </Canvas>
-        <ListBox x:Name="shapeList" Margin="10,146,10,10" SelectionMode="Extended" ScrollViewer.HorizontalScrollBarVisibility="Disabled">
+        <ListBox x:Name="shapeList" Margin="10,146,10,10" SelectionMode="Extended" ScrollViewer.HorizontalScrollBarVisibility="Disabled" Background="{DynamicResource Theme.BackgroundBrush2}">
             <ListBox.ItemsPanel>
                 <ItemsPanelTemplate>
                     <WrapPanel x:Name="wrapPanel" Orientation="Horizontal" Loaded="WrapPanelLoaded"></WrapPanel>

--- a/PowerPointLabs/PowerPointLabs/SyncLab/SyncFormatConstants.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/SyncFormatConstants.cs
@@ -12,7 +12,7 @@ namespace PowerPointLabs.SyncLab.ObjectFormats
     public class SyncFormatConstants
     {
 
-        public static readonly Size DisplayImageSize = new Size(30, 30);
+        public static readonly Size DisplayImageSize = new Size(50, 50);
         
         // values for bevel display
         public static readonly float DisplayImageDepth = 15;
@@ -24,7 +24,7 @@ namespace PowerPointLabs.SyncLab.ObjectFormats
         public static readonly string DisplaySizeUnit = "pt";
         public static readonly string DisplayFontString = "Text";
         public static readonly string DisplayDegreeSymbol = "°";
-        public static readonly int DisplayImageFontSize = 12;
+        public static readonly int DisplayImageFontSize = 24;
         public static readonly Font DisplayImageFont = new Font("Arial", DisplayImageFontSize);
 
         public static readonly int ColorBlack = 0;

--- a/PowerPointLabs/PowerPointLabs/SyncLab/SyncLabShapeStorage.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/SyncLabShapeStorage.cs
@@ -25,7 +25,6 @@ namespace PowerPointLabs.SyncLab
     /// </summary>
     public sealed class SyncLabShapeStorage : PowerPointPresentation
     {
-
         public const int FormatStorageSlide = 0;
 
         private int nextKey = 0;
@@ -99,22 +98,34 @@ namespace PowerPointLabs.SyncLab
         /// <returns>identifier of copied shape</returns>
         public string CopyShape(Shape shape, Format[] formats)
         {
+            #pragma warning disable 618
+            PowerPointPresentation pres = PowerPointPresentation.Current;
+            PowerPointSlide slide = PowerPointCurrentPresentationInfo.CurrentSlide;
             Shape copiedShape = null;
             if (shape.Type == MsoShapeType.msoPlaceholder)
             {
-                copiedShape = ShapeUtil.CopyMsoPlaceHolder(formats, shape, GetTemplateShapes());
+                ClipboardUtil.RestoreClipboardAfterAction(() =>
+                {
+                    copiedShape = ShapeUtil.CopyMsoPlaceHolder(formats, shape, GetTemplateShapes());
+                    return ClipboardUtil.ClipboardRestoreSuccess;
+                }, pres, slide);
             }
             else
             {
                 try
                 {
-                    copiedShape = Slides[0].Shapes.SafeCopyPlaceholder(shape);
+                    ClipboardUtil.RestoreClipboardAfterAction(() =>
+                    {
+                        copiedShape = Slides[0].Shapes.SafeCopyPlaceholder(shape);
+                        return ClipboardUtil.ClipboardRestoreSuccess;
+                    }, pres, slide);
                 }
                 catch
                 {
                     copiedShape = null;
                 }
             }
+            #pragma warning restore 618
 
             if (copiedShape == null)
             {
@@ -142,6 +153,7 @@ namespace PowerPointLabs.SyncLab
             
             ForceSave();
             return shapeKey;
+
         }
 
         public Shape GetShape(string shapeKey)

--- a/PowerPointLabs/PowerPointLabs/SyncLab/Views/SyncFormatDialog.xaml
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/Views/SyncFormatDialog.xaml
@@ -1,15 +1,42 @@
 ﻿<Window x:Class="PowerPointLabs.SyncLab.Views.SyncFormatDialog"
-             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
-             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
-             xmlns:local="clr-namespace:PowerPointLabs.SyncLab.Views"
-             mc:Ignorable="d" 
-             Title="Copy Format"
-             d:DesignHeight="600" d:DesignWidth="300" Height="600"  Width="307">
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+        xmlns:local="clr-namespace:PowerPointLabs.SyncLab.Views"
+        xmlns:theme="clr-namespace:PowerPointLabs.ColorThemes"
+        mc:Ignorable="d" 
+        Title="Copy Format"
+        d:DesignHeight="600" d:DesignWidth="300" Height="600"  Width="320">
+    <Window.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <theme:DesignTheme Theme="Colorful"/>
+                <theme:BaseStylesDictionary/>
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </Window.Resources>
+
+    <!-- 
+    The style has to be set manually since the style in the Window's Resources will 
+    not automatically be set to the Window itself.
+    -->
+    <Window.Style>
+        <Style TargetType="{x:Type Window}" BasedOn="{StaticResource BaseWindowStyle}"/>
+    </Window.Style>
+
+    <!-- 
+    Developer note: I can't get the background colour to appear in the designer by the setting the style above.
+    It does work during runtime, but not in design-time. Setting the background directly, or creating a new style
+    that uses this DynamicResource will work in design-time.
+    -->
+    <!--<Window.Background>
+        <DynamicResource ResourceKey="Window.Static.Background"/>
+    </Window.Background>-->
+    
     <Grid>
         <TextBox x:Name="nameTextBox" Height="23" Margin="10,10,10,0" TextWrapping="Wrap" Text="TextBox" VerticalAlignment="Top"/>
-        <TreeView x:Name="treeView" Margin="10,38,10,35" HorizontalContentAlignment="Stretch"/>
+        <TreeView x:Name="treeView" Margin="10,38,10,35" HorizontalContentAlignment="Stretch" />
         <Button x:Name="okButton" IsDefault="True" Content="OK" Margin="0,0,90,10" HorizontalAlignment="Right" Width="75" Height="20" VerticalAlignment="Bottom" Grid.ColumnSpan="2" Click="OkButton_Click" Grid.Row="1"/>
         <Button x:Name="cancelButton" IsCancel="True" Content="Cancel" Margin="0,0,10,10" HorizontalAlignment="Right" Width="75" Height="20" VerticalAlignment="Bottom" Grid.Column="1" Grid.Row="1"/>
     </Grid>

--- a/PowerPointLabs/PowerPointLabs/SyncLab/Views/SyncFormatListItem.xaml
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/Views/SyncFormatListItem.xaml
@@ -7,9 +7,9 @@
              mc:Ignorable="d" 
              d:DesignHeight="50" d:DesignWidth="300">
     <Grid x:Name="grid">
-        <CheckBox x:Name="checkBox" HorizontalAlignment="Left" Margin="5,17,0,18" VerticalAlignment="Center"/>
-        <Image x:Name="imageBox" Margin="30,10,0,10" OpacityMask="{DynamicResource {x:Static SystemColors.ControlBrushKey}}" HorizontalAlignment="Left" Width="30" Height="30"/>
-        <Label x:Name="label" Margin="65,7,10,7" HorizontalContentAlignment="Left" VerticalContentAlignment="Center"/>
+        <CheckBox x:Name="checkBox" HorizontalAlignment="Left" Margin="5,5,0,5" VerticalAlignment="Center"/>
+        <Image x:Name="imageBox" Margin="30,2,0,2" OpacityMask="{DynamicResource {x:Static SystemColors.ControlBrushKey}}" HorizontalAlignment="Left" Width="30" Height="30"/>
+        <Label x:Name="label" Margin="65,2,10,2" HorizontalContentAlignment="Left" VerticalContentAlignment="Center"/>
 
     </Grid>
 </UserControl>

--- a/PowerPointLabs/PowerPointLabs/SyncLab/Views/SyncFormatListItem.xaml
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/Views/SyncFormatListItem.xaml
@@ -5,11 +5,44 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              xmlns:local="clr-namespace:PowerPointLabs.SyncLab.Views"
              mc:Ignorable="d" 
-             d:DesignHeight="50" d:DesignWidth="300">
-    <Grid x:Name="grid">
-        <CheckBox x:Name="checkBox" HorizontalAlignment="Left" Margin="5,5,0,5" VerticalAlignment="Center"/>
-        <Image x:Name="imageBox" Margin="30,2,0,2" OpacityMask="{DynamicResource {x:Static SystemColors.ControlBrushKey}}" HorizontalAlignment="Left" Width="30" Height="30"/>
-        <Label x:Name="label" Margin="65,2,10,2" HorizontalContentAlignment="Left" VerticalContentAlignment="Center"/>
-
-    </Grid>
+             d:DesignWidth="300">
+    <CheckBox x:Name="checkBox" 
+              Margin="5, 3" 
+              VerticalAlignment="Center"
+              HorizontalContentAlignment="Stretch"
+              VerticalContentAlignment="Center">
+        <CheckBox.Content>
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="*"/>
+                </Grid.ColumnDefinitions>
+                <Border x:Name="imageBorder"
+                            Grid.Column="0"
+                            BorderBrush="Black"
+                            BorderThickness="1"
+                            Visibility="Visible"
+                            Background="White"
+                            Margin="5,0"
+                            Width="34"
+                            Height="34"
+                            HorizontalAlignment="Left"
+                            VerticalAlignment="Center"
+                            Padding="1">
+                    <Image x:Name="imageBox" 
+                               OpacityMask="{DynamicResource {x:Static SystemColors.ControlBrushKey}}" 
+                               HorizontalAlignment="Center"
+                               VerticalAlignment="Center"/>
+                </Border>
+                <Label x:Name="label" 
+                           Grid.Column="1"
+                           Margin="5,0" 
+                           Padding="0"
+                           MinHeight="34"
+                           HorizontalAlignment="Left" 
+                           VerticalAlignment="Center"
+                           VerticalContentAlignment="Center"/>
+            </Grid>
+        </CheckBox.Content>
+    </CheckBox>
 </UserControl>

--- a/PowerPointLabs/PowerPointLabs/SyncLab/Views/SyncFormatListItem.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/Views/SyncFormatListItem.xaml.cs
@@ -14,7 +14,6 @@ namespace PowerPointLabs.SyncLab.Views
     /// </summary>
     public partial class SyncFormatListItem : UserControl
     {
-
         Bitmap image;
 
         public SyncFormatListItem()
@@ -25,22 +24,13 @@ namespace PowerPointLabs.SyncLab.Views
 
         public bool? IsChecked
         {
-            get
-            {
-                return checkBox.IsChecked;
-            }
-            set
-            {
-                checkBox.IsChecked = value;
-            }
+            get => checkBox.IsChecked;
+            set => checkBox.IsChecked = value;
         }
 
         public Bitmap Image
         {
-            get
-            {
-                return image;
-            }
+            get => image;
             set
             {
                 image = value;
@@ -50,34 +40,22 @@ namespace PowerPointLabs.SyncLab.Views
 
         private void UpdateImage()
         {
-            // if image isn't set, fill the control with the label
+            // if image isn't set, hide the image border.
             if (image == null)
             {
-                imageBox.Visibility = Visibility.Hidden;
-                label.Margin = new Thickness(30, label.Margin.Top,
-                            label.Margin.Right, label.Margin.Bottom);
+                imageBorder.Visibility = Visibility.Collapsed;
                 return;
             }
-            else
-            {
-                BitmapSource source = GraphicsUtil.BitmapToImageSource(image);
-                imageBox.Source = source;
-                imageBox.Visibility = Visibility.Visible;
-                label.Margin = new Thickness(65, label.Margin.Top,
-                            label.Margin.Right, label.Margin.Bottom);
-            }
+
+            imageBorder.Visibility = Visibility.Visible;
+            BitmapSource source = GraphicsUtil.BitmapToImageSource(image);
+            imageBox.Source = source;
         }
 
-        public String Text
+        public string Text
         {
-            get
-            {
-                return label.Content.ToString();
-            }
-            set
-            {
-                label.Content = value;
-            }
+            get => label.Content.ToString();
+            set => label.Content = value;
         }
     }
 }

--- a/PowerPointLabs/PowerPointLabs/SyncLab/Views/SyncFormatPaneItem.xaml
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/Views/SyncFormatPaneItem.xaml
@@ -7,6 +7,17 @@
              mc:Ignorable="d" 
              d:DesignHeight="60" d:DesignWidth="300"
              MouseDoubleClick="OnMouseDoubleClick">
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <!-- 
+            Because the buttons use black-coloured images, the background should stay light even
+            in a Dark theme. By setting an explicit style, it will not be changed between ColorThemes.
+            -->
+            <Style TargetType="Button" x:Key="ImageButtonStyle">
+                <Setter Property="Background" Value="WhiteSmoke"/>
+            </Style>
+        </ResourceDictionary>
+    </UserControl.Resources>
     <Grid x:Name="grid" ClipToBounds="True" Background="Transparent">
         <Grid.ToolTip>
             <StackPanel>
@@ -20,11 +31,18 @@
             <ColumnDefinition x:Name="col2" Width="*"/>
             <ColumnDefinition x:Name="col3" Width="100" MaxWidth="100"/>
         </Grid.ColumnDefinitions>
-        <Image x:Name="imageBox" Grid.Column="0" Margin="10,10,0,10" OpacityMask="{DynamicResource {x:Static SystemColors.ControlBrushKey}}" HorizontalAlignment="Left" Width="40" Height="40"/>
-        <Canvas x:Name="canvas" Grid.Column="1" >
-            <TextBlock x:Name="textBlock" Margin="0,20,0,20" MaxWidth="{Binding ActualWidth, ElementName=canvas}" HorizontalAlignment="Stretch" VerticalAlignment="Center" TextTrimming="CharacterEllipsis" IsHitTestVisible="False"/>
-        </Canvas>
-        <Button x:Name="pasteButton" Grid.Column="2" Margin="0,10,65,10" Click="PasteButton_Click" HorizontalAlignment="Right" MinWidth="25" MaxWidth="25" MinHeight="25" MaxHeight="25">
+        <Border Grid.Column="0" 
+                Margin="5" 
+                Padding="3"
+                BorderBrush="Black"
+                BorderThickness="2"
+                Background="White">
+            <Image x:Name="imageBox" OpacityMask="{DynamicResource {x:Static SystemColors.ControlBrushKey}}" HorizontalAlignment="Left" Width="40" Height="40" />
+        </Border>
+        <Grid x:Name="canvas" Grid.Column="1" >
+            <TextBlock x:Name="textBlock"  MaxWidth="{Binding ActualWidth, ElementName=canvas}" HorizontalAlignment="Stretch" VerticalAlignment="Center" TextTrimming="CharacterEllipsis" IsHitTestVisible="False"/>
+        </Grid>
+        <Button x:Name="pasteButton" Grid.Column="2" Margin="0,10,65,10" Click="PasteButton_Click" HorizontalAlignment="Right" MinWidth="25" MaxWidth="25" MinHeight="25" MaxHeight="25" Style="{StaticResource ImageButtonStyle}">
             <Image x:Name="pasteImage" Source="pack://siteoforigin:,,,/Resources/SyncLabPasteButton.png" Stretch="Fill"/>
             <Button.ToolTip>
                 <StackPanel>
@@ -36,7 +54,7 @@
                 </StackPanel>
             </Button.ToolTip>
         </Button>
-        <Button x:Name="editButton" Grid.Column="2" Margin="0,10,35,10" Click="EditButton_Click" HorizontalAlignment="Right" MinWidth="25" MaxWidth="25" MinHeight="25" MaxHeight="25">
+        <Button x:Name="editButton" Grid.Column="2" Margin="0,10,35,10" Click="EditButton_Click" HorizontalAlignment="Right" MinWidth="25" MaxWidth="25" MinHeight="25" MaxHeight="25" Style="{StaticResource ImageButtonStyle}">
             <Image x:Name="editImage" Source="pack://siteoforigin:,,,/Resources/SyncLabEditButton.png" Stretch="Fill"/>
             <Button.ToolTip>
                 <StackPanel>
@@ -50,7 +68,7 @@
                 </StackPanel>
             </Button.ToolTip>
         </Button>
-        <Button x:Name="deleteButton" Grid.Column="2" Margin="0,10,5,10" Click="DeleteButton_Click" HorizontalAlignment="Right" MinWidth="25" MaxWidth="25" MinHeight="25" MaxHeight="25">
+        <Button x:Name="deleteButton" Grid.Column="2" Margin="0,10,5,10" Click="DeleteButton_Click" HorizontalAlignment="Right" MinWidth="25" MaxWidth="25" MinHeight="25" MaxHeight="25" Style="{StaticResource ImageButtonStyle}">
             <Image x:Name="deleteImage" Source="pack://siteoforigin:,,,/Resources/SyncLabDeleteButton.png" Stretch="Fill"/>
             <Button.ToolTip>
                 <StackPanel>

--- a/PowerPointLabs/PowerPointLabs/SyncLab/Views/SyncPaneWPF.xaml
+++ b/PowerPointLabs/PowerPointLabs/SyncLab/Views/SyncPaneWPF.xaml
@@ -3,20 +3,23 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:theme="clr-namespace:PowerPointLabs.ColorThemes"
              mc:Ignorable="d" 
              d:DesignHeight="833" d:DesignWidth="300" 
              Loaded="SyncPaneWPF_Loaded">
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <theme:DesignTheme Theme="Black"/>
+                <theme:BaseStylesDictionary/>
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </UserControl.Resources>
+    <UserControl.Background>
+        <SolidColorBrush Color="{DynamicResource Theme.PaneBackground}"/>
+    </UserControl.Background>
     <Grid>
-        <Button x:Name="copyButton" HorizontalAlignment="Left" Height="45" Margin="10,10,0,0" ToolTipService.ShowOnDisabled="True" VerticalAlignment="Top" Width="45" Click="CopyButton_Click" Background="White" IsEnabled="True">
-            <Button.Style>
-                <Style TargetType="Button">
-                    <Style.Triggers>
-                        <Trigger Property="IsEnabled" Value="False">
-                            <Setter Property="Opacity" Value="0.3" />
-                        </Trigger>
-                    </Style.Triggers>
-                </Style>
-            </Button.Style>
+        <Button x:Name="copyButton" HorizontalAlignment="Left" Height="45" Margin="10,10,0,0" ToolTipService.ShowOnDisabled="True" VerticalAlignment="Top" Width="45" Click="CopyButton_Click" IsEnabled="True">
             <Image x:Name="copyImage" Source="..\..\Resources\SyncLabCopyButton.png" Stretch="Fill"/>
             <Button.ToolTip>
                 <StackPanel>
@@ -26,8 +29,20 @@
                     </TextBlock>
                 </StackPanel>
             </Button.ToolTip>
+            <Button.Style>
+                <Style TargetType="Button" BasedOn="{StaticResource BaseButtonStyle}">
+                    <Style.Triggers>
+                        <Trigger Property="IsEnabled" Value="False">
+                            <Setter Property="Opacity" Value="0.3"/>
+                        </Trigger>
+                    </Style.Triggers>
+                </Style>
+            </Button.Style>
         </Button>
         <Label x:Name="copyLabel" Content="Copy" HorizontalAlignment="Left" Margin="10,55,0,0" VerticalAlignment="Top" HorizontalContentAlignment="Center" VerticalContentAlignment="Center" Width="45"/>
-        <ListBox x:Name="formatListBox" Margin="10,86,10,10" HorizontalContentAlignment="Stretch"/>
+        <ListBox x:Name="formatListBox" 
+                 Margin="10,86,10,10" 
+                 HorizontalContentAlignment="Stretch"
+                 Background="{DynamicResource Theme.BackgroundBrush2}"/>
     </Grid>
 </UserControl>

--- a/PowerPointLabs/PowerPointLabs/TimerLab/TimerLabPaneWPF.xaml
+++ b/PowerPointLabs/PowerPointLabs/TimerLab/TimerLabPaneWPF.xaml
@@ -5,11 +5,13 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              xmlns:local="clr-namespace:PowerPointLabs.TimerLab"
              xmlns:Controls="clr-namespace:MahApps.Metro.Controls;assembly=MahApps.Metro"
+             xmlns:theme="clr-namespace:PowerPointLabs.ColorThemes"
              mc:Ignorable="d" 
              Height="725" Width="300">
     <UserControl.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
+                <theme:DesignTheme Theme="Black"/>
                 <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Controls.xaml" />
                 <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Fonts.xaml" />
                 <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Colors.xaml" />
@@ -18,6 +20,9 @@
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
     </UserControl.Resources>
+    <UserControl.Background>
+        <DynamicResource ResourceKey="Theme.PaneBackgroundBrush"/>
+    </UserControl.Background>
     <ScrollViewer x:Name="PaneScroll">
         <Grid>
             <Grid.RowDefinitions>

--- a/PowerPointLabs/PowerPointLabs/TimerLab/TimerLabPaneWPF.xaml.cs
+++ b/PowerPointLabs/PowerPointLabs/TimerLab/TimerLabPaneWPF.xaml.cs
@@ -6,6 +6,8 @@ using System.Windows.Controls;
 using System.Windows.Input;
 
 using PowerPointLabs.ActionFramework.Common.Extension;
+using PowerPointLabs.ColorThemes;
+using PowerPointLabs.ColorThemes.Extensions;
 using PowerPointLabs.Utils;
 
 using PowerPoint = Microsoft.Office.Interop.PowerPoint;
@@ -16,7 +18,7 @@ namespace PowerPointLabs.TimerLab
     /// <summary>
     /// Interaction logic for TimerLabPaneWPF.xaml
     /// </summary>
-    public partial class TimerLabPaneWPF : UserControl
+    public partial class TimerLabPaneWPF : UserControl, INotifyOnThemeChanged
     {
         Shape timerBody = null;
         Shape lineMarkerGroup = null;
@@ -30,7 +32,34 @@ namespace PowerPointLabs.TimerLab
         {
             InitializeComponent();
         }
-        
+
+        #region INotifyOnThemeChanged Interface methods
+
+        /// <summary>
+        /// Changes the MahApps accent of this pane based on the Color Theme.
+        /// </summary>
+        /// <remarks>
+        /// The Steel accent will be used on all themes, except for the DarkGray
+        /// theme, which will use the Teal accent.
+        /// </remarks>
+        /// <param name="updatedColorTheme">The new color theme</param>
+        public void OnThemeChanged(ColorTheme updatedColorTheme)
+        {
+            // The Steel accent doesn't look good on the DarkGray background.
+            // The closest accent that looks okay is Teal.
+            switch (updatedColorTheme.ThemeId)
+            {
+                case ColorTheme.DARK_GRAY:
+                    ThemeExtensions.ChangeMahAppsAccent(this, "Teal");
+                    break;
+                default:
+                    ThemeExtensions.ChangeMahAppsAccent(this, "Steel");
+                    break;
+            }
+        }
+
+        #endregion
+
         #region Timer Properties
         private int Duration()
         {

--- a/PowerPointLabs/PowerPointLabs/ZoomLab/AutoZoom.cs
+++ b/PowerPointLabs/PowerPointLabs/ZoomLab/AutoZoom.cs
@@ -15,15 +15,19 @@ namespace PowerPointLabs.ZoomLab
     internal static class AutoZoom
     {
 #pragma warning disable 0618
-        public static void AddDrillDownAnimation()
+        public static void AddDrillDownAnimation(PowerPointPresentation pres, PowerPointSlide slide)
         {
             if (!IsSelectingShapes())
             {
                 return;
             }
 
-            AddDrillDownAnimation(Globals.ThisAddIn.Application.ActiveWindow.Selection.ShapeRange[1],
+            ClipboardUtil.RestoreClipboardAfterAction(() =>
+            {
+                AddDrillDownAnimation(Globals.ThisAddIn.Application.ActiveWindow.Selection.ShapeRange[1],
                 PowerPointCurrentPresentationInfo.CurrentSlide);
+                return ClipboardUtil.ClipboardRestoreSuccess;
+            }, pres, slide);
         }
 
         public static void AddDrillDownAnimation(PowerPoint.Shape selectedShape, PowerPointSlide currentSlide)
@@ -37,7 +41,8 @@ namespace PowerPointLabs.ZoomLab
         {
             try
             {
-                if (currentSlide == null || currentSlide.Index == PowerPointPresentation.Current.SlideCount)
+                //SlideCount - 1 due to #RestoreClipboardAfterAction creating a temporary slide to store clipboard
+                if (currentSlide == null || currentSlide.Index == PowerPointPresentation.Current.SlideCount - 1)
                 {
                     System.Windows.Forms.MessageBox.Show(TextCollection.ZoomLabText.ErrorInvalidNextSlide, TextCollection.ZoomLabText.ErrorUnableToAddAnimationsCaption);
                     addedSlide = null;
@@ -113,15 +118,19 @@ namespace PowerPointLabs.ZoomLab
             }
         }
 
-        public static void AddStepBackAnimation()
+        public static void AddStepBackAnimation(PowerPointPresentation pres, PowerPointSlide slide)
         {
             if (!IsSelectingShapes())
             {
                 return;
             }
 
-            AddStepBackAnimation(Globals.ThisAddIn.Application.ActiveWindow.Selection.ShapeRange[1],
-                PowerPointCurrentPresentationInfo.CurrentSlide);
+            ClipboardUtil.RestoreClipboardAfterAction(() =>
+            {
+                AddStepBackAnimation(Globals.ThisAddIn.Application.ActiveWindow.Selection.ShapeRange[1],
+                    PowerPointCurrentPresentationInfo.CurrentSlide);
+                return ClipboardUtil.ClipboardRestoreSuccess;
+            }, pres, slide);
         }
 
         public static void AddStepBackAnimation(PowerPoint.Shape selectedShape, PowerPointSlide currentSlide)

--- a/PowerPointLabs/PowerPointLabs/app.config
+++ b/PowerPointLabs/PowerPointLabs/app.config
@@ -20,10 +20,10 @@
     <value>https://www.comp.nus.edu.sg/~pptlabs/download/dev/</value>
    </setting>
    <setting name="Version" serializeAs="String">
-    <value>6.0.0.1</value>
+    <value>6.1.0.0</value>
    </setting>
    <setting name="ReleaseDate" serializeAs="String">
-    <value>2 August 2019</value>
+    <value>8 May 2020</value>
    </setting>
   </PowerPointLabs.Properties.Settings>
 	</applicationSettings>

--- a/PowerPointLabs/Test/Util/WindowWatcher.cs
+++ b/PowerPointLabs/Test/Util/WindowWatcher.cs
@@ -35,6 +35,11 @@ namespace Test.Util
 
         public static void RevalidateApp()
         {
+            if (process == null)
+            {
+                // headless
+                return;
+            }
             try
             {
                 process.WaitForInputIdle();
@@ -112,13 +117,7 @@ namespace Test.Util
 
         public static void HeadlessSetup(int processId)
         {
-            windowTriggers = new Dictionary<string, WindowOpenTrigger>();
-            if (whitelist == null)
-            {
-                whitelist = new HashSet<string>();
-            }
-            whitelistInstances = new SortedDictionary<string, WindowOpenTrigger>();
-
+            SetupWhitelist();
             handler = GetOpenWindowHandler(processId);
             Automation.AddAutomationEventHandler(
                 WindowPattern.WindowOpenedEvent,


### PR DESCRIPTION
Fixes #1994

**Outline of Solution**
The CropToShape functionality on PowerPoint 2010 was not functioning properly. The cropped shape ended up being slightly off center, and the image had slightly different dimension as well. This resulted in the FT for AutoCropTest failing.

This has been fixed by implementing a multiplier to the height/width/X axis to minimize the difference caused. This fix should make the Crop functionality on PowerPoint 2010 work just like the later versions.

However, this fix does not fix the following:
- #2027
- EffectsLab having different behavior, which is mentioned in #1994